### PR TITLE
syntax tests example: account for test assertion lines without selectors

### DIFF
--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -41,7 +41,7 @@ lazy_static! {
     pub static ref SYNTAX_TEST_ASSERTION_PATTERN: Regex = Regex::new(r#"(?xm)
         \s*(?:
             (?P<begin_of_token><-)|(?P<range>\^+)
-        )(.+)$"#).unwrap();
+        )(.*)$"#).unwrap();
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
such assertion lines always pass due to the selector being empty, no idea why this is a thing though...

- https://github.com/sublimehq/Packages/blob/1349d1a18dd6d56916427275d70df0265b6449bd/Ruby/syntax_test_ruby.rb#L86
- https://github.com/sublimehq/Packages/blob/1349d1a18dd6d56916427275d70df0265b6449bd/Regular%20Expressions/syntax_test_regexp.re#L272