### PR TITLE
Add an option to statically link libonig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,8 @@ bincode = "0.6"
 flate2 = "0.2"
 fnv = "1.0.2"
 
+[features]
+static-onig = ["onig/static-libonig"]
+
 # [profile.release]
 # debug = true


### PR DESCRIPTION
We're using syntect over at [Cobalt](https://github.com/cobalt-org/cobalt.rs) and it's an awesome library. However, we currently can't enable it by default because Windows and musl and a couple of other targets require onig to be statically linked, I think.

This is a pull request that adds an optional feature that toggles the corresponding feature in rust-onig.

Note that I had some test failures locally (OSX), even before applying this change.