### PR TITLE
Add derive(Hash) to scope, + doc nits

### DIFF
--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -35,7 +35,7 @@ lazy_static! {
 /// 16 bit numbers to represent and compare atoms. Like "atoms" or "symbols" in other languages.
 /// This means that while comparing and prefix are fast, extracting a string is relatively slower
 /// but ideally should be very rare.
-#[derive(Clone, PartialEq, Eq, Copy, Default)]
+#[derive(Clone, PartialEq, Eq, Copy, Default, Hash)]
 pub struct Scope {
     a: u64,
     b: u64,
@@ -52,7 +52,7 @@ pub enum ParseScopeError {
     TooManyAtoms,
 }
 
-/// The structure used to keep of the mapping between scope atom numbers
+/// The structure used to keep track of the mapping between scope atom numbers
 /// and their string names. It is only exposed in case you want to lock
 /// `SCOPE_REPO` and then allocate a whole bunch of scopes at once
 /// without thrashing the lock. It is recommended you just use `Scope::new()`

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -22,8 +22,9 @@ use onig::Regex;
 ///
 /// Linking replaces the references between syntaxes with direct
 /// pointers. See `link_syntaxes` for more.
-/// Linking, followed by adding more unlinked syntaxes with `load_syntaxes`
-/// and then linking again is allowed.
+///
+/// Re-linking— linking, adding more unlinked syntaxes with `load_syntaxes`,
+/// and then linking again—is allowed.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SyntaxSet {
     syntaxes: Vec<SyntaxDefinition>,


### PR DESCRIPTION
I need `Hash` (or `Ord`, if I switch to a btree) for the plugin-side identifier lookup.


Also bundled some doc changes that were sitting there. 🤷‍♂️ 