### PR TITLE
fix bug in synstats example whereby scopes from previous line weren't considered

### DIFF
--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -80,10 +80,9 @@ fn is_ignored(entry: &DirEntry) -> bool {
          .unwrap_or(false)
 }
 
-fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stats: &mut Stats) {
+fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack, stats: &mut Stats) {
     stats.lines += 1;
 
-    let mut stack = ScopeStack::new();
     let mut line_has_comment = false;
     let mut line_has_doc_comment = false;
     let mut line_has_code = false;
@@ -133,11 +132,12 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let f = File::open(path).unwrap();
     let mut reader = BufReader::new(f);
     let mut line = String::new();
+    let mut stack = ScopeStack::new();
     while reader.read_line(&mut line).unwrap() > 0 {
         {
             let ops = state.parse_line(&line);
             stats.chars += line.len();
-            count_line(&ops, &line, stats);
+            count_line(&ops, &line, &mut stack, stats);
         }
         line.clear();
     }


### PR DESCRIPTION
This PR fixes a bug in the `synstats` example, whereby scopes from the previous line(s) weren't considered, as a new scope stack was being constructed each line. This especially affected meta scopes.

For example, given the following JavaScript file as an input:

```js
/* test multi
line comment
*/
;
```

the output from synstats before this PR was:
```
################## Stats ###################
File count:                                1
Total characters:                         32

Function count:                            0
Type count (structs, enums, classes):      0

Code lines (traditional SLOC):             3
Total lines (w/ comments & blanks):        4
Comment lines (comment but no code):       1
Blank lines (lines-blank-comment):         0

Lines with a documentation comment:        0
Total words written in doc comments:       0
Total words written in all comments:       2
Characters of comment:                    14
```

where as there are clearly 3 comment lines in the file being analysed. After this PR, the results are:
```
################## Stats ###################
File count:                                1
Total characters:                         32

Function count:                            0
Type count (structs, enums, classes):      0

Code lines (traditional SLOC):             1
Total lines (w/ comments & blanks):        4
Comment lines (comment but no code):       3
Blank lines (lines-blank-comment):         0

Lines with a documentation comment:        0
Total words written in doc comments:       0
Total words written in all comments:       4
Characters of comment:                    29
```