### PR TITLE
Add "yaml-load" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = "0.3.5"
+yaml-rust = { version = "0.3.5", optional = true }
 onig = "1.2.0"
 walkdir = "^1.0"
 regex-syntax = "^0.4"
@@ -29,7 +29,8 @@ fnv = "^1.0"
 static-onig = ["onig/static-libonig"]
 assets = []
 html = ["assets"]
-default = ["assets", "html"]
+yaml-load = ["yaml-rust"]
+default = ["assets", "html", "yaml-load"]
 
 # [profile.release]
 # debug = true

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -104,9 +104,10 @@ impl ThemeSet {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    #[cfg(feature = "yaml-load")]
     #[test]
     fn can_dump_and_load() {
+        use super::*;
         use parsing::SyntaxSet;
         let mut ps = SyntaxSet::new();
         ps.load_syntaxes("testdata/Packages", false).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! Some docs have example code but a good place to look is the `syncat` example as well as the source code
 //! for the `easy` module in `easy.rs` as that shows how to plug the various parts together for common use cases.
+#[cfg(feature = "yaml-load")]
 extern crate yaml_rust;
 extern crate onig;
 extern crate walkdir;
@@ -38,6 +39,7 @@ pub mod html;
 mod escape;
 
 use std::io::Error as IoError;
+#[cfg(feature = "yaml-load")]
 use parsing::ParseSyntaxError;
 use highlighting::{ParseThemeError, SettingsError};
 
@@ -49,6 +51,7 @@ pub enum LoadingError {
     /// error reading a file
     Io(IoError),
     /// a syntax file was invalid in some way
+    #[cfg(feature = "yaml-load")]
     ParseSyntax(ParseSyntaxError),
     /// a theme file was invalid in some way
     ParseTheme(ParseThemeError),
@@ -77,6 +80,7 @@ impl From<ParseThemeError> for LoadingError {
     }
 }
 
+#[cfg(feature = "yaml-load")]
 impl From<ParseSyntaxError> for LoadingError {
     fn from(error: ParseSyntaxError) -> LoadingError {
         LoadingError::ParseSyntax(error)

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,12 +1,14 @@
 //! Everything about parsing text into text annotated with scopes.
 //! The most important struct here is `SyntaxSet`, check out the docs for that.
 pub mod syntax_definition;
+#[cfg(feature = "yaml-load")]
 mod yaml_load;
 mod syntax_set;
 mod scope;
 mod parser;
 
 pub use self::syntax_definition::SyntaxDefinition;
+#[cfg(feature = "yaml-load")]
 pub use self::yaml_load::*;
 pub use self::syntax_set::*;
 pub use self::scope::*;

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -383,6 +383,7 @@ impl ParseState {
     }
 }
 
+#[cfg(feature = "yaml-load")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -1,10 +1,14 @@
 use super::syntax_definition::*;
 use super::scope::*;
+#[cfg(feature = "yaml-load")]
 use super::super::LoadingError;
 
 use std::path::Path;
+#[cfg(feature = "yaml-load")]
 use walkdir::WalkDir;
-use std::io::{self, Read, BufRead, BufReader};
+#[cfg(feature = "yaml-load")]
+use std::io::Read;
+use std::io::{self, BufRead, BufReader};
 use std::fs::File;
 use std::ops::DerefMut;
 use std::mem;
@@ -28,6 +32,7 @@ pub struct SyntaxSet {
     first_line_cache: Mutex<FirstLineCache>,
 }
 
+#[cfg(feature = "yaml-load")]
 fn load_syntax_file(p: &Path,
                     lines_include_newline: bool)
                     -> Result<SyntaxDefinition, LoadingError> {
@@ -57,6 +62,7 @@ impl SyntaxSet {
     /// defaults to lines given not including newline characters, see the
     /// `load_syntaxes` method docs for an explanation as to why this might not be the best.
     /// It also links all the syntaxes together, see `link_syntaxes` for what that means.
+    #[cfg(feature = "yaml-load")]
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<SyntaxSet, LoadingError> {
         let mut ps = Self::new();
         try!(ps.load_syntaxes(folder, false));
@@ -76,6 +82,7 @@ impl SyntaxSet {
     ///
     /// In the future I might include a "slow mode" that copies the lines passed in and appends a newline if there isn't one.
     /// but in the interest of performance currently this hacky fix will have to do.
+    #[cfg(feature = "yaml-load")]
     pub fn load_syntaxes<P: AsRef<Path>>(&mut self,
                                          folder: P,
                                          lines_include_newline: bool)
@@ -106,6 +113,7 @@ impl SyntaxSet {
     /// Rarely useful method that loads in a syntax with no highlighting rules for plain text.
     /// Exists mainly for adding the plain text syntax to syntax set dumps, because for some
     /// reason the default Sublime plain text syntax is still in `.tmLanguage` format.
+    #[cfg(feature = "yaml-load")]
     pub fn load_plain_text_syntax(&mut self) {
         let s = "---\nname: Plain Text\nfile_extensions: [txt]\nscope: text.plain\ncontexts: \
                  {main: []}";

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -402,6 +402,7 @@ impl Decodable for SyntaxSet {
     }
 }
 
+#[cfg(feature = "yaml-load")]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Default on.
If off, there will be no usage of yaml-rust, which turns out to
be problematic if you are already using it with different feature
flags (i.e. linked hashmap vs. btreemap).

This also means the only way to create a syntax set is using the
functions from `dumps`, and it might be nice to have one of these
directly in the SyntaxSet type itself.