### PR TITLE
Generalize gendata to make it more useful to API-users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ script:
       export LD_LIBRARY_PATH="${p}:${LD_LIBRARY_PATH}"
     fi
   - cargo test
+  - make assets
   - cargo doc
 after_success: curl https://raw.githubusercontent.com/trishume/syntect/master/scripts/travis-doc-upload.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SUBMODULES = testdata/Packages/.git
+
+info:
+	$(info Targets)
+	$(info -----------------------------------------------------------------------)
+	$(info assets      | generate default theme packs and syntax)
+	$(info - OTHER TARGETS -------------------------------------------------------)
+	$(info themes      | generate default theme pack)
+	$(info packs       | generate default syntax pack)
+	
+	
+$(SUBMODULES):
+	git submodule update --init --recursive
+
+assets: packs themes
+
+packs: $(SUBMODULES)
+	cargo run --example gendata -- synpack testdata/Packages assets/default_newlines.packdump assets/default_nonewlines.packdump 
+	
+themes: $(SUBMODULES)
+	cargo run --example gendata -- themepack testdata assets/default.themedump
+	

--- a/examples/gendata.rs
+++ b/examples/gendata.rs
@@ -6,18 +6,37 @@ extern crate syntect;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::ThemeSet;
 use syntect::dumps::*;
+use std::env;
+
+fn usage_and_exit() -> ! {
+    println!("USAGE: gendata synpack source-dir newlines.packdump nonewlines.packdump\n
+              gendata themepack source-dir themepack.themedump");
+    ::std::process::exit(2);
+}
 
 fn main() {
-    let mut ps = SyntaxSet::new();
-    ps.load_plain_text_syntax();
-    ps.load_syntaxes("testdata/Packages", true).unwrap();
-    dump_to_file(&ps, "assets/default_newlines.packdump").unwrap();
 
-    let mut ps2 = SyntaxSet::new();
-    ps2.load_plain_text_syntax();
-    ps2.load_syntaxes("testdata/Packages", false).unwrap();
-    dump_to_file(&ps2, "assets/default_nonewlines.packdump").unwrap();
+    let mut a = env::args().skip(1);
+    match (a.next(), a.next(), a.next(), a.next()) {
+        (Some(ref cmd),
+         Some(ref package_dir),
+         Some(ref packpath_newlines),
+         Some(ref packpath_nonewlines)) if cmd == "synpack" => {
+            let mut ps = SyntaxSet::new();
+            ps.load_plain_text_syntax();
+            ps.load_syntaxes(package_dir, true).unwrap();
+            dump_to_file(&ps, packpath_newlines).unwrap();
 
-    let ts = ThemeSet::load_from_folder("testdata").unwrap();
-    dump_to_file(&ts, "assets/default.themedump").unwrap();
+            ps = SyntaxSet::new();
+            ps.load_plain_text_syntax();
+            ps.load_syntaxes(package_dir, false).unwrap();
+            dump_to_file(&ps, packpath_nonewlines).unwrap();
+
+        }
+        (Some(ref s), Some(ref theme_dir), Some(ref packpath), None) if s == "themepack" => {
+            let ts = ThemeSet::load_from_folder(theme_dir).unwrap();
+            dump_to_file(&ts, packpath).unwrap();
+        }
+        _ => usage_and_exit(),
+    }
 }


### PR DESCRIPTION
'gendata' now does some trivial argument parsing to support
different source directories to be specified.
That way, customizations can be more easily built.

A Makefile was added to keep track of the arguments needed
to build the default assets.

To prevent regressions, travis also builds assets.

#### Motivation

I want to use syntect in [`tokio-cassandra`s](https://github.com/nhellwig/tokio-cassandra) CQL shell, and want to add just CQL syntax descriptions in the most efficient format possible.

Thus this might be just the first of more PRs as I merely start to discover what this fantastic crate has to offer :)!