### PR TITLE
Update onig to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 
 [dependencies]
 yaml-rust = "0.3"
-onig = "0.6"
+onig = "1.1.0"
 walkdir = "0.1"
 regex-syntax = "0.3.3"
 lazy_static = "0.2.1"


### PR DESCRIPTION
This includes the "static-libonig" feature flag for statically linking
to libonig.

Changes: https://github.com/rust-onig/rust-onig/compare/v0.6.0...v1.1.0