### PR TITLE
Switch to global scope repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ yaml-rust = "0.3"
 onig = { git = "https://github.com/trishume/rust-onig.git" }
 walkdir = "0.1"
 regex-syntax = "0.3.3"
+lazy_static = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate yaml_rust;
 extern crate onig;
 extern crate walkdir;
 extern crate regex_syntax;
+#[macro_use] extern crate lazy_static;
 pub mod syntax_definition;
 pub mod yaml_load;
 pub mod package_set;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,10 @@ mod tests {
     fn it_works() {
         use syntax_definition::SyntaxDefinition;
         use scope::*;
-        let mut repo = ScopeRepository::new();
         let defn: SyntaxDefinition =
-            SyntaxDefinition::load_from_str("name: C\nscope: source.c\ncontexts: {main: []}",
-                                            &mut repo)
+            SyntaxDefinition::load_from_str("name: C\nscope: source.c\ncontexts: {main: []}")
                 .unwrap();
         assert_eq!(defn.name, "C");
-        assert_eq!(defn.scope, repo.build("source.c"));
+        assert_eq!(defn.scope, Scope::new("source.c"));
     }
 }

--- a/src/package_set.rs
+++ b/src/package_set.rs
@@ -126,7 +126,8 @@ mod tests {
     fn can_load() {
         use package_set::PackageSet;
         use syntax_definition::*;
-        let mut ps = PackageSet::load_from_folder("testdata/Packages").unwrap();
+        use scope::*;
+        let ps = PackageSet::load_from_folder("testdata/Packages").unwrap();
         let rails_scope = Scope::new("source.ruby.rails");
         let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
         // println!("{:#?}", syntax);

--- a/src/package_set.rs
+++ b/src/package_set.rs
@@ -13,7 +13,6 @@ use std::rc::Rc;
 #[derive(Debug)]
 pub struct PackageSet {
     pub syntaxes: Vec<SyntaxDefinition>,
-    pub scope_repo: ScopeRepository,
 }
 
 #[derive(Debug)]
@@ -23,30 +22,27 @@ pub enum PackageLoadError {
     Parsing(ParseError),
 }
 
-fn load_syntax_file(p: &Path,
-                    scope_repo: &mut ScopeRepository)
+fn load_syntax_file(p: &Path)
                     -> Result<SyntaxDefinition, PackageLoadError> {
     let mut f = try!(File::open(p).map_err(|e| PackageLoadError::IOErr(e)));
     let mut s = String::new();
     try!(f.read_to_string(&mut s).map_err(|e| PackageLoadError::IOErr(e)));
 
-    SyntaxDefinition::load_from_str(&s, scope_repo).map_err(|e| PackageLoadError::Parsing(e))
+    SyntaxDefinition::load_from_str(&s).map_err(|e| PackageLoadError::Parsing(e))
 }
 
 impl PackageSet {
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<PackageSet, PackageLoadError> {
-        let mut repo = ScopeRepository::new();
         let mut syntaxes = Vec::new();
         for entry in WalkDir::new(folder) {
             let entry = try!(entry.map_err(|e| PackageLoadError::WalkDir(e)));
             if entry.path().extension().map(|e| e == "sublime-syntax").unwrap_or(false) {
                 // println!("{}", entry.path().display());
-                syntaxes.push(try!(load_syntax_file(entry.path(), &mut repo)));
+                syntaxes.push(try!(load_syntax_file(entry.path())));
             }
         }
         let mut ps = PackageSet {
             syntaxes: syntaxes,
-            scope_repo: repo,
         };
         ps.link_syntaxes();
         Ok(ps)
@@ -131,7 +127,7 @@ mod tests {
         use package_set::PackageSet;
         use syntax_definition::*;
         let mut ps = PackageSet::load_from_folder("testdata/Packages").unwrap();
-        let rails_scope = ps.scope_repo.build("source.ruby.rails");
+        let rails_scope = Scope::new("source.ruby.rails");
         let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
         // println!("{:#?}", syntax);
         assert_eq!(syntax.scope, rails_scope);

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -5,10 +5,10 @@ use std::sync::Mutex;
 use std::fmt;
 
 lazy_static! {
-    static ref SCOPE_REPO: Mutex<ScopeRepository> = Mutex::new(ScopeRepository::new());
+    pub static ref SCOPE_REPO: Mutex<ScopeRepository> = Mutex::new(ScopeRepository::new());
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub struct Scope {
     data: [u16; 8],
 }
@@ -33,7 +33,7 @@ fn pack_as_u16s(atoms: &[usize]) -> [u16; 8] {
 }
 
 impl ScopeRepository {
-    pub fn new() -> ScopeRepository {
+    fn new() -> ScopeRepository {
         ScopeRepository {
             atoms: Vec::new(),
             atom_index_map: HashMap::new(),
@@ -75,7 +75,7 @@ impl ScopeRepository {
 }
 
 impl Scope {
-    fn new(s: &str) -> Scope {
+    pub fn new(s: &str) -> Scope {
         let mut repo = SCOPE_REPO.lock().unwrap();
         repo.build(s)
     }
@@ -83,7 +83,15 @@ impl Scope {
 
 impl fmt::Display for Scope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut repo = SCOPE_REPO.lock().unwrap();
+        let repo = SCOPE_REPO.lock().unwrap();
+        let s = repo.to_string(*self);
+        write!(f, "{}", s)
+    }
+}
+
+impl fmt::Debug for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let repo = SCOPE_REPO.lock().unwrap();
         let s = repo.to_string(*self);
         write!(f, "<{}>", s)
     }
@@ -122,6 +130,15 @@ impl ScopeStack {
             print!("{} ", repo.to_string(*s));
         }
         println!("");
+    }
+}
+
+impl fmt::Display for ScopeStack {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for s in self.scopes.iter() {
+            try!(write!(f, "{} ", s));
+        }
+        Ok(())
     }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,12 @@
 // see DESIGN.md
 use std::collections::HashMap;
 use std::u16;
+use std::sync::Mutex;
+use std::fmt;
+
+lazy_static! {
+    static ref SCOPE_REPO: Mutex<ScopeRepository> = Mutex::new(ScopeRepository::new());
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Scope {
@@ -65,6 +71,21 @@ impl ScopeRepository {
         let index = self.atoms.len() - 1;
         self.atom_index_map.insert(atom.to_owned(), index);
         return index;
+    }
+}
+
+impl Scope {
+    fn new(s: &str) -> Scope {
+        let mut repo = SCOPE_REPO.lock().unwrap();
+        repo.build(s)
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut repo = SCOPE_REPO.lock().unwrap();
+        let s = repo.to_string(*self);
+        write!(f, "<{}>", s)
     }
 }
 


### PR DESCRIPTION
Use a lazy static global scope repo. This makes everything way nicer.

Performance isn’t an issue since creating scopes isn’t on the critical path.

As an added perf benefit the scope repo is available for you to lock it once and create a bunch of scopes, like the yaml parser currently does.