### PR TITLE
[WIP] Kinda-working fancy-regex support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
-onig = { version = "3.2.1", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "1.0"
@@ -25,7 +24,7 @@ bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }
 regex = "*"
-fancy-regex = { git = "https://github.com/google/fancy-regex.git" }
+fancy-regex = { git = "https://github.com/google/fancy-regex.git", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -51,7 +50,7 @@ dump-create = ["flate2/default", "bincode"]
 # Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
 dump-create-rs = ["flate2/rust_backend", "bincode"]
 
-parsing = ["onig", "regex-syntax", "fnv"]
+parsing = ["fancy-regex", "regex-syntax", "fnv"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
 # For `assets` to do anything, it requires one of `dump-load-rs` or `dump-load` to be set.
 assets = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ plist = "0.2"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }
+regex = "*"
+fancy-regex = { git = "https://github.com/trishume/fancy-regex.git" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -31,7 +33,6 @@ serde_json = "1.0"
 [dev-dependencies]
 criterion = "0.2"
 rayon = "1.0.0"
-regex = "0.2"
 getopts = "0.2"
 pretty_assertions = "0.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }
 regex = "*"
-fancy-regex = { git = "https://github.com/trishume/fancy-regex.git" }
+fancy-regex = { git = "https://github.com/google/fancy-regex.git" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@
 
 #[cfg(feature = "yaml-load")]
 extern crate yaml_rust;
-#[cfg(feature = "parsing")]
-extern crate onig;
+// extern crate onig;
 extern crate walkdir;
 #[cfg(feature = "parsing")]
 extern crate regex_syntax;
@@ -42,6 +41,11 @@ extern crate serde_json;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+#[cfg(feature = "parsing")]
+extern crate regex;
+#[cfg(feature = "parsing")]
+extern crate fancy_regex;
+
 pub mod highlighting;
 pub mod parsing;
 pub mod util;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -2,6 +2,7 @@
 //! The most important struct here is `SyntaxSet`, check out the docs for that.
 #[cfg(feature = "parsing")]
 pub mod syntax_definition;
+mod util;
 #[cfg(all( feature = "parsing", feature = "yaml-load"))]
 mod yaml_load;
 #[cfg(feature = "parsing")]

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -2,6 +2,7 @@
 //! The most important struct here is `SyntaxSet`, check out the docs for that.
 #[cfg(feature = "parsing")]
 pub mod syntax_definition;
+#[cfg(feature = "parsing")]
 mod util;
 #[cfg(all( feature = "parsing", feature = "yaml-load"))]
 mod yaml_load;

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -678,6 +678,26 @@ mod tests {
     }
 
     #[test]
+    fn can_parse_yaml() {
+        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let mut state = {
+            let syntax = ps.find_syntax_by_name("YAML").unwrap();
+            ParseState::new(syntax)
+        };
+
+        assert_eq!(ops("key: value\n", &mut state), vec![
+            (0, Push(Scope::new("source.yaml").unwrap())),
+            (0, Push(Scope::new("string.unquoted.plain.out.yaml").unwrap())),
+            (0, Push(Scope::new("entity.name.tag.yaml").unwrap())),
+            (3, Pop(2)),
+            (3, Push(Scope::new("punctuation.separator.key-value.mapping.yaml").unwrap())),
+            (4, Pop(1)),
+            (5, Push(Scope::new("string.unquoted.plain.out.yaml").unwrap())),
+            (10, Pop(1)),
+        ]);
+    }
+
+    #[test]
     fn can_parse_includes() {
         let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
         let mut state = {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1240,6 +1240,22 @@ contexts:
         expect_scope_stacks(&line, &expect, syntax);
     }
 
+    #[test]
+    fn can_parse_syntax_with_eol_and_newline() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: foo$\n
+      scope: foo.newline
+"#;
+
+        let line = "foo";
+        let expect = ["<source.test>, <foo.newline>"];
+        expect_scope_stacks(&line, &expect, syntax);
+    }
+
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {
         println!("Parsing with newlines");
         let line_with_newline = format!("{}\n", line_without_newline);

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -256,9 +256,10 @@ impl MatchPattern {
 
     fn compile_regex(&mut self) {
         // TODO don't panic on invalid regex
-        println!("compiling {:?}", self.regex_str);
-        let compiled = fancy_regex::Regex::new(&self.regex_str).unwrap();
-        self.regex = Some(compiled);
+        self.regex = match fancy_regex::Regex::new(&self.regex_str) {
+            Ok(regex) => Some(regex),
+            Err(e) => panic!("Error compiling regex {:?}: {:?}", self.regex_str, e),
+        };
     }
 
     /// Makes sure the regex is compiled if it doesn't have captures.

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 use std::ascii::AsciiExt;
 
 use std::sync::Mutex;
-use onig::Regex;
+use fancy_regex::Regex;
 
 /// A syntax set holds a bunch of syntaxes and manages
 /// loading them and the crucial operation of *linking*.
@@ -168,7 +168,7 @@ impl SyntaxSet {
         let mut cache = self.first_line_cache.lock().unwrap();
         cache.ensure_filled(self.syntaxes());
         for &(ref reg, i) in &cache.regexes {
-            if reg.find(s).is_some() {
+            if reg.find(s).unwrap().is_some() {
                 return Some(&self.syntaxes[i]);
             }
         }

--- a/src/parsing/util.rs
+++ b/src/parsing/util.rs
@@ -1,0 +1,30 @@
+use fancy_regex::Captures;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Region {
+  positions: Vec<Option<(usize,usize)>>
+}
+
+impl Region {
+  pub fn new() -> Region {
+    Region {
+      positions: Vec::new()
+    }
+  }
+
+  pub fn from_captures<'a>(captures: &Captures<'a>) -> Region {
+    let mut region = Region::new();
+    for i in 0..captures.len() {
+      region.positions.push(captures.pos(i));
+    }
+    region
+  }
+
+  pub fn pos(&self, i: usize) -> Option<(usize,usize)> {
+    if i < self.positions.len() {
+      self.positions[i]
+    } else {
+      None
+    }
+  }
+}


### PR DESCRIPTION
This branch switches the regex engine to [fancy-regex](https://github.com/google/fancy-regex) or more specifically [my fork of it](https://github.com/trishume/fancy-regex).

Currently it only works for a few syntaxes because of a few different features fancy-regex doesn't support:
- [x] The `\n` escape (Everything, but fixed it my fork)
- [x] Unnecessary escapes in character classes like `[\<]`
- [x] The `\h` escape in character classes (Rust)
- [x] Fix #76 so `nonewlines` mode doesn't produce weird regexes.
- [x] Named backrefs `\k<marker>` (Markdown)
- [x] Fancy character class syntax `[a-w&&[^c-g]z]`
- [ ] Add support for match limit to fancy-regex: https://github.com/google/fancy-regex/issues/44

The jQuery highlighting benchmark now takes 1s instead of 0.66s. Which is super unfortunate given that I'd hoped it would be faster than Oniguruma. I have no idea why it is substantially slower.

@raphlinus @robinst 