### PR TITLE
Make syntax name optional, fixes #46

### DIFF
--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -114,7 +114,7 @@ impl SyntaxDefinition {
         SyntaxDefinition::add_initial_contexts(&mut contexts, &mut state, top_level_scope);
 
         let defn = SyntaxDefinition {
-            name: try!(get_key(h, "name", |x| x.as_str())).to_owned(),
+            name: get_key(h, "name", |x| x.as_str()).unwrap_or("Unnamed").to_owned(),
             scope: top_level_scope,
             file_extensions: {
                 get_key(h, "file_extensions", |x| x.as_vec())


### PR DESCRIPTION
Ideally we would pass in the file name and it would default to that if it existed,
but this should be fine for most cases. At least it doesn't crash.

cc @keith-hall @FichteFoll