### PR TITLE
Add 'html' and 'assets' cargo features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ script:
       export LD_LIBRARY_PATH="${p}:${LD_LIBRARY_PATH}"
     fi
   - cargo test
+  - rm -Rf examples 
   - cargo doc
+  # default features are required for examples to build - so remove them from sight.
+  # Doc-tests may also use default features
+  - rm -Rf examples && cargo test --lib --no-default-features
 after_success: curl https://raw.githubusercontent.com/trishume/syntect/master/scripts/travis-doc-upload.sh | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ fnv = "^1.0"
 
 [features]
 static-onig = ["onig/static-libonig"]
+assets = []
+html = ["assets"]
+default = ["assets", "html"]
 
 # [profile.release]
 # debug = true

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -11,7 +11,9 @@ use bincode::SizeLimit;
 use bincode::rustc_serialize::*;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
+#[cfg(feature = "assets")]
 use parsing::SyntaxSet;
+#[cfg(feature = "assets")]
 use highlighting::ThemeSet;
 use std::path::Path;
 use flate2::write::ZlibEncoder;
@@ -53,6 +55,7 @@ pub fn from_dump_file<T: Decodable, P: AsRef<Path>>(path: P) -> DecodingResult<T
     decode_from(&mut decoder, SizeLimit::Infinite)
 }
 
+#[cfg(feature = "assets")]
 impl SyntaxSet {
     /// Instantiates a new syntax set from a binary dump of
     /// Sublime Text's default open source syntax definitions and then links it.
@@ -86,6 +89,7 @@ impl SyntaxSet {
     }
 }
 
+#[cfg(feature = "assets")]
 impl ThemeSet {
     /// Loads the set of default themes
     /// Currently includes (these are the keys for the map):
@@ -101,10 +105,9 @@ impl ThemeSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parsing::SyntaxSet;
-    use highlighting::ThemeSet;
     #[test]
     fn can_dump_and_load() {
+        use parsing::SyntaxSet;
         let mut ps = SyntaxSet::new();
         ps.load_syntaxes("testdata/Packages", false).unwrap();
 
@@ -112,6 +115,12 @@ mod tests {
         let ps2: SyntaxSet = from_binary(&bin[..]);
         assert_eq!(ps.syntaxes().len(), ps2.syntaxes().len());
 
+    }
+    
+    #[cfg(feature = "assets")]
+    #[test]
+    fn has_default_themes() {
+        use highlighting::ThemeSet;
         let themes = ThemeSet::load_defaults();
         assert!(themes.themes.len() > 4);
     }

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -168,12 +168,14 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
     }
 }
 
+#[cfg(feature = "assets")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use parsing::{SyntaxSet, ParseState, ScopeStack};
     use highlighting::ThemeSet;
     use std::str::FromStr;
+    
     #[test]
     fn can_highlight_lines() {
         let ps = SyntaxSet::load_defaults_nonewlines();

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -241,12 +241,13 @@ impl<'a> Highlighter<'a> {
     }
 }
 
+#[cfg(feature = "assets")]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parsing::{SyntaxSet, ScopeStack, ParseState};
     use highlighting::{ThemeSet, Style, Color, FontStyle};
-
+    use parsing::{ SyntaxSet, ScopeStack, ParseState};
+    
     #[test]
     fn can_parse() {
         let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
@@ -280,7 +281,5 @@ mod tests {
                        font_style: FontStyle::empty(),
                    },
                     "5"));
-
-        // assert!(false);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ pub mod parsing;
 pub mod util;
 pub mod dumps;
 pub mod easy;
+#[cfg(feature = "html")]
 pub mod html;
+#[cfg(feature = "html")]
 mod escape;
 
 use std::io::Error as IoError;


### PR DESCRIPTION
That way, users of this library can remove support for highlighting
that is not needed for them.

Binaries will be smaller (e.g. no static asset data), and
compile times will be reduced as well.

This commit is motivated by the `tokio-cassandra` shell, which will
use only use two syntaxes, YAML + SQL/CQL, and a handful of themes.