### PR TITLE
Feature flag for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,15 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.3.5", optional = true }
-onig = "^1.2"
+onig = { version = "^1.2", optional = true }
 walkdir = "^1.0"
-regex-syntax = "^0.4"
+regex-syntax = { version = "^0.4", optional = true }
 lazy_static = "^0.2"
 bitflags = "^0.8"
 plist = "0.2"
 bincode = "0.8"
 flate2 = "^0.2"
-fnv = "^1.0"
+fnv = { version = "^1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -32,10 +32,11 @@ regex = "0.2.1"
 
 [features]
 static-onig = ["onig/static-libonig"]
+parsing = ["onig", "regex-syntax", "fnv"]
 assets = []
-html = ["assets"]
+html = ["parsing", "assets"]
 yaml-load = ["yaml-rust"]
-default = ["assets", "html", "yaml-load"]
+default = ["parsing", "assets", "html", "yaml-load"]
 
 # [profile.release]
 # debug = true

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,12 @@ git submodule update --init
 
 to fetch all the required dependencies for running the tests.
 
+### feature flags
+
+Syntect makes heavy use of [cargo features](http://doc.crates.io/manifest.html#the-features-section), to support users who require only a subset of functionality. In particular, it is possible to use the highlighting component of syntect without the parser (for instance when hand-rolling a higher performance parser for a particular language), by adding `default-features = false` to the syntect entry in your `Cargo.toml`.
+
+For more information on available features, see the features section in `Cargo.toml`.
+
 ## Features/Goals
 
 - [x] Work with many languages (accomplished through using existing grammar formats)

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -10,7 +10,7 @@
 use bincode::{ErrorKind, Infinite, Result, deserialize_from, serialize_into};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
-#[cfg(feature = "assets")]
+#[cfg(all(feature = "parsing", feature = "assets"))]
 use parsing::SyntaxSet;
 #[cfg(feature = "assets")]
 use highlighting::ThemeSet;
@@ -55,7 +55,7 @@ pub fn from_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T>
     deserialize_from(&mut decoder, Infinite)
 }
 
-#[cfg(feature = "assets")]
+#[cfg(all(feature = "parsing", feature = "assets"))]
 impl SyntaxSet {
     /// Instantiates a new syntax set from a binary dump of
     /// Sublime Text's default open source syntax definitions and then links it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,10 @@
 //! for the `easy` module in `easy.rs` as that shows how to plug the various parts together for common use cases.
 #[cfg(feature = "yaml-load")]
 extern crate yaml_rust;
+#[cfg(feature = "parsing")]
 extern crate onig;
 extern crate walkdir;
+#[cfg(feature = "parsing")]
 extern crate regex_syntax;
 #[macro_use]
 extern crate lazy_static;
@@ -26,6 +28,7 @@ extern crate bincode;
 #[macro_use]
 extern crate bitflags;
 extern crate flate2;
+#[cfg(feature = "parsing")]
 extern crate fnv;
 extern crate serde;
 #[macro_use]
@@ -35,6 +38,7 @@ pub mod highlighting;
 pub mod parsing;
 pub mod util;
 pub mod dumps;
+#[cfg(feature = "parsing")]
 pub mod easy;
 #[cfg(feature = "html")]
 pub mod html;
@@ -42,7 +46,7 @@ pub mod html;
 mod escape;
 
 use std::io::Error as IoError;
-#[cfg(feature = "yaml-load")]
+#[cfg(all(feature = "yaml-load", feature = "parsing"))]
 use parsing::ParseSyntaxError;
 use highlighting::{ParseThemeError, SettingsError};
 
@@ -83,7 +87,7 @@ impl From<ParseThemeError> for LoadingError {
     }
 }
 
-#[cfg(feature = "yaml-load")]
+#[cfg(all(feature = "yaml-load", feature = "parsing"))]
 impl From<ParseSyntaxError> for LoadingError {
     fn from(error: ParseSyntaxError) -> LoadingError {
         LoadingError::ParseSyntax(error)

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,15 +1,23 @@
 //! Everything about parsing text into text annotated with scopes.
 //! The most important struct here is `SyntaxSet`, check out the docs for that.
+#[cfg(feature = "parsing")]
 pub mod syntax_definition;
-#[cfg(feature = "yaml-load")]
+#[cfg(all( feature = "parsing", feature = "yaml-load"))]
 mod yaml_load;
+#[cfg(feature = "parsing")]
 mod syntax_set;
-mod scope;
+#[cfg(feature = "parsing")]
 mod parser;
 
+mod scope;
+
+#[cfg(feature = "parsing")]
 pub use self::syntax_definition::SyntaxDefinition;
-#[cfg(feature = "yaml-load")]
+#[cfg(all( feature = "parsing", feature = "yaml-load"))]
 pub use self::yaml_load::*;
+#[cfg(feature = "parsing")]
 pub use self::syntax_set::*;
-pub use self::scope::*;
+#[cfg(feature = "parsing")]
 pub use self::parser::*;
+
+pub use self::scope::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@
 //! prettily to the terminal.
 use highlighting::Style;
 use std::fmt::Write;
+#[cfg(feature = "parsing")]
 use parsing::ScopeStackOp;
 
 /// Formats the styled fragments using 24-bit colour
@@ -39,6 +40,7 @@ pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
 
 /// Print out the various push and pop operations in a vector
 /// with visual alignment to the line. Obviously for debugging.
+#[cfg(feature = "parsing")]
 pub fn debug_print_ops(line: &str, ops: &[(usize, ScopeStackOp)]) {
     for &(i, ref op) in ops.iter() {
         println!("{}", line.trim_right());


### PR DESCRIPTION
This is a dirty first-pass at putting more of syntect behind feature flags. Specifically, this adds the `parsing` feature, which wraps most of the `parsing` module. 

@trishume I wanted to check in and see what you thought. With `--release --no-features` this compiles to about 1.5M on macOS.  That seems manageable. Is there any low hanging fruit you can think of? I'm looking at `dumps`, but that's probably convenient for us to hold on to for now, and doesn't really produce much savings.

If this is okay with you I'll clean it up a bit and revise docs as needed.