### PR TITLE
Improved syncat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ fnv = { version = "^1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-getopts = "0.2"
 
 [dev-dependencies]
 regex = "0.2.1"
+getopts = "0.2"
 
 [features]
 static-onig = ["onig/static-libonig"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ fnv = { version = "^1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
+getopts = "0.2"
 
 [dev-dependencies]
 regex = "0.2.1"

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -10,7 +10,7 @@ use std::io::BufRead;
 
 fn load_theme(tm_file: &String) -> Theme {
     let tm_path = Path::new(tm_file);
-    let tm_cache = tm_path.with_extension("themedump");
+    let tm_cache = tm_path.with_extension("tmdump");
 
     if tm_cache.exists() {
         from_dump_file(tm_cache).unwrap()

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -27,7 +27,6 @@ fn main() {
     let ts = ThemeSet::load_defaults();
 
     let args: Vec<String> = std::env::args().collect();
-    let src;
     let theme;
     let theme_ref;
 
@@ -47,14 +46,13 @@ fn main() {
 
     } else if args.len() == 2 {
         theme_ref = &ts.themes["base16-ocean.dark"];
-        src = &args[1];
 
     } else {
         theme = load_theme(&args[1]);
         theme_ref = &theme;
-        src = &args[2];
     }
 
+    let src = args.last().unwrap();
     let mut highlighter = HighlightFile::new(src, &ss, theme_ref).unwrap();
 
     // We use read_line instead of `for line in highlighter.reader.lines()` because that

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -1,4 +1,5 @@
 extern crate syntect;
+use std::borrow::Cow;
 use std::path::Path;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{Theme, ThemeSet, Style};
@@ -28,7 +29,6 @@ fn main() {
 
     let args: Vec<String> = std::env::args().collect();
     let theme;
-    let theme_ref;
 
     if args.len() < 2 {
         println!("USAGE: ./syncat [THEME_FILE] SRC_FILE");
@@ -45,15 +45,14 @@ fn main() {
         return;
 
     } else if args.len() == 2 {
-        theme_ref = &ts.themes["base16-ocean.dark"];
+        theme = Cow::Borrowed(&ts.themes["base16-ocean.dark"]);
 
     } else {
-        theme = load_theme(&args[1]);
-        theme_ref = &theme;
+        theme = Cow::Owned(load_theme(&args[1]));
     }
 
     let src = args.last().unwrap();
-    let mut highlighter = HighlightFile::new(src, &ss, theme_ref).unwrap();
+    let mut highlighter = HighlightFile::new(src, &ss, &theme).unwrap();
 
     // We use read_line instead of `for line in highlighter.reader.lines()` because that
     // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -11,12 +11,24 @@ fn main() {
     let ts = ThemeSet::load_defaults();
 
     let args: Vec<String> = std::env::args().collect();
+    let src;
+    let theme;
+    let themeRef;
+
     if args.len() < 2 {
-        println!("Please pass in a file to highlight");
+        println!("USAGE: ./syncat [THEME_FILE] SRC_FILE");
         return;
+    } else if args.len() == 2 {
+        src = &args[1];
+        themeRef = &ts.themes["base16-ocean.dark"];
+    } else {
+        let theme_file = &args[1];
+        src = &args[2];
+        theme = ThemeSet::get_theme(theme_file).unwrap();
+        themeRef = &theme;
     }
 
-    let mut highlighter = HighlightFile::new(&args[1], &ss, &ts.themes["base16-ocean.dark"]).unwrap();
+    let mut highlighter = HighlightFile::new(src, &ss, themeRef).unwrap();
 
     // We use read_line instead of `for line in highlighter.reader.lines()` because that
     // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -33,10 +33,22 @@ fn main() {
 
     if args.len() < 2 {
         println!("USAGE: ./syncat [THEME_FILE] SRC_FILE");
+        println!("       ./syncat --list-file-types");
         return;
+
+    } else if args.len() > 1 && args[1] == "--list-file-types" {
+        println!("Supported file types:");
+
+        for sd in ss.syntaxes() {
+            println!("- {} (.{})", sd.name, sd.file_extensions.join(", ."));
+        }
+
+        return;
+
     } else if args.len() == 2 {
         theme_ref = &ts.themes["base16-ocean.dark"];
         src = &args[1];
+
     } else {
         theme = load_theme(&args[1]);
         theme_ref = &theme;

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -1,5 +1,9 @@
 extern crate syntect;
+extern crate getopts;
+
+use getopts::Options;
 use std::borrow::Cow;
+use std::io::BufRead;
 use std::path::Path;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{Theme, ThemeSet, Style};
@@ -7,19 +11,22 @@ use syntect::util::as_24_bit_terminal_escaped;
 use syntect::easy::HighlightFile;
 use syntect::dumps::{from_dump_file, dump_to_file};
 
-use std::io::BufRead;
 
-fn load_theme(tm_file: &String) -> Theme {
+fn load_theme(tm_file: &String, enable_caching: bool) -> Theme {
     let tm_path = Path::new(tm_file);
-    let tm_cache = tm_path.with_extension("tmdump");
 
-    if tm_cache.exists() {
-        from_dump_file(tm_cache).unwrap()
+    if enable_caching {
+        let tm_cache = tm_path.with_extension("tmdump");
+
+        if tm_cache.exists() {
+            from_dump_file(tm_cache).unwrap()
+        } else {
+            let theme = ThemeSet::get_theme(tm_path).unwrap();
+            dump_to_file(&theme, tm_cache).unwrap();
+            theme
+        }
     } else {
-        let theme = ThemeSet::get_theme(tm_path).unwrap();
-        dump_to_file(&theme, tm_cache).unwrap();
-        theme
-
+        ThemeSet::get_theme(tm_path).unwrap()
     }
 }
 
@@ -28,42 +35,55 @@ fn main() {
     let ts = ThemeSet::load_defaults();
 
     let args: Vec<String> = std::env::args().collect();
-    let theme;
+    let mut opts = Options::new();
+    opts.optflag("l", "list-file-types", "Lists supported file types");
+    opts.optopt("t", "theme-file", "Theme file to use. Default: base16-ocean (embedded)", "THEME_FILE");
+    opts.optflag("c", "cache-theme", "Cache the parsed theme file.");
 
-    if args.len() < 2 {
-        println!("USAGE: ./syncat [THEME_FILE] SRC_FILE");
-        println!("       ./syncat --list-file-types");
-        return;
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => { m }
+        Err(f) => { panic!(f.to_string()) }
+    };
 
-    } else if args.len() > 1 && args[1] == "--list-file-types" {
+    if matches.opt_present("list-file-types") {
         println!("Supported file types:");
 
         for sd in ss.syntaxes() {
             println!("- {} (.{})", sd.name, sd.file_extensions.join(", ."));
         }
 
-        return;
-
-    } else if args.len() == 2 {
-        theme = Cow::Borrowed(&ts.themes["base16-ocean.dark"]);
+    } else if matches.free.len() == 0 {
+        let brief = format!("USAGE: {} [options] FILES", args[0]);
+        println!("{}", opts.usage(&brief));
 
     } else {
-        theme = Cow::Owned(load_theme(&args[1]));
-    }
+        let theme = matches.opt_str("theme-file").map_or(
+            Cow::Borrowed(&ts.themes["base16-ocean.dark"]),
+            |tf| Cow::Owned(load_theme(&tf, matches.opt_present("cache-theme")))
+        );
 
-    let src = args.last().unwrap();
-    let mut highlighter = HighlightFile::new(src, &ss, &theme).unwrap();
+        for src in &matches.free[..] {
+            if matches.free.len() > 1 {
+                println!("==> {} <==", src);
+            }
 
-    // We use read_line instead of `for line in highlighter.reader.lines()` because that
-    // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
-    // See the documentation for `SyntaxSet::load_syntaxes`.
-    // It also allows re-using the line buffer, which should be a tiny bit faster.
-    let mut line = String::new();
-    while highlighter.reader.read_line(&mut line).unwrap() > 0 {
-        {
-            let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line);
-            print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
+            let mut highlighter = HighlightFile::new(src, &ss, &theme).unwrap();
+
+            // We use read_line instead of `for line in highlighter.reader.lines()` because that
+            // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
+            // See the documentation for `SyntaxSet::load_syntaxes`.
+            // It also allows re-using the line buffer, which should be a tiny bit faster.
+            let mut line = String::new();
+            while highlighter.reader.read_line(&mut line).unwrap() > 0 {
+                {
+                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line);
+                    print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
+                }
+                line.clear();
+            }
+
+            // Clear the formatting
+            println!("\x1b[0m");
         }
-        line.clear();
     }
 }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -1,10 +1,15 @@
 extern crate syntect;
 use syntect::parsing::SyntaxSet;
-use syntect::highlighting::{ThemeSet, Style};
+use syntect::highlighting::{Theme, ThemeSet, Style};
 use syntect::util::as_24_bit_terminal_escaped;
 use syntect::easy::HighlightFile;
 
 use std::io::BufRead;
+
+fn load_theme(path: &String) -> Theme {
+    // TODO: cache this
+    ThemeSet::get_theme(path).unwrap()
+}
 
 fn main() {
     let ss = SyntaxSet::load_defaults_newlines(); // note we load the version with newlines
@@ -19,13 +24,12 @@ fn main() {
         println!("USAGE: ./syncat [THEME_FILE] SRC_FILE");
         return;
     } else if args.len() == 2 {
-        src = &args[1];
         themeRef = &ts.themes["base16-ocean.dark"];
+        src = &args[1];
     } else {
-        let theme_file = &args[1];
-        src = &args[2];
-        theme = ThemeSet::get_theme(theme_file).unwrap();
+        theme = load_theme(&args[1]);
         themeRef = &theme;
+        src = &args[2];
     }
 
     let mut highlighter = HighlightFile::new(src, &ss, themeRef).unwrap();


### PR DESCRIPTION
This PR adds some niceties to make syncat slightly more useful as a tool in its own right:
* ability to specify the theme at runtime (and cache its parsed representation)
* ability to list supported file types

I apologise if the code isn't idiomatic, as I'm not very familiar with Rust.