### PR TITLE
iterate the stack in top-down (FILO) order to apply the prototypes

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -339,11 +339,11 @@ impl ParseState {
                         }
                     }
                 } else {
-                    let repush = !cur_context.meta_scope.is_empty() || !cur_context.meta_content_scope.is_empty() || context_refs.iter().any(|r| {
+                    let repush = (is_set && (!cur_context.meta_scope.is_empty() || !cur_context.meta_content_scope.is_empty())) || context_refs.iter().any(|r| {
                         let ctx_ptr = r.resolve();
                         let ctx = ctx_ptr.borrow();
 
-                        !ctx.meta_content_scope.is_empty() || ctx.clear_scopes.is_some()
+                        !ctx.meta_content_scope.is_empty() || (ctx.clear_scopes.is_some() && is_set)
                     });
                     if repush {
                         // remove previously pushed meta scopes, so that meta content scopes will be applied in the correct order
@@ -510,6 +510,8 @@ mod tests {
             (6, Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())),
             (6, Push(Scope::new("punctuation.definition.string.begin.ruby").unwrap())),
             (12, Pop(1)),
+            (12, Pop(1)),
+            (12, Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())),
             (12, Push(Scope::new("text.sql.embedded.ruby").unwrap())),
             (12, Clear(ClearAmount::TopN(2))),
             (12, Restore),

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -128,7 +128,7 @@ impl ParseState {
                 ctx_ref.prototype.clone()
             };
             let context_chain = self.stack
-                .iter()
+                .iter().rev() // iterate the stack in top-down order to apply the prototypes
                 .filter_map(|lvl| lvl.prototype.as_ref().cloned())
                 .chain(prototype.into_iter())
                 .chain(Some(cur_level.context.clone()).into_iter());


### PR DESCRIPTION
This reduces the number of PHP failures from 104 to 40.
Basically, `with_prototype`s pushed onto the stack later take precedence over those pushed earlier.