### PR TITLE
Add pooling for parallel usage of SyntaxSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,11 @@ fnv = { version = "^1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"
+num_cpus = "^1.5"
 
 [dev-dependencies]
 regex = "0.2.1"
+crossbeam = "0.2.0"
 
 [features]
 static-onig = ["onig/static-libonig"]

--- a/benches/parallel_parsing.rs
+++ b/benches/parallel_parsing.rs
@@ -1,0 +1,58 @@
+#![feature(test)]
+
+extern crate test;
+extern crate syntect;
+extern crate crossbeam;
+
+use syntect::parsing::{SyntaxSetPool, SyntaxSet, SyntaxDefinition, ParseState};
+use test::Bencher;
+use std::fs::File;
+use std::io::Read;
+
+fn do_parse(s: &str, syntax: &SyntaxDefinition) {
+    let mut state = ParseState::new(syntax);
+    for line in s.lines() {
+        let ops = state.parse_line(line);
+        test::black_box(&ops);
+    }
+}
+
+fn parse_file(path_s: &str, ps: &SyntaxSet) {
+    let syntax = ps.find_syntax_for_file(path_s).unwrap().unwrap();
+    let mut f = File::open(path_s).unwrap();
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+
+    do_parse(&s, syntax);
+}
+
+#[bench]
+fn bench_parallel_parsing(b: &mut Bencher) {
+    let files =
+        [ "audit.rb"
+        , "download_strategy.rb"
+        , "formula.rb"
+        , "load_commands.rb"
+        , "parser.rs"
+        , "README.md"
+        , "core_unix.ml"
+        , "Core.hs"
+        ];
+    let syntaxes = SyntaxSetPool::new(SyntaxSet::load_defaults_nonewlines);
+    let syntaxes_ref = &syntaxes;
+
+    b.iter(|| {
+        crossbeam::scope(|scope| {
+            for file in &files {
+                let filepath = format!("testdata/issue20/{}", file);
+                test::black_box(
+                    scope.spawn(move || {
+                        syntaxes_ref.with_syntax_set(|ps| {
+                            parse_file(&filepath, ps);
+                        });
+                    })
+                );
+            }
+        });
+    });
+}

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -1,0 +1,63 @@
+extern crate syntect;
+extern crate crossbeam;
+
+use syntect::parsing::{SyntaxSetPool, SyntaxSet};
+use syntect::highlighting::ThemeSet;
+use syntect::util::as_24_bit_terminal_escaped;
+use syntect::easy::HighlightLines;
+
+use std::io::{stdout, BufReader, BufRead, Write};
+use std::fs::File;
+
+trait HasSync: Sync {}
+
+fn main() {
+  let ssp = SyntaxSetPool::new(SyntaxSet::load_defaults_newlines);
+  let ssp_ref = &ssp;
+  let ts = ThemeSet::load_defaults();
+  let theme = &ts.themes["base16-ocean.dark"];
+  let out = stdout();
+  let out_ref = &out;
+
+  let args: Vec<String> = std::env::args().collect();
+  if args.len() < 2 {
+    println!("Please pass in files to highlight");
+    return;
+  }
+
+  crossbeam::scope(|scope| {
+    for file in args.iter().skip(1) {
+      scope.spawn(move || {
+        let mut lines = Vec::new();
+
+        {
+          let f = File::open(file).unwrap();
+          let mut bufread = BufReader::new(f);
+          let mut line = String::new();
+          while bufread.read_line(&mut line).unwrap() > 0 {
+            lines.push(line);
+            line = String::new();
+          }
+        }
+         
+        {
+          let mut regions = Vec::new();
+
+          ssp_ref.with_syntax_set(|ss| {
+            let syntax = ss.find_syntax_for_file(file).unwrap().unwrap();
+            let mut highlighter = HighlightLines::new(syntax, theme);
+            for line in &lines {
+              for region in highlighter.highlight(&line) {
+                regions.push(region);
+              }
+            }
+          });
+
+          let mut out = out_ref.lock();
+          write!(out, "{}", as_24_bit_terminal_escaped(&regions[..], true))
+            .unwrap();
+        }
+      });
+    }
+  });
+}

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -2,7 +2,7 @@ extern crate syntect;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{ThemeSet, Style};
 use syntect::util::as_24_bit_terminal_escaped;
-use syntect::easy::HighlightFile;
+use syntect::easy::HighlightLines;
 
 use std::io::BufRead;
 
@@ -22,12 +22,4 @@ fn main() {
     // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
     // See the documentation for `SyntaxSet::load_syntaxes`.
     // It also allows re-using the line buffer, which should be a tiny bit faster.
-    let mut line = String::new();
-    while highlighter.reader.read_line(&mut line).unwrap() > 0 {
-        {
-            let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line);
-            print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
-        }
-        line.clear();
-    }
 }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -2,7 +2,7 @@ extern crate syntect;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{ThemeSet, Style};
 use syntect::util::as_24_bit_terminal_escaped;
-use syntect::easy::HighlightLines;
+use syntect::easy::HighlightFile;
 
 use std::io::BufRead;
 
@@ -22,4 +22,12 @@ fn main() {
     // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
     // See the documentation for `SyntaxSet::load_syntaxes`.
     // It also allows re-using the line buffer, which should be a tiny bit faster.
+    let mut line = String::new();
+    while highlighter.reader.read_line(&mut line).unwrap() > 0 {
+        {
+            let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line);
+            print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
+        }
+        line.clear();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate num_cpus;
 pub mod highlighting;
 pub mod parsing;
 pub mod util;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -6,6 +6,7 @@ pub mod syntax_definition;
 mod yaml_load;
 #[cfg(feature = "parsing")]
 mod syntax_set;
+mod syntax_set_pool;
 #[cfg(feature = "parsing")]
 mod parser;
 
@@ -17,6 +18,7 @@ pub use self::syntax_definition::SyntaxDefinition;
 pub use self::yaml_load::*;
 #[cfg(feature = "parsing")]
 pub use self::syntax_set::*;
+pub use self::syntax_set_pool::*;
 #[cfg(feature = "parsing")]
 pub use self::parser::*;
 

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -6,6 +6,7 @@ pub mod syntax_definition;
 mod yaml_load;
 #[cfg(feature = "parsing")]
 mod syntax_set;
+#[cfg(feature = "parsing")]
 mod syntax_set_pool;
 #[cfg(feature = "parsing")]
 mod parser;
@@ -18,6 +19,7 @@ pub use self::syntax_definition::SyntaxDefinition;
 pub use self::yaml_load::*;
 #[cfg(feature = "parsing")]
 pub use self::syntax_set::*;
+#[cfg(feature = "parsing")]
 pub use self::syntax_set_pool::*;
 #[cfg(feature = "parsing")]
 pub use self::parser::*;

--- a/src/parsing/syntax_set_pool.rs
+++ b/src/parsing/syntax_set_pool.rs
@@ -1,0 +1,122 @@
+use std::cell::UnsafeCell;
+use std::sync::{Mutex, Condvar};
+
+use num_cpus;
+
+use super::SyntaxSet;
+
+/// This is intentionally not public. The `Send` implementation makes
+/// this unsafe to use outside this module.
+struct LazyInit<T> {
+    inner: UnsafeCell<Option<T>>
+}
+
+/// A pool for parallelizing syntax parsing/highlighting. Constructs
+/// a lazily-initialized pool of `SyntaxSet`s, each initialized the
+/// same way. The first time each `SyntaxSet` gets used, the thread
+/// using it runs its setup code.
+///
+/// Use syntax sets by passing a closure to `with_syntax_set()`. A
+/// `SyntaxSet` will be removed from the pool, and a reference to it
+/// passed to the given closure. Afterwards, the set will automatically
+/// be returned to the pool.
+pub struct SyntaxSetPool<F: Fn() -> SyntaxSet> {
+    /// We intentionally use a *stack* of `SyntaxSet`s so that
+    /// already-initialized syntaxes get reused as much as possible.
+    syntaxes: Mutex<Vec<LazyInit<SyntaxSet>>>,
+    has_syntax: Condvar,
+    init_fn: F
+}
+
+// The unsafety boundary for this `unsafe` is not *this* module, but the
+// *parent* module. With the way we're using this, `SyntaxSet` must not
+// implement either `Clone` or `Copy`.
+unsafe impl<T> Send for LazyInit<T> {}
+
+impl<T> LazyInit<T> {
+    /// Create a `LazyInit` with contents uninitialized.
+    fn new() -> Self {
+        LazyInit { inner: UnsafeCell::new(None) }
+    }
+
+    fn maybe_init<F>(&self, init_fn: F) -> *mut T where F: Fn() -> T {
+        let inner_ptr = self.inner.get();
+        unsafe {
+            if let None = *inner_ptr {
+                *inner_ptr = Some(init_fn());
+            }
+
+            match *inner_ptr {
+                Some(ref mut inner) => inner as *mut T,
+                None => unreachable!()
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn get_or<F>(&self, init_fn: F) -> &T where F: Fn() -> T {
+        unsafe { &*self.maybe_init(init_fn) }
+    }
+
+    fn get_mut_or<F>(&self, init_fn: F) -> &mut T where F: Fn() -> T {
+        unsafe { &mut *self.maybe_init(init_fn) }
+    }
+}
+
+struct Repeating<F, T> where F: Fn() -> T {
+    item_fn: F
+}
+
+impl<F, T> Iterator for Repeating<F, T> where F: Fn() -> T {
+    type Item = T;
+    fn next(&mut self) -> Option<Self::Item> {
+        Some((self.item_fn)())
+    }
+}
+
+fn repeating<F, T>(item_fn: F) -> Repeating<F, T> where F: Fn() -> T {
+    Repeating { item_fn: item_fn }
+}
+
+impl<F> SyntaxSetPool<F> where F: Fn() -> SyntaxSet + Sync {
+    pub fn new(init_fn: F) -> Self {
+        Self::with_pool_size(init_fn, num_cpus::get())
+    }
+  
+    pub fn with_pool_size(init_fn: F, pool_size: usize) -> Self {
+        SyntaxSetPool {
+            syntaxes: Mutex::new(repeating(LazyInit::new).take(pool_size).collect()),
+            has_syntax: Condvar::new(),
+            init_fn: init_fn
+        }
+    }
+
+    pub fn with_syntax_set<G, R>(&self, go: G) -> R where G: FnOnce(&mut SyntaxSet) -> R {
+        let syntax_init;
+
+        {
+            let mut syntaxes = self.syntaxes.lock().unwrap();
+            loop {  // catch spurious wakeups on condvar
+                match syntaxes.pop() {
+                    Some(init) => {
+                        syntax_init = init;
+                        break;
+                    },
+                    None => {
+                        syntaxes = self.has_syntax.wait(syntaxes).unwrap();
+                    }
+                }
+            }
+        }
+
+        let result = go(syntax_init.get_mut_or(|| (self.init_fn)()));
+
+        {
+            let mut syntaxes = self.syntaxes.lock().unwrap();
+            syntaxes.push(syntax_init);
+            self.has_syntax.notify_one();
+        }
+
+        result
+    }
+}

--- a/src/parsing/syntax_set_pool.rs
+++ b/src/parsing/syntax_set_pool.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, Condvar};
 
 use num_cpus;
 
-use super::SyntaxSet;
+use super::syntax_set::SyntaxSet;
 
 /// This is intentionally not public. The `Send` implementation makes
 /// this unsafe to use outside this module.

--- a/testdata/issue20/Core.hs
+++ b/testdata/issue20/Core.hs
@@ -1,0 +1,664 @@
+{-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving,
+             MultiParamTypeClasses, TypeSynonymInstances, CPP, DeriveDataTypeable #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Core
+-- Copyright   :  (c) Spencer Janssen 2007
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  spencerjanssen@gmail.com
+-- Stability   :  unstable
+-- Portability :  not portable, uses cunning newtype deriving
+--
+-- The 'X' monad, a state monad transformer over 'IO', for the window
+-- manager state, and support routines.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Core (
+    X, WindowSet, WindowSpace, WorkspaceId,
+    ScreenId(..), ScreenDetail(..), XState(..),
+    XConf(..), XConfig(..), LayoutClass(..),
+    Layout(..), readsLayout, Typeable, Message,
+    SomeMessage(..), fromMessage, LayoutMessages(..),
+    StateExtension(..), ExtensionClass(..),
+    runX, catchX, userCode, userCodeDef, io, catchIO, installSignalHandlers, uninstallSignalHandlers,
+    withDisplay, withWindowSet, isRoot, runOnWorkspaces,
+    getAtom, spawn, spawnPID, xfork, recompile, trace, whenJust, whenX,
+    getXMonadDir, getXMonadCacheDir, getXMonadDataDir, stateFileName,
+    atom_WM_STATE, atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_TAKE_FOCUS, withWindowAttributes,
+    ManageHook, Query(..), runQuery
+  ) where
+
+import XMonad.StackSet hiding (modify)
+
+import Prelude
+import Control.Exception.Extensible (fromException, try, bracket, throw, finally, SomeException(..))
+import qualified Control.Exception.Extensible as E
+import Control.Applicative
+import Control.Monad.State
+import Control.Monad.Reader
+import Data.Default
+import System.FilePath
+import System.IO
+import System.Info
+import System.Posix.Env (getEnv)
+import System.Posix.Process (executeFile, forkProcess, getAnyProcessStatus, createSession)
+import System.Posix.Signals
+import System.Posix.IO
+import System.Posix.Types (ProcessID)
+import System.Process
+import System.Directory
+import System.Exit
+import Graphics.X11.Xlib
+import Graphics.X11.Xlib.Extras (getWindowAttributes, WindowAttributes, Event)
+import Data.Typeable
+import Data.List ((\\))
+import Data.Maybe (isJust,fromMaybe)
+import Data.Monoid
+
+import qualified Data.Map as M
+import qualified Data.Set as S
+
+-- | XState, the (mutable) window manager state.
+data XState = XState
+    { windowset        :: !WindowSet                     -- ^ workspace list
+    , mapped           :: !(S.Set Window)                -- ^ the Set of mapped windows
+    , waitingUnmap     :: !(M.Map Window Int)            -- ^ the number of expected UnmapEvents
+    , dragging         :: !(Maybe (Position -> Position -> X (), X ()))
+    , numberlockMask   :: !KeyMask                       -- ^ The numlock modifier
+    , extensibleState  :: !(M.Map String (Either String StateExtension))
+    -- ^ stores custom state information.
+    --
+    -- The module "XMonad.Utils.ExtensibleState" in xmonad-contrib
+    -- provides additional information and a simple interface for using this.
+    }
+
+-- | XConf, the (read-only) window manager configuration.
+data XConf = XConf
+    { display       :: Display        -- ^ the X11 display
+    , config        :: !(XConfig Layout)       -- ^ initial user configuration
+    , theRoot       :: !Window        -- ^ the root window
+    , normalBorder  :: !Pixel         -- ^ border color of unfocused windows
+    , focusedBorder :: !Pixel         -- ^ border color of the focused window
+    , keyActions    :: !(M.Map (KeyMask, KeySym) (X ()))
+                                      -- ^ a mapping of key presses to actions
+    , buttonActions :: !(M.Map (KeyMask, Button) (Window -> X ()))
+                                      -- ^ a mapping of button presses to actions
+    , mouseFocused :: !Bool           -- ^ was refocus caused by mouse action?
+    , mousePosition :: !(Maybe (Position, Position))
+                                      -- ^ position of the mouse according to
+                                      -- the event currently being processed
+    , currentEvent :: !(Maybe Event)
+                                      -- ^ event currently being processed
+    }
+
+-- todo, better name
+data XConfig l = XConfig
+    { normalBorderColor  :: !String              -- ^ Non focused windows border color. Default: \"#dddddd\"
+    , focusedBorderColor :: !String              -- ^ Focused windows border color. Default: \"#ff0000\"
+    , terminal           :: !String              -- ^ The preferred terminal application. Default: \"xterm\"
+    , layoutHook         :: !(l Window)          -- ^ The available layouts
+    , manageHook         :: !ManageHook          -- ^ The action to run when a new window is opened
+    , handleEventHook    :: !(Event -> X All)    -- ^ Handle an X event, returns (All True) if the default handler
+                                                 -- should also be run afterwards. mappend should be used for combining
+                                                 -- event hooks in most cases.
+    , workspaces         :: ![String]            -- ^ The list of workspaces' names
+    , modMask            :: !KeyMask             -- ^ the mod modifier
+    , keys               :: !(XConfig Layout -> M.Map (ButtonMask,KeySym) (X ()))
+                                                 -- ^ The key binding: a map from key presses and actions
+    , mouseBindings      :: !(XConfig Layout -> M.Map (ButtonMask, Button) (Window -> X ()))
+                                                 -- ^ The mouse bindings
+    , borderWidth        :: !Dimension           -- ^ The border width
+    , logHook            :: !(X ())              -- ^ The action to perform when the windows set is changed
+    , startupHook        :: !(X ())              -- ^ The action to perform on startup
+    , focusFollowsMouse  :: !Bool                -- ^ Whether window entry events can change focus
+    , clickJustFocuses   :: !Bool                -- ^ False to make a click which changes focus to be additionally passed to the window
+    , clientMask         :: !EventMask           -- ^ The client events that xmonad is interested in
+    , rootMask           :: !EventMask           -- ^ The root events that xmonad is interested in
+    , handleExtraArgs    :: !([String] -> XConfig Layout -> IO (XConfig Layout))
+                                                 -- ^ Modify the configuration, complain about extra arguments etc. with arguments that are not handled by default
+    }
+
+
+type WindowSet   = StackSet  WorkspaceId (Layout Window) Window ScreenId ScreenDetail
+type WindowSpace = Workspace WorkspaceId (Layout Window) Window
+
+-- | Virtual workspace indices
+type WorkspaceId = String
+
+-- | Physical screen indices
+newtype ScreenId    = S Int deriving (Eq,Ord,Show,Read,Enum,Num,Integral,Real)
+
+-- | The 'Rectangle' with screen dimensions
+data ScreenDetail   = SD { screenRect :: !Rectangle } deriving (Eq,Show, Read)
+
+------------------------------------------------------------------------
+
+-- | The X monad, 'ReaderT' and 'StateT' transformers over 'IO'
+-- encapsulating the window manager configuration and state,
+-- respectively.
+--
+-- Dynamic components may be retrieved with 'get', static components
+-- with 'ask'. With newtype deriving we get readers and state monads
+-- instantiated on 'XConf' and 'XState' automatically.
+--
+newtype X a = X (ReaderT XConf (StateT XState IO) a)
+    deriving (Functor, Monad, MonadIO, MonadState XState, MonadReader XConf, Typeable)
+
+instance Applicative X where
+  pure = return
+  (<*>) = ap
+
+instance (Monoid a) => Monoid (X a) where
+    mempty  = return mempty
+    mappend = liftM2 mappend
+
+instance Default a => Default (X a) where
+    def = return def
+
+type ManageHook = Query (Endo WindowSet)
+newtype Query a = Query (ReaderT Window X a)
+    deriving (Functor, Applicative, Monad, MonadReader Window, MonadIO)
+
+runQuery :: Query a -> Window -> X a
+runQuery (Query m) w = runReaderT m w
+
+instance Monoid a => Monoid (Query a) where
+    mempty  = return mempty
+    mappend = liftM2 mappend
+
+instance Default a => Default (Query a) where
+    def = return def
+
+-- | Run the 'X' monad, given a chunk of 'X' monad code, and an initial state
+-- Return the result, and final state
+runX :: XConf -> XState -> X a -> IO (a, XState)
+runX c st (X a) = runStateT (runReaderT a c) st
+
+-- | Run in the 'X' monad, and in case of exception, and catch it and log it
+-- to stderr, and run the error case.
+catchX :: X a -> X a -> X a
+catchX job errcase = do
+    st <- get
+    c <- ask
+    (a, s') <- io $ runX c st job `E.catch` \e -> case fromException e of
+                        Just x -> throw e `const` (x `asTypeOf` ExitSuccess)
+                        _ -> do hPrint stderr e; runX c st errcase
+    put s'
+    return a
+
+-- | Execute the argument, catching all exceptions.  Either this function or
+-- 'catchX' should be used at all callsites of user customized code.
+userCode :: X a -> X (Maybe a)
+userCode a = catchX (Just `liftM` a) (return Nothing)
+
+-- | Same as userCode but with a default argument to return instead of using
+-- Maybe, provided for convenience.
+userCodeDef :: a -> X a -> X a
+userCodeDef defValue a = fromMaybe defValue `liftM` userCode a
+
+-- ---------------------------------------------------------------------
+-- Convenient wrappers to state
+
+-- | Run a monad action with the current display settings
+withDisplay :: (Display -> X a) -> X a
+withDisplay   f = asks display >>= f
+
+-- | Run a monadic action with the current stack set
+withWindowSet :: (WindowSet -> X a) -> X a
+withWindowSet f = gets windowset >>= f
+
+-- | Safely access window attributes.
+withWindowAttributes :: Display -> Window -> (WindowAttributes -> X ()) -> X ()
+withWindowAttributes dpy win f = do
+    wa <- userCode (io $ getWindowAttributes dpy win)
+    catchX (whenJust wa f) (return ())
+
+-- | True if the given window is the root window
+isRoot :: Window -> X Bool
+isRoot w = (w==) <$> asks theRoot
+
+-- | Wrapper for the common case of atom internment
+getAtom :: String -> X Atom
+getAtom str = withDisplay $ \dpy -> io $ internAtom dpy str False
+
+-- | Common non-predefined atoms
+atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_STATE, atom_WM_TAKE_FOCUS :: X Atom
+atom_WM_PROTOCOLS       = getAtom "WM_PROTOCOLS"
+atom_WM_DELETE_WINDOW   = getAtom "WM_DELETE_WINDOW"
+atom_WM_STATE           = getAtom "WM_STATE"
+atom_WM_TAKE_FOCUS      = getAtom "WM_TAKE_FOCUS"
+
+------------------------------------------------------------------------
+-- LayoutClass handling. See particular instances in Operations.hs
+
+-- | An existential type that can hold any object that is in 'Read'
+--   and 'LayoutClass'.
+data Layout a = forall l. (LayoutClass l a, Read (l a)) => Layout (l a)
+
+-- | Using the 'Layout' as a witness, parse existentially wrapped windows
+-- from a 'String'.
+readsLayout :: Layout a -> String -> [(Layout a, String)]
+readsLayout (Layout l) s = [(Layout (asTypeOf x l), rs) | (x, rs) <- reads s]
+
+-- | Every layout must be an instance of 'LayoutClass', which defines
+-- the basic layout operations along with a sensible default for each.
+--
+-- Minimal complete definition:
+--
+-- * 'runLayout' || (('doLayout' || 'pureLayout') && 'emptyLayout'), and
+--
+-- * 'handleMessage' || 'pureMessage'
+--
+-- You should also strongly consider implementing 'description',
+-- although it is not required.
+--
+-- Note that any code which /uses/ 'LayoutClass' methods should only
+-- ever call 'runLayout', 'handleMessage', and 'description'!  In
+-- other words, the only calls to 'doLayout', 'pureMessage', and other
+-- such methods should be from the default implementations of
+-- 'runLayout', 'handleMessage', and so on.  This ensures that the
+-- proper methods will be used, regardless of the particular methods
+-- that any 'LayoutClass' instance chooses to define.
+class Show (layout a) => LayoutClass layout a where
+
+    -- | By default, 'runLayout' calls 'doLayout' if there are any
+    --   windows to be laid out, and 'emptyLayout' otherwise.  Most
+    --   instances of 'LayoutClass' probably do not need to implement
+    --   'runLayout'; it is only useful for layouts which wish to make
+    --   use of more of the 'Workspace' information (for example,
+    --   "XMonad.Layout.PerWorkspace").
+    runLayout :: Workspace WorkspaceId (layout a) a
+              -> Rectangle
+              -> X ([(a, Rectangle)], Maybe (layout a))
+    runLayout (Workspace _ l ms) r = maybe (emptyLayout l r) (doLayout l r) ms
+
+    -- | Given a 'Rectangle' in which to place the windows, and a 'Stack'
+    -- of windows, return a list of windows and their corresponding
+    -- Rectangles.  If an element is not given a Rectangle by
+    -- 'doLayout', then it is not shown on screen.  The order of
+    -- windows in this list should be the desired stacking order.
+    --
+    -- Also possibly return a modified layout (by returning @Just
+    -- newLayout@), if this layout needs to be modified (e.g. if it
+    -- keeps track of some sort of state).  Return @Nothing@ if the
+    -- layout does not need to be modified.
+    --
+    -- Layouts which do not need access to the 'X' monad ('IO', window
+    -- manager state, or configuration) and do not keep track of their
+    -- own state should implement 'pureLayout' instead of 'doLayout'.
+    doLayout    :: layout a -> Rectangle -> Stack a
+                -> X ([(a, Rectangle)], Maybe (layout a))
+    doLayout l r s   = return (pureLayout l r s, Nothing)
+
+    -- | This is a pure version of 'doLayout', for cases where we
+    -- don't need access to the 'X' monad to determine how to lay out
+    -- the windows, and we don't need to modify the layout itself.
+    pureLayout  :: layout a -> Rectangle -> Stack a -> [(a, Rectangle)]
+    pureLayout _ r s = [(focus s, r)]
+
+    -- | 'emptyLayout' is called when there are no windows.
+    emptyLayout :: layout a -> Rectangle -> X ([(a, Rectangle)], Maybe (layout a))
+    emptyLayout _ _ = return ([], Nothing)
+
+    -- | 'handleMessage' performs message handling.  If
+    -- 'handleMessage' returns @Nothing@, then the layout did not
+    -- respond to the message and the screen is not refreshed.
+    -- Otherwise, 'handleMessage' returns an updated layout and the
+    -- screen is refreshed.
+    --
+    -- Layouts which do not need access to the 'X' monad to decide how
+    -- to handle messages should implement 'pureMessage' instead of
+    -- 'handleMessage' (this restricts the risk of error, and makes
+    -- testing much easier).
+    handleMessage :: layout a -> SomeMessage -> X (Maybe (layout a))
+    handleMessage l  = return . pureMessage l
+
+    -- | Respond to a message by (possibly) changing our layout, but
+    -- taking no other action.  If the layout changes, the screen will
+    -- be refreshed.
+    pureMessage :: layout a -> SomeMessage -> Maybe (layout a)
+    pureMessage _ _  = Nothing
+
+    -- | This should be a human-readable string that is used when
+    -- selecting layouts by name.  The default implementation is
+    -- 'show', which is in some cases a poor default.
+    description :: layout a -> String
+    description      = show
+
+instance LayoutClass Layout Window where
+    runLayout (Workspace i (Layout l) ms) r = fmap (fmap Layout) `fmap` runLayout (Workspace i l ms) r
+    doLayout (Layout l) r s  = fmap (fmap Layout) `fmap` doLayout l r s
+    emptyLayout (Layout l) r = fmap (fmap Layout) `fmap` emptyLayout l r
+    handleMessage (Layout l) = fmap (fmap Layout) . handleMessage l
+    description (Layout l)   = description l
+
+instance Show (Layout a) where show (Layout l) = show l
+
+-- | Based on ideas in /An Extensible Dynamically-Typed Hierarchy of
+-- Exceptions/, Simon Marlow, 2006. Use extensible messages to the
+-- 'handleMessage' handler.
+--
+-- User-extensible messages must be a member of this class.
+--
+class Typeable a => Message a
+
+-- |
+-- A wrapped value of some type in the 'Message' class.
+--
+data SomeMessage = forall a. Message a => SomeMessage a
+
+-- |
+-- And now, unwrap a given, unknown 'Message' type, performing a (dynamic)
+-- type check on the result.
+--
+fromMessage :: Message m => SomeMessage -> Maybe m
+fromMessage (SomeMessage m) = cast m
+
+-- X Events are valid Messages.
+instance Message Event
+
+-- | 'LayoutMessages' are core messages that all layouts (especially stateful
+-- layouts) should consider handling.
+data LayoutMessages = Hide              -- ^ sent when a layout becomes non-visible
+                    | ReleaseResources  -- ^ sent when xmonad is exiting or restarting
+    deriving (Typeable, Eq)
+
+instance Message LayoutMessages
+
+-- ---------------------------------------------------------------------
+-- Extensible state
+--
+
+-- | Every module must make the data it wants to store
+-- an instance of this class.
+--
+-- Minimal complete definition: initialValue
+class Typeable a => ExtensionClass a where
+    -- | Defines an initial value for the state extension
+    initialValue :: a
+    -- | Specifies whether the state extension should be
+    -- persistent. Setting this method to 'PersistentExtension'
+    -- will make the stored data survive restarts, but
+    -- requires a to be an instance of Read and Show.
+    --
+    -- It defaults to 'StateExtension', i.e. no persistence.
+    extensionType :: a -> StateExtension
+    extensionType = StateExtension
+
+-- | Existential type to store a state extension.
+data StateExtension =
+    forall a. ExtensionClass a => StateExtension a
+    -- ^ Non-persistent state extension
+  | forall a. (Read a, Show a, ExtensionClass a) => PersistentExtension a
+    -- ^ Persistent extension
+
+-- ---------------------------------------------------------------------
+-- | General utilities
+--
+-- Lift an 'IO' action into the 'X' monad
+io :: MonadIO m => IO a -> m a
+io = liftIO
+
+-- | Lift an 'IO' action into the 'X' monad.  If the action results in an 'IO'
+-- exception, log the exception to stderr and continue normal execution.
+catchIO :: MonadIO m => IO () -> m ()
+catchIO f = io (f `E.catch` \(SomeException e) -> hPrint stderr e >> hFlush stderr)
+
+-- | spawn. Launch an external application. Specifically, it double-forks and
+-- runs the 'String' you pass as a command to \/bin\/sh.
+--
+-- Note this function assumes your locale uses utf8.
+spawn :: MonadIO m => String -> m ()
+spawn x = spawnPID x >> return ()
+
+-- | Like 'spawn', but returns the 'ProcessID' of the launched application
+spawnPID :: MonadIO m => String -> m ProcessID
+spawnPID x = xfork $ executeFile "/bin/sh" False ["-c", x] Nothing
+
+-- | A replacement for 'forkProcess' which resets default signal handlers.
+xfork :: MonadIO m => IO () -> m ProcessID
+xfork x = io . forkProcess . finally nullStdin $ do
+                uninstallSignalHandlers
+                createSession
+                x
+ where
+    nullStdin = do
+        fd <- openFd "/dev/null" ReadOnly Nothing defaultFileFlags
+        dupTo fd stdInput
+        closeFd fd
+
+-- | This is basically a map function, running a function in the 'X' monad on
+-- each workspace with the output of that function being the modified workspace.
+runOnWorkspaces :: (WindowSpace -> X WindowSpace) -> X ()
+runOnWorkspaces job = do
+    ws <- gets windowset
+    h <- mapM job $ hidden ws
+    c:v <- mapM (\s -> (\w -> s { workspace = w}) <$> job (workspace s))
+             $ current ws : visible ws
+    modify $ \s -> s { windowset = ws { current = c, visible = v, hidden = h } }
+
+-- | Return the path to the xmonad configuration directory.  This
+-- directory is where user configuration files are stored (e.g, the
+-- xmonad.hs file).  You may also create a @lib@ subdirectory in the
+-- configuration directory and the default recompile command will add
+-- it to the GHC include path.
+--
+-- Several directories are considered.  In order of
+-- preference:
+--
+--   1. The directory specified in the @XMONAD_CONFIG_DIR@ environment variable.
+--   2. The @~\/.xmonad@ directory.
+--   3. The @XDG_CONFIG_HOME/xmonad@ directory.
+--
+-- The first directory that exists will be used.  If none of the
+-- directories exist then (1) will be used if it is set, otherwise (2)
+-- will be used.  Either way, a directory will be created if necessary.
+getXMonadDir :: MonadIO m => m String
+getXMonadDir =
+    findFirstDirWithEnv "XMONAD_CONFIG_DIR"
+      [ getAppUserDataDirectory "xmonad"
+      , getXdgDirectory XdgConfig "xmonad"
+      ]
+
+-- | Return the path to the xmonad cache directory.  This directory is
+-- used to store temporary files that can easily be recreated.  For
+-- example, the XPrompt history file.
+--
+-- Several directories are considered.  In order of preference:
+--
+--   1. The directory specified in the @XMONAD_CACHE_DIR@ environment variable.
+--   2. The @~\/.xmonad@ directory.
+--   3. The @XDG_CACHE_HOME/xmonad@ directory.
+--
+-- The first directory that exists will be used.  If none of the
+-- directories exist then (1) will be used if it is set, otherwise (2)
+-- will be used.  Either way, a directory will be created if necessary.
+getXMonadCacheDir :: MonadIO m => m String
+getXMonadCacheDir =
+    findFirstDirWithEnv "XMONAD_CACHE_DIR"
+      [ getAppUserDataDirectory "xmonad"
+      , getXdgDirectory XdgCache "xmonad"
+      ]
+
+-- | Return the path to the xmonad data directory.  This directory is
+-- used by XMonad to store data files such as the run-time state file
+-- and the configuration binary generated by GHC.
+--
+-- Several directories are considered.  In order of preference:
+--
+--   1. The directory specified in the @XMONAD_DATA_DIR@ environment variable.
+--   2. The @~\/.xmonad@ directory.
+--   3. The @XDG_DATA_HOME/xmonad@ directory.
+--
+-- The first directory that exists will be used.  If none of the
+-- directories exist then (1) will be used if it is set, otherwise (2)
+-- will be used.  Either way, a directory will be created if necessary.
+getXMonadDataDir :: MonadIO m => m String
+getXMonadDataDir =
+    findFirstDirWithEnv "XMONAD_DATA_DIR"
+      [ getAppUserDataDirectory "xmonad"
+      , getXdgDirectory XdgData "xmonad"
+      ]
+
+-- | Helper function that will find the first existing directory and
+-- return its path.  If none of the directories can be found, create
+-- and return the first from the list.  If the list is empty this
+-- function returns the historical @~\/.xmonad@ directory.
+findFirstDirOf :: MonadIO m => [IO FilePath] -> m FilePath
+findFirstDirOf []        = findFirstDirOf [getAppUserDataDirectory "xmonad"]
+findFirstDirOf possibles = do
+    found <- go possibles
+
+    case found of
+      Just path -> return path
+      Nothing   -> do
+        primary <- io (head possibles)
+        io (createDirectoryIfMissing True primary)
+        return primary
+
+  where
+    go []     = return Nothing
+    go (x:xs) = do
+      dir    <- io x
+      exists <- io (doesDirectoryExist dir)
+      if exists then return (Just dir) else go xs
+
+-- | Simple wrapper around @findFirstDirOf@ that allows the primary
+-- path to be specified by an environment variable.
+findFirstDirWithEnv :: MonadIO m => String -> [IO FilePath] -> m FilePath
+findFirstDirWithEnv envName paths = do
+    envPath' <- io (getEnv envName)
+
+    case envPath' of
+      Nothing      -> findFirstDirOf paths
+      Just envPath -> findFirstDirOf (return envPath:paths)
+
+
+-- | Get the name of the file used to store the xmonad window state.
+stateFileName :: (Functor m, MonadIO m) => m FilePath
+stateFileName = (</> "xmonad.state") <$> getXMonadDataDir
+
+-- | 'recompile force', recompile the xmonad configuration file when
+-- any of the following apply:
+--
+--      * force is 'True'
+--
+--      * the xmonad executable does not exist
+--
+--      * the xmonad executable is older than xmonad.hs or any file in
+--        the @lib@ directory (under the configuration directory).
+--
+-- The -i flag is used to restrict recompilation to the xmonad.hs file only,
+-- and any files in the aforementioned @lib@ directory.
+--
+-- Compilation errors (if any) are logged to the @xmonad.errors@ file
+-- in the xmonad data directory.  If GHC indicates failure with a
+-- non-zero exit code, an xmessage displaying that file is spawned.
+--
+-- 'False' is returned if there are compilation errors.
+--
+recompile :: MonadIO m => Bool -> m Bool
+recompile force = io $ do
+    cfgdir  <- getXMonadDir
+    datadir <- getXMonadDataDir
+    let binn = "xmonad-"++arch++"-"++os
+        bin  = datadir </> binn
+        err  = datadir </> "xmonad.errors"
+        src  = cfgdir </> "xmonad.hs"
+        lib  = cfgdir </> "lib"
+        buildscript = cfgdir </> "build"
+
+    libTs <- mapM getModTime . Prelude.filter isSource =<< allFiles lib
+    srcT <- getModTime src
+    binT <- getModTime bin
+
+    useBuildscript <- do
+      exists <- doesFileExist buildscript
+      if exists then isExecutable buildscript else return False
+
+    if force || useBuildscript || any (binT <) (srcT : libTs)
+      then do
+        -- temporarily disable SIGCHLD ignoring:
+        uninstallSignalHandlers
+        status <- bracket (openFile err WriteMode) hClose $ \errHandle ->
+            waitForProcess =<< if useBuildscript
+                               then compileScript bin cfgdir buildscript errHandle
+                               else compileGHC bin cfgdir errHandle
+
+        -- re-enable SIGCHLD:
+        installSignalHandlers
+
+        -- now, if it fails, run xmessage to let the user know:
+        when (status /= ExitSuccess) $ do
+            ghcErr <- readFile err
+            let msg = unlines $
+                    ["Error detected while loading xmonad configuration file: " ++ src]
+                    ++ lines (if null ghcErr then show status else ghcErr)
+                    ++ ["","Please check the file for errors."]
+            -- nb, the ordering of printing, then forking, is crucial due to
+            -- lazy evaluation
+            hPutStrLn stderr msg
+            forkProcess $ executeFile "xmessage" True ["-default", "okay", replaceUnicode msg] Nothing
+            return ()
+        return (status == ExitSuccess)
+      else return True
+ where getModTime f = E.catch (Just <$> getModificationTime f) (\(SomeException _) -> return Nothing)
+       isSource = flip elem [".hs",".lhs",".hsc"] . takeExtension
+       isExecutable f = E.catch (executable <$> getPermissions f) (\(SomeException _) -> return False)
+       allFiles t = do
+            let prep = map (t</>) . Prelude.filter (`notElem` [".",".."])
+            cs <- prep <$> E.catch (getDirectoryContents t) (\(SomeException _) -> return [])
+            ds <- filterM doesDirectoryExist cs
+            concat . ((cs \\ ds):) <$> mapM allFiles ds
+       -- Replace some of the unicode symbols GHC uses in its output
+       replaceUnicode = map $ \c -> case c of
+           '\8226' -> '*'  -- •
+           '\8216' -> '`'  -- ‘
+           '\8217' -> '`'  -- ’
+           _ -> c
+       compileGHC bin dir errHandle =
+         runProcess "ghc" ["--make"
+                          , "xmonad.hs"
+                          , "-i"
+                          , "-ilib"
+                          , "-fforce-recomp"
+                          , "-main-is", "main"
+                          , "-v0"
+                          , "-o", bin
+                          ] (Just dir) Nothing Nothing Nothing (Just errHandle)
+       compileScript bin dir script errHandle =
+         runProcess script [bin] (Just dir) Nothing Nothing Nothing (Just errHandle)
+
+-- | Conditionally run an action, using a @Maybe a@ to decide.
+whenJust :: Monad m => Maybe a -> (a -> m ()) -> m ()
+whenJust mg f = maybe (return ()) f mg
+
+-- | Conditionally run an action, using a 'X' event to decide
+whenX :: X Bool -> X () -> X ()
+whenX a f = a >>= \b -> when b f
+
+-- | A 'trace' for the 'X' monad. Logs a string to stderr. The result may
+-- be found in your .xsession-errors file
+trace :: MonadIO m => String -> m ()
+trace = io . hPutStrLn stderr
+
+-- | Ignore SIGPIPE to avoid termination when a pipe is full, and SIGCHLD to
+-- avoid zombie processes, and clean up any extant zombie processes.
+installSignalHandlers :: MonadIO m => m ()
+installSignalHandlers = io $ do
+    installHandler openEndedPipe Ignore Nothing
+    installHandler sigCHLD Ignore Nothing
+    (try :: IO a -> IO (Either SomeException a))
+      $ fix $ \more -> do
+        x <- getAnyProcessStatus False False
+        when (isJust x) more
+    return ()
+
+uninstallSignalHandlers :: MonadIO m => m ()
+uninstallSignalHandlers = io $ do
+    installHandler openEndedPipe Default Nothing
+    installHandler sigCHLD Default Nothing
+    return ()

--- a/testdata/issue20/README.md
+++ b/testdata/issue20/README.md
@@ -1,0 +1,197 @@
+![](https://stumpwm.github.io/images/stumpwm-logo-stripe.png)
+# The Stump Window Manager
+![](https://travis-ci.org/stumpwm/stumpwm.svg)
+
+Stumpwm is a window manager written entirely in Common Lisp. It
+attempts to be highly customizable while relying entirely on the
+keyboard for input. You will not find buttons, icons, title bars, tool
+bars, or any of the other conventional GUI widgets.
+
+These design decisions reflect the growing popularity of productive,
+customizable lisp based systems.
+
+## Philosophy 
+
+Stumpwm is a "everything-and-the-kitchen-sink WM" or "the emacs of
+WMs."
+
+**StumpWM:Windows::Emacs:Text**
+
+* StumpWM is
+  * Hackable
+  * A tileable window manager
+  * Includes support for floats
+  * Written in Common Lisp
+  * Compatible with many lisp distributions
+  * A Superior window managing experience 
+* StumpWM is *not*
+  * Minimalist
+  * Narrow Scope
+  * Configured by editing the source directly
+  * A full blown desktop environment
+
+If you want a minimalist tiling window manager, then StumpWM is *not*
+what you're looking for.  The code base is ~15k sloc, the binaries
+produced are ~60mb.
+
+StumpWM manages windows the way emacs manages buffers, or the way
+screen manages terminals. If you want a flexible, customizable,
+hackable desktop experience, look no further.
+
+# Build & Start Stumpwm
+
+## Prerequisites
+
+* sbcl
+* quicklisp (for obtaining the following dependencies, not needed if you use your distribution's package manager.)
+* clx
+* cl-ppcre
+* alexandria
+
+The recommended way to install the dependencies is using Quicklisp.
+Follow the instructions at http://www.quicklisp.org/ to install it.
+In short: 
+
+```
+$ curl -O https://beta.quicklisp.org/quicklisp.lisp
+$ sbcl --load quicklisp.lisp
+```
+
+Then at the REPL:
+
+```lisp
+(quicklisp-quickstart:install)
+```
+
+Make sure you have added it to your lisp init file using:
+
+```lisp
+ (ql:add-to-init-file)
+```
+
+Then, in a repl:
+
+```lisp
+ (ql:quickload "clx")
+ (ql:quickload "cl-ppcre")
+ (ql:quickload "alexandria")
+```
+## Building
+
+Building stumpwm from git requires that you build the configure script:
+
+```
+ autoconf
+```
+
+If there's already a configure script then just run it.
+
+```
+ ./configure
+```
+
+Now build it:
+
+```
+ make
+```
+
+If all goes well, you should have a stumpwm binary now.  You can run
+the binary from where it is or install it, along with the .info
+documentation, with:
+
+```
+ make install
+```
+
+Now that you have a binary, call it from your ~/.xinitrc file:
+
+```
+ echo /path/to/stumpwm >> ~/.xinitrc
+ startx
+```
+
+Hopefully that will put you in X running stumpwm! See [StartUp on the
+wiki](https://github.com/sabetts/stumpwm/wiki/StartUp) for more
+examples.
+
+# Contributing
+
+Pull requests are always welcome! Here are some guidelines to ensure
+that your contribution gets merged in a timely manner: 
+* Do's 
+  * Add your name to the list of AUTHORS with your pull request.  
+  * Preserve comments or docstrings explaining what code does, and
+    update them if your patch changes them in a significant way
+  * Try to follow an "80 column rule." The current code base does not
+    follow this all the time, so don't use it as an example
+  * [Use lisp idioms](http://people.ace.ed.ac.uk/staff/medward2/class/moz/cm/doc/contrib/lispstyle.html)
+  * If you are working on a major change to the internals, keep us
+    informed on stumpwm-devel! Also, it will probably help if the
+    changes are made and then incrementally applied to the codebase in
+    order to avoid introducing show-stopping bugs.
+* Do not's
+  * Include emacs local variables 
+  * Change whitespace 
+  * Write lots of code without supporting comments/documentation
+  * Delete comments or docstrings (yes this is a duplicate of above!)
+  * Export symbols from packages that aren't widely useful (many times
+    a little more thought will reveal how to implement your internal
+    change without having to export/break encapsulation)
+  * Make stylistic changes that suit your coding style/way of thinking 
+
+Our wiki has fallen into disarray/disrepair, but it is shaping up.  If
+you aren't a lisp hacker, you can contribute in the form of
+documenting and organizing the wiki. There's a lot of information
+floating around, if you find it where you didn't expect it, move or
+link to it in a more logical place.
+
+# Wishlist 
+
+Fancy yourself a lisp hacker? Here's a wishlist of features for the
+StumpWM universe (in no particular order):
+* float-splits (ie allow floating windows over tiled ones)
+* Float windows within parent applications (specifically dialogs in
+  gimp or firefox).
+* tab-list showing the contents of the current frame at the side, top,
+  or bottom of the frame
+* Emacs' iswitchb function implemented in emacs
+  * Re-arranging windows between groups
+  * Killing windows
+  * Marking windows for batch operations
+  * Deleting/adding groups
+  * Import data from stumpwm to emacs, use an emacs minor mode to
+    implement the above features, then export the data back to stumpwm
+    and let stumpwm perform the appropriate actions 
+* Emacs' completing-read-multiple function
+* Dynamic tiling
+* Lock Screen (with support for leaving notes, bonus points if emacs
+  is involved)
+* Wallpapers! (support pulling from remote sources, changing based on
+  timers, and other hacky features)
+* Shutdown, restart, suspend, and hibernate functions that don't
+  require root access
+* Revamped, mouse-friendly mode-line. 
+  * Support fixed number of chars for window titles
+  * Dynamically trim window titles to fit them all on the mode-line
+  * Split the mode-line into multiple cells for containing different information
+  * Implement widget icons to indicate system status (new mail, low
+    battery, network etc)
+  * Support raising windows when left-clicked, closing/killing when right-clicked  
+
+# Help
+
+There's a texinfo manual, stumpwm.texi.  The build scripts generate an
+info file you can read in emacs or with the `info' program.  The
+manual for the latest git version (may be slightly out of date) is
+available to read online at: [The Manual](https://stumpwm.github.io/)
+
+And, as in emacs, you can always do "C-t h v,f,k,c,w" for docstrings
+of Variable,Functions,Keys,Commands, and Where-is respectively.
+
+For other stuff (tips tricks and examples) visit the [stumpwm wiki](https://github.com/stumpwm/stumpwm/wiki)
+
+There's a #stumpwm channel on irc.freenode.net, too.
+
+Finally, there's our mailing list (click to sign up)
+[stumpwm-devel@nongnu.org](https://lists.nongnu.org/mailman/listinfo/stumpwm-devel).

--- a/testdata/issue20/audit.rb
+++ b/testdata/issue20/audit.rb
@@ -1,0 +1,1541 @@
+#:  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [`--only=`<method>|`--except=`<method>] [`--only-cops=`[COP1,COP2..]|`--except-cops=`[COP1,COP2..]] [<formulae>]:
+#:    Check <formulae> for Homebrew coding style violations. This should be
+#:    run before submitting a new formula.
+#:
+#:    If no <formulae> are provided, all of them are checked.
+#:
+#:    If `--strict` is passed, additional checks are run, including RuboCop
+#:    style checks.
+#:
+#:    If `--fix` is passed, style violations will be
+#:    automatically fixed using RuboCop's `--auto-correct` feature.
+#:
+#:    If `--online` is passed, additional slower checks that require a network
+#:    connection are run.
+#:
+#:    If `--new-formula` is passed, various additional checks are run that check
+#:    if a new formula is eligible for Homebrew. This should be used when creating
+#:    new formulae and implies `--strict` and `--online`.
+#:
+#:    If `--display-cop-names` is passed, the RuboCop cop name for each violation
+#:    is included in the output.
+#:
+#:    If `--display-filename` is passed, every line of output is prefixed with the
+#:    name of the file or formula being audited, to make the output easy to grep.
+#:
+#:    If `--only` is passed, only the methods named `audit_<method>` will be run.
+#:
+#:    If `--except` is passed, the methods named `audit_<method>` will not be run.
+#:
+#:    If `--only-cops` is passed, only the given Rubocop cop(s)' violations would be checked.
+#:
+#:    If `--except-cops` is passed, the given Rubocop cop(s)' checks would be skipped.
+#:
+#:    `audit` exits with a non-zero status if any errors are found. This is useful,
+#:    for instance, for implementing pre-commit hooks.
+
+# Undocumented options:
+#     -D activates debugging and profiling of the audit methods (not the same as --debug)
+
+require "formula"
+require "formula_versions"
+require "utils"
+require "extend/ENV"
+require "formula_cellar_checks"
+require "official_taps"
+require "cmd/search"
+require "cmd/style"
+require "date"
+require "missing_formula"
+require "digest"
+
+module Homebrew
+  module_function
+
+  def audit
+    Homebrew.inject_dump_stats!(FormulaAuditor, /^audit_/) if ARGV.switch? "D"
+
+    formula_count = 0
+    problem_count = 0
+
+    new_formula = ARGV.include? "--new-formula"
+    strict = new_formula || ARGV.include?("--strict")
+    online = new_formula || ARGV.include?("--online")
+
+    ENV.activate_extensions!
+    ENV.setup_build_environment
+
+    if ARGV.named.empty?
+      ff = Formula
+      files = Tap.map(&:formula_dir)
+    else
+      ff = ARGV.resolved_formulae
+      files = ARGV.resolved_formulae.map(&:path)
+    end
+
+    only_cops = ARGV.value("only-cops").to_s.split(",")
+    except_cops = ARGV.value("except-cops").to_s.split(",")
+    if !only_cops.empty? && !except_cops.empty?
+      odie "--only-cops and --except-cops cannot be used simultaneously!"
+    elsif (!only_cops.empty? || !except_cops.empty?) && strict
+      odie "--only-cops/--except-cops and --strict cannot be used simultaneously"
+    end
+
+    options = { fix: ARGV.flag?("--fix"), realpath: true }
+
+    if !only_cops.empty?
+      options[:only_cops] = only_cops
+    elsif !except_cops.empty?
+      options[:except_cops] = except_cops
+    elsif !strict
+      options[:except_cops] = [:FormulaAuditStrict]
+    end
+
+    # Check style in a single batch run up front for performance
+    style_results = check_style_json(files, options)
+
+    ff.each do |f|
+      options = { new_formula: new_formula, strict: strict, online: online }
+      options[:style_offenses] = style_results.file_offenses(f.path)
+      fa = FormulaAuditor.new(f, options)
+      fa.audit
+
+      next if fa.problems.empty?
+      fa.problems
+      formula_count += 1
+      problem_count += fa.problems.size
+      problem_lines = fa.problems.map { |p| "* #{p.chomp.gsub("\n", "\n    ")}" }
+      if ARGV.include? "--display-filename"
+        puts problem_lines.map { |s| "#{f.path}: #{s}" }
+      else
+        puts "#{f.full_name}:", problem_lines.map { |s| "  #{s}" }
+      end
+    end
+
+    return if problem_count.zero?
+
+    ofail "#{Formatter.pluralize(problem_count, "problem")} in #{Formatter.pluralize(formula_count, "formula")}"
+  end
+end
+
+class FormulaText
+  def initialize(path)
+    @text = path.open("rb", &:read)
+    @lines = @text.lines.to_a
+  end
+
+  def without_patch
+    @text.split("\n__END__").first
+  end
+
+  def data?
+    /^[^#]*\bDATA\b/ =~ @text
+  end
+
+  def end?
+    /^__END__$/ =~ @text
+  end
+
+  def trailing_newline?
+    /\Z\n/ =~ @text
+  end
+
+  def =~(other)
+    other =~ @text
+  end
+
+  def include?(s)
+    @text.include? s
+  end
+
+  def line_number(regex, skip = 0)
+    index = @lines.drop(skip).index { |line| line =~ regex }
+    index ? index + 1 : nil
+  end
+
+  def reverse_line_number(regex)
+    index = @lines.reverse.index { |line| line =~ regex }
+    index ? @lines.count - index : nil
+  end
+end
+
+class FormulaAuditor
+  include FormulaCellarChecks
+
+  attr_reader :formula, :text, :problems
+
+  BUILD_TIME_DEPS = %w[
+    autoconf
+    automake
+    boost-build
+    bsdmake
+    cmake
+    godep
+    imake
+    intltool
+    libtool
+    pkg-config
+    scons
+    smake
+    sphinx-doc
+    swig
+  ].freeze
+
+  FILEUTILS_METHODS = FileUtils.singleton_methods(false).map { |m| Regexp.escape(m) }.join "|"
+
+  def initialize(formula, options = {})
+    @formula = formula
+    @new_formula = options[:new_formula]
+    @strict = options[:strict]
+    @online = options[:online]
+    # Accept precomputed style offense results, for efficiency
+    @style_offenses = options[:style_offenses]
+    @problems = []
+    @text = FormulaText.new(formula.path)
+    @specs = %w[stable devel head].map { |s| formula.send(s) }.compact
+  end
+
+  def self.check_http_content(url, name, user_agents: [:default])
+    return unless url.start_with? "http"
+
+    details = nil
+    user_agent = nil
+    hash_needed = url.start_with?("http:") && name != "curl"
+    user_agents.each do |ua|
+      details = http_content_headers_and_checksum(url, hash_needed: hash_needed, user_agent: ua)
+      user_agent = ua
+      break if details[:status].to_s.start_with?("2")
+    end
+
+    return "The URL #{url} is not reachable" unless details[:status]
+    unless details[:status].start_with? "2"
+      return "The URL #{url} is not reachable (HTTP status code #{details[:status]})"
+    end
+
+    return unless hash_needed
+
+    secure_url = url.sub "http", "https"
+    secure_details =
+      http_content_headers_and_checksum(secure_url, hash_needed: true, user_agent: user_agent)
+
+    if !details[:status].to_s.start_with?("2") ||
+       !secure_details[:status].to_s.start_with?("2")
+      return
+    end
+
+    etag_match = details[:etag] &&
+                 details[:etag] == secure_details[:etag]
+    content_length_match =
+      details[:content_length] &&
+      details[:content_length] == secure_details[:content_length]
+    file_match = details[:file_hash] == secure_details[:file_hash]
+
+    return if !etag_match && !content_length_match && !file_match
+    "The URL #{url} could use HTTPS rather than HTTP"
+  end
+
+  def self.http_content_headers_and_checksum(url, hash_needed: false, user_agent: :default)
+    max_time = hash_needed ? "600" : "25"
+    args = curl_args(
+      extra_args: ["--connect-timeout", "15", "--include", "--max-time", max_time, url],
+      show_output: true,
+      user_agent: user_agent,
+    )
+    output = Open3.popen3(*args) { |_, stdout, _, _| stdout.read }
+
+    status_code = :unknown
+    while status_code == :unknown || status_code.to_s.start_with?("3")
+      headers, _, output = output.partition("\r\n\r\n")
+      status_code = headers[%r{HTTP\/.* (\d+)}, 1]
+    end
+
+    output_hash = Digest::SHA256.digest(output) if hash_needed
+
+    {
+      status: status_code,
+      etag: headers[%r{ETag: ([wW]\/)?"(([^"]|\\")*)"}, 2],
+      content_length: headers[/Content-Length: (\d+)/, 1],
+      file_hash: output_hash,
+    }
+  end
+
+  def audit_style
+    return unless @style_offenses
+    display_cop_names = ARGV.include?("--display-cop-names")
+    @style_offenses.each do |offense|
+      problem offense.to_s(display_cop_name: display_cop_names)
+    end
+  end
+
+  def audit_file
+    # Under normal circumstances (umask 0022), we expect a file mode of 644. If
+    # the user's umask is more restrictive, respect that by masking out the
+    # corresponding bits. (The also included 0100000 flag means regular file.)
+    wanted_mode = 0100644 & ~File.umask
+    actual_mode = formula.path.stat.mode
+    unless actual_mode == wanted_mode
+      problem format("Incorrect file permissions (%03o): chmod %03o %s",
+                     actual_mode & 0777, wanted_mode & 0777, formula.path)
+    end
+
+    problem "'DATA' was found, but no '__END__'" if text.data? && !text.end?
+
+    if text.end? && !text.data?
+      problem "'__END__' was found, but 'DATA' is not used"
+    end
+
+    if text =~ /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m
+      problem "'inreplace ... do' was used for a single substitution (use the non-block form instead)."
+    end
+
+    problem "File should end with a newline" unless text.trailing_newline?
+
+    if formula.versioned_formula?
+      unversioned_formula = begin
+        # build this ourselves as we want e.g. homebrew/core to be present
+        full_name = if formula.tap
+          "#{formula.tap}/#{formula.name}"
+        else
+          formula.name
+        end
+        Formulary.factory(full_name.gsub(/@.*$/, "")).path
+      rescue FormulaUnavailableError, TapFormulaAmbiguityError,
+             TapFormulaWithOldnameAmbiguityError
+        Pathname.new formula.path.to_s.gsub(/@.*\.rb$/, ".rb")
+      end
+      unless unversioned_formula.exist?
+        unversioned_name = unversioned_formula.basename(".rb")
+        problem "#{formula} is versioned but no #{unversioned_name} formula exists"
+      end
+    elsif ARGV.build_stable? &&
+          !(versioned_formulae = Dir[formula.path.to_s.gsub(/\.rb$/, "@*.rb")]).empty?
+      versioned_aliases = formula.aliases.grep(/.@\d/)
+      _, last_alias_version =
+        File.basename(versioned_formulae.sort.reverse.first)
+            .gsub(/\.rb$/, "").split("@")
+      major, minor, = formula.version.to_s.split(".")
+      alias_name_major = "#{formula.name}@#{major}"
+      alias_name_major_minor = "#{alias_name_major}.#{minor}"
+      alias_name = if last_alias_version.split(".").length == 1
+        alias_name_major
+      else
+        alias_name_major_minor
+      end
+      valid_alias_names = [alias_name_major, alias_name_major_minor]
+
+      if formula.tap && !formula.tap.core_tap?
+        valid_alias_names.map! { |a| "#{formula.tap}/#{a}" }
+      end
+
+      valid_versioned_aliases = versioned_aliases & valid_alias_names
+      invalid_versioned_aliases = versioned_aliases - valid_alias_names
+
+      if valid_versioned_aliases.empty?
+        if formula.tap
+          problem <<-EOS.undent
+            Formula has other versions so create a versioned alias:
+              cd #{formula.tap.alias_dir}
+              ln -s #{formula.path.to_s.gsub(formula.tap.path, "..")} #{alias_name}
+          EOS
+        else
+          problem "Formula has other versions so create an alias named #{alias_name}."
+        end
+      end
+
+      unless invalid_versioned_aliases.empty?
+        problem <<-EOS.undent
+          Formula has invalid versioned aliases:
+            #{invalid_versioned_aliases.join("\n  ")}
+        EOS
+      end
+    end
+  end
+
+  def audit_class
+    if @strict
+      unless formula.test_defined?
+        problem "A `test do` test block should be added"
+      end
+    end
+
+    classes = %w[GithubGistFormula ScriptFileFormula AmazonWebServicesFormula]
+    klass = classes.find do |c|
+      Object.const_defined?(c) && formula.class < Object.const_get(c)
+    end
+
+    problem "#{klass} is deprecated, use Formula instead" if klass
+  end
+
+  # core aliases + tap alias names + tap alias full name
+  @@aliases ||= Formula.aliases + Formula.tap_aliases
+
+  def audit_formula_name
+    return unless @strict
+    # skip for non-official taps
+    return if formula.tap.nil? || !formula.tap.official?
+
+    name = formula.name
+    full_name = formula.full_name
+
+    if Homebrew::MissingFormula.blacklisted_reason(name)
+      problem "'#{name}' is blacklisted."
+    end
+
+    if Formula.aliases.include? name
+      problem "Formula name conflicts with existing aliases."
+      return
+    end
+
+    if oldname = CoreTap.instance.formula_renames[name]
+      problem "'#{name}' is reserved as the old name of #{oldname}"
+      return
+    end
+
+    if !formula.core_formula? && Formula.core_names.include?(name)
+      problem "Formula name conflicts with existing core formula."
+      return
+    end
+
+    @@local_official_taps_name_map ||= Tap.select(&:official?).flat_map(&:formula_names)
+                                          .each_with_object({}) do |tap_formula_full_name, name_map|
+      tap_formula_name = tap_formula_full_name.split("/").last
+      name_map[tap_formula_name] ||= []
+      name_map[tap_formula_name] << tap_formula_full_name
+      name_map
+    end
+
+    same_name_tap_formulae = @@local_official_taps_name_map[name] || []
+
+    if @online
+      Homebrew.search_taps(name).each do |tap_formula_full_name|
+        tap_formula_name = tap_formula_full_name.split("/").last
+        next if tap_formula_name != name
+        same_name_tap_formulae << tap_formula_full_name
+      end
+    end
+
+    same_name_tap_formulae.delete(full_name)
+
+    return if same_name_tap_formulae.empty?
+    problem "Formula name conflicts with #{same_name_tap_formulae.join ", "}"
+  end
+
+  def audit_deps
+    @specs.each do |spec|
+      # Check for things we don't like to depend on.
+      # We allow non-Homebrew installs whenever possible.
+      spec.deps.each do |dep|
+        begin
+          dep_f = dep.to_formula
+        rescue TapFormulaUnavailableError
+          # Don't complain about missing cross-tap dependencies
+          next
+        rescue FormulaUnavailableError
+          problem "Can't find dependency #{dep.name.inspect}."
+          next
+        rescue TapFormulaAmbiguityError
+          problem "Ambiguous dependency #{dep.name.inspect}."
+          next
+        rescue TapFormulaWithOldnameAmbiguityError
+          problem "Ambiguous oldname dependency #{dep.name.inspect}."
+          next
+        end
+
+        if dep_f.oldname && dep.name.split("/").last == dep_f.oldname
+          problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
+        end
+
+        if @@aliases.include?(dep.name) &&
+           (dep_f.core_formula? || !dep_f.versioned_formula?)
+          problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
+        end
+
+        if @new_formula && dep_f.keg_only_reason &&
+           !["openssl", "apr", "apr-util"].include?(dep.name) &&
+           [:provided_by_macos, :provided_by_osx].include?(dep_f.keg_only_reason.reason)
+          problem "Dependency '#{dep.name}' may be unnecessary as it is provided by macOS; try to build this formula without it."
+        end
+
+        dep.options.reject do |opt|
+          next true if dep_f.option_defined?(opt)
+          dep_f.requirements.detect do |r|
+            if r.recommended?
+              opt.name == "with-#{r.name}"
+            elsif r.optional?
+              opt.name == "without-#{r.name}"
+            end
+          end
+        end.each do |opt|
+          problem "Dependency #{dep} does not define option #{opt.name.inspect}"
+        end
+
+        case dep.name
+        when "git"
+          problem "Don't use git as a dependency"
+        when "mercurial"
+          problem "Use `depends_on :hg` instead of `depends_on 'mercurial'`"
+        when "gfortran"
+          problem "Use `depends_on :fortran` instead of `depends_on 'gfortran'`"
+        when "ruby"
+          problem <<-EOS.undent
+            Don't use "ruby" as a dependency. If this formula requires a
+            minimum Ruby version not provided by the system you should
+            use the RubyRequirement:
+              depends_on :ruby => "1.8"
+            where "1.8" is the minimum version of Ruby required.
+          EOS
+        when "open-mpi", "mpich"
+          problem <<-EOS.undent
+            There are multiple conflicting ways to install MPI. Use an MPIRequirement:
+              depends_on :mpi => [<lang list>]
+            Where <lang list> is a comma delimited list that can include:
+              :cc, :cxx, :f77, :f90
+            EOS
+        when *BUILD_TIME_DEPS
+          next if dep.build? || dep.run?
+          problem <<-EOS.undent
+            #{dep} dependency should be
+              depends_on "#{dep}" => :build
+            Or if it is indeed a runtime dependency
+              depends_on "#{dep}" => :run
+          EOS
+        end
+      end
+    end
+  end
+
+  def audit_conflicts
+    formula.conflicts.each do |c|
+      begin
+        Formulary.factory(c.name)
+      rescue TapFormulaUnavailableError
+        # Don't complain about missing cross-tap conflicts.
+        next
+      rescue FormulaUnavailableError
+        problem "Can't find conflicting formula #{c.name.inspect}."
+      rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
+        problem "Ambiguous conflicting formula #{c.name.inspect}."
+      end
+    end
+
+    versioned_conflicts_whitelist = %w[node@ bash-completion@].freeze
+
+    return unless formula.conflicts.any? && formula.versioned_formula?
+    return if formula.name.start_with?(*versioned_conflicts_whitelist)
+    problem <<-EOS
+      Versioned formulae should not use `conflicts_with`.
+      Use `keg_only :versioned_formula` instead.
+    EOS
+  end
+
+  def audit_keg_only_style
+    return unless @strict
+    return unless formula.keg_only?
+
+    whitelist = %w[
+      Apple
+      macOS
+      OS
+      Homebrew
+      Xcode
+      GPG
+      GNOME
+      BSD
+      Firefox
+    ].freeze
+
+    reason = formula.keg_only_reason.to_s
+    # Formulae names can legitimately be uppercase/lowercase/both.
+    name = Regexp.new(formula.name, Regexp::IGNORECASE)
+    reason.sub!(name, "")
+    first_word = reason.split[0]
+
+    if reason =~ /\A[A-Z]/ && !reason.start_with?(*whitelist)
+      problem <<-EOS.undent
+        '#{first_word}' from the keg_only reason should be '#{first_word.downcase}'.
+      EOS
+    end
+
+    return unless reason.end_with?(".")
+    problem "keg_only reason should not end with a period."
+  end
+
+  def audit_options
+    formula.options.each do |o|
+      if o.name == "32-bit"
+        problem "macOS has been 64-bit only since 10.6 so 32-bit options are deprecated."
+      end
+
+      next unless @strict
+
+      if o.name == "universal"
+        problem "macOS has been 64-bit only since 10.6 so universal options are deprecated."
+      end
+
+      if o.name !~ /with(out)?-/ && o.name != "c++11" && o.name != "universal"
+        problem "Options should begin with with/without. Migrate '--#{o.name}' with `deprecated_option`."
+      end
+
+      next unless o.name =~ /^with(out)?-(?:checks?|tests)$/
+      unless formula.deps.any? { |d| d.name == "check" && (d.optional? || d.recommended?) }
+        problem "Use '--with#{Regexp.last_match(1)}-test' instead of '--#{o.name}'. Migrate '--#{o.name}' with `deprecated_option`."
+      end
+    end
+
+    return unless @new_formula
+    return if formula.deprecated_options.empty?
+    return if formula.versioned_formula?
+    problem "New formulae should not use `deprecated_option`."
+  end
+
+  def audit_homepage
+    homepage = formula.homepage
+
+    return if homepage.nil? || homepage.empty?
+
+    return unless @online
+
+    return unless DevelopmentTools.curl_handles_most_https_homepages?
+    if http_content_problem = FormulaAuditor.check_http_content(homepage,
+                                               formula.name,
+                                               user_agents: [:browser, :default])
+      problem http_content_problem
+    end
+  end
+
+  def audit_bottle_spec
+    return unless formula.bottle_disabled?
+    return if formula.bottle_disable_reason.valid?
+    problem "Unrecognized bottle modifier"
+  end
+
+  def audit_github_repository
+    return unless @online
+    return unless @new_formula
+
+    regex = %r{https?://github\.com/([^/]+)/([^/]+)/?.*}
+    _, user, repo = *regex.match(formula.stable.url) if formula.stable
+    _, user, repo = *regex.match(formula.homepage) unless user
+    return if !user || !repo
+
+    repo.gsub!(/.git$/, "")
+
+    begin
+      metadata = GitHub.repository(user, repo)
+    rescue GitHub::HTTPNotFoundError
+      return
+    end
+
+    return if metadata.nil?
+
+    problem "GitHub fork (not canonical repository)" if metadata["fork"]
+    if (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
+       (metadata["stargazers_count"] < 50)
+      problem "GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)"
+    end
+
+    return if Date.parse(metadata["created_at"]) <= (Date.today - 30)
+    problem "GitHub repository too new (<30 days old)"
+  end
+
+  def audit_specs
+    if head_only?(formula) && formula.tap.to_s.downcase !~ %r{[-/]head-only$}
+      problem "Head-only (no stable download)"
+    end
+
+    if devel_only?(formula) && formula.tap.to_s.downcase !~ %r{[-/]devel-only$}
+      problem "Devel-only (no stable download)"
+    end
+
+    %w[Stable Devel HEAD].each do |name|
+      next unless spec = formula.send(name.downcase)
+
+      ra = ResourceAuditor.new(spec, online: @online, strict: @strict).audit
+      problems.concat ra.problems.map { |problem| "#{name}: #{problem}" }
+
+      spec.resources.each_value do |resource|
+        ra = ResourceAuditor.new(resource, online: @online, strict: @strict).audit
+        problems.concat ra.problems.map { |problem|
+          "#{name} resource #{resource.name.inspect}: #{problem}"
+        }
+      end
+
+      next if spec.patches.empty?
+      spec.patches.each { |p| patch_problems(p) if p.external? }
+      next unless @new_formula
+      problem "New formulae should not require patches to build. Patches should be submitted and accepted upstream first."
+    end
+
+    %w[Stable Devel].each do |name|
+      next unless spec = formula.send(name.downcase)
+      version = spec.version
+      if version.to_s !~ /\d/
+        problem "#{name}: version (#{version}) is set to a string without a digit"
+      end
+      if version.to_s.start_with?("HEAD")
+        problem "#{name}: non-HEAD version name (#{version}) should not begin with HEAD"
+      end
+    end
+
+    if formula.stable && formula.devel
+      if formula.devel.version < formula.stable.version
+        problem "devel version #{formula.devel.version} is older than stable version #{formula.stable.version}"
+      elsif formula.devel.version == formula.stable.version
+        problem "stable and devel versions are identical"
+      end
+    end
+
+    unstable_whitelist = %w[
+      aalib 1.4rc5
+      angolmois 2.0.0alpha2
+      automysqlbackup 3.0-rc6
+      aview 1.3.0rc1
+      distcc 3.2rc1
+      elm-format 0.6.0-alpha
+      ftgl 2.1.3-rc5
+      hidapi 0.8.0-rc1
+      libcaca 0.99b19
+      nethack4 4.3.0-beta2
+      opensyobon 1.0rc2
+      premake 4.4-beta5
+      pwnat 0.3-beta
+      pxz 4.999.9
+      recode 3.7-beta2
+      speexdsp 1.2rc3
+      sqoop 1.4.6
+      tcptraceroute 1.5beta7
+      testssl 2.8rc3
+      tiny-fugue 5.0b8
+      vbindiff 3.0_beta4
+    ].each_slice(2).to_a.map do |formula, version|
+      [formula, version.sub(/\d+$/, "")]
+    end
+
+    gnome_devel_whitelist = %w[
+      gtk-doc 1.25
+      libart 2.3.21
+      pygtkglext 1.1.0
+    ].each_slice(2).to_a.map do |formula, version|
+      [formula, version.split(".")[0..1].join(".")]
+    end
+
+    stable = formula.stable
+    case stable && stable.url
+    when /[\d\._-](alpha|beta|rc\d)/
+      matched = Regexp.last_match(1)
+      version_prefix = stable.version.to_s.sub(/\d+$/, "")
+      return if unstable_whitelist.include?([formula.name, version_prefix])
+      problem "Stable version URLs should not contain #{matched}"
+    when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i
+      version_prefix = stable.version.to_s.split(".")[0..1].join(".")
+      return if gnome_devel_whitelist.include?([formula.name, version_prefix])
+      version = Version.parse(stable.url)
+      if version >= Version.create("1.0")
+        minor_version = version.to_s.split(".", 3)[1].to_i
+        if minor_version.odd?
+          problem "#{stable.version} is a development release"
+        end
+      end
+    end
+  end
+
+  def audit_revision_and_version_scheme
+    return unless formula.tap # skip formula not from core or any taps
+    return unless formula.tap.git? # git log is required
+    return if @new_formula
+
+    fv = FormulaVersions.new(formula)
+
+    previous_version_and_checksum = fv.previous_version_and_checksum("origin/master")
+    [:stable, :devel].each do |spec_sym|
+      next unless spec = formula.send(spec_sym)
+      next unless previous_version_and_checksum[spec_sym][:version] == spec.version
+      next if previous_version_and_checksum[spec_sym][:checksum] == spec.checksum
+      problem "#{spec_sym}: sha256 changed without the version also changing; please create an issue upstream to rule out malicious circumstances and to find out why the file changed."
+    end
+
+    attributes = [:revision, :version_scheme]
+    attributes_map = fv.version_attributes_map(attributes, "origin/master")
+
+    current_version_scheme = formula.version_scheme
+    [:stable, :devel].each do |spec|
+      spec_version_scheme_map = attributes_map[:version_scheme][spec]
+      next if spec_version_scheme_map.empty?
+
+      version_schemes = spec_version_scheme_map.values.flatten
+      max_version_scheme = version_schemes.max
+      max_version = spec_version_scheme_map.select do |_, version_scheme|
+        version_scheme.first == max_version_scheme
+      end.keys.max
+
+      if max_version_scheme && current_version_scheme < max_version_scheme
+        problem "version_scheme should not decrease (from #{max_version_scheme} to #{current_version_scheme})"
+      end
+
+      if max_version_scheme && current_version_scheme >= max_version_scheme &&
+         current_version_scheme > 1 &&
+         !version_schemes.include?(current_version_scheme - 1)
+        problem "version_schemes should only increment by 1"
+      end
+
+      formula_spec = formula.send(spec)
+      next unless formula_spec
+
+      spec_version = formula_spec.version
+      next unless max_version
+      next if spec_version >= max_version
+
+      above_max_version_scheme = current_version_scheme > max_version_scheme
+      map_includes_version = spec_version_scheme_map.keys.include?(spec_version)
+      next if !current_version_scheme.zero? &&
+              (above_max_version_scheme || map_includes_version)
+      problem "#{spec} version should not decrease (from #{max_version} to #{spec_version})"
+    end
+
+    current_revision = formula.revision
+    revision_map = attributes_map[:revision][:stable]
+    if formula.stable && !revision_map.empty?
+      stable_revisions = revision_map[formula.stable.version]
+      stable_revisions ||= []
+      max_revision = stable_revisions.max || 0
+
+      if current_revision < max_revision
+        problem "revision should not decrease (from #{max_revision} to #{current_revision})"
+      end
+
+      stable_revisions -= [formula.revision]
+      if !current_revision.zero? && stable_revisions.empty? &&
+         revision_map.keys.length > 1
+        problem "'revision #{formula.revision}' should be removed"
+      elsif current_revision > 1 &&
+            current_revision != max_revision &&
+            !stable_revisions.include?(current_revision - 1)
+        problem "revisions should only increment by 1"
+      end
+    elsif !current_revision.zero? # head/devel-only formula
+      problem "'revision #{current_revision}' should be removed"
+    end
+  end
+
+  def audit_legacy_patches
+    return unless formula.respond_to?(:patches)
+    legacy_patches = Patch.normalize_legacy_patches(formula.patches).grep(LegacyPatch)
+
+    return if legacy_patches.empty?
+
+    problem "Use the patch DSL instead of defining a 'patches' method"
+    legacy_patches.each { |p| patch_problems(p) }
+  end
+
+  def patch_problems(patch)
+    case patch.url
+    when /raw\.github\.com/, %r{gist\.github\.com/raw}, %r{gist\.github\.com/.+/raw},
+      %r{gist\.githubusercontent\.com/.+/raw}
+      unless patch.url =~ /[a-fA-F0-9]{40}/
+        problem "GitHub/Gist patches should specify a revision:\n#{patch.url}"
+      end
+    when %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
+      problem <<-EOS.undent
+        use GitHub pull request URLs:
+          https://github.com/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}/pull/#{Regexp.last_match(3)}.patch
+        Rather than patch-diff:
+          #{patch.url}
+      EOS
+    when %r{macports/trunk}
+      problem "MacPorts patches should specify a revision instead of trunk:\n#{patch.url}"
+    when %r{^http://trac\.macports\.org}
+      problem "Patches from MacPorts Trac should be https://, not http:\n#{patch.url}"
+    when %r{^http://bugs\.debian\.org}
+      problem "Patches from Debian should be https://, not http:\n#{patch.url}"
+    end
+  end
+
+  def audit_text
+    bin_names = Set.new
+    bin_names << formula.name
+    bin_names += formula.aliases
+    [formula.bin, formula.sbin].each do |dir|
+      next unless dir.exist?
+      bin_names += dir.children.map(&:basename).map(&:to_s)
+    end
+    bin_names.each do |name|
+      ["system", "shell_output", "pipe_output"].each do |cmd|
+        if text =~ %r{(def test|test do).*(#{Regexp.escape(HOMEBREW_PREFIX)}/bin/)?#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]}m
+          problem %Q(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
+        end
+      end
+    end
+  end
+
+  def audit_lines
+    text.without_patch.split("\n").each_with_index do |line, lineno|
+      line_problems(line, lineno + 1)
+    end
+  end
+
+  def line_problems(line, _lineno)
+    if line =~ /<(Formula|AmazonWebServicesFormula|ScriptFileFormula|GithubGistFormula)/
+      problem "Use a space in class inheritance: class Foo < #{Regexp.last_match(1)}"
+    end
+
+    # Commented-out cmake support from default template
+    problem "Commented cmake call found" if line.include?('# system "cmake')
+
+    # Comments from default template
+    [
+      "# PLEASE REMOVE",
+      "# Documentation:",
+      "# if this fails, try separate make/make install steps",
+      "# The URL of the archive",
+      "## Naming --",
+      "# if your formula requires any X11/XQuartz components",
+      "# if your formula fails when building in parallel",
+      "# Remove unrecognized options if warned by configure",
+    ].each do |comment|
+      next unless line.include?(comment)
+      problem "Please remove default template comments"
+    end
+
+    # FileUtils is included in Formula
+    # encfs modifies a file with this name, so check for some leading characters
+    if line =~ %r{[^'"/]FileUtils\.(\w+)}
+      problem "Don't need 'FileUtils.' before #{Regexp.last_match(1)}."
+    end
+
+    # Check for long inreplace block vars
+    if line =~ /inreplace .* do \|(.{2,})\|/
+      problem "\"inreplace <filenames> do |s|\" is preferred over \"|#{Regexp.last_match(1)}|\"."
+    end
+
+    # Check for string interpolation of single values.
+    if line =~ /(system|inreplace|gsub!|change_make_var!).*[ ,]"#\{([\w.]+)\}"/
+      problem "Don't need to interpolate \"#{Regexp.last_match(2)}\" with #{Regexp.last_match(1)}"
+    end
+
+    # Check for string concatenation; prefer interpolation
+    if line =~ /(#\{\w+\s*\+\s*['"][^}]+\})/
+      problem "Try not to concatenate paths in string interpolation:\n   #{Regexp.last_match(1)}"
+    end
+
+    # Prefer formula path shortcuts in Pathname+
+    if line =~ %r{\(\s*(prefix\s*\+\s*(['"])(bin|include|libexec|lib|sbin|share|Frameworks)[/'"])}
+      problem "\"(#{Regexp.last_match(1)}...#{Regexp.last_match(2)})\" should be \"(#{Regexp.last_match(3).downcase}+...)\""
+    end
+
+    if line =~ /((man)\s*\+\s*(['"])(man[1-8])(['"]))/
+      problem "\"#{Regexp.last_match(1)}\" should be \"#{Regexp.last_match(4)}\""
+    end
+
+    # Prefer formula path shortcuts in strings
+    if line =~ %r[(\#\{prefix\}/(bin|include|libexec|lib|sbin|share|Frameworks))]
+      problem "\"#{Regexp.last_match(1)}\" should be \"\#{#{Regexp.last_match(2).downcase}}\""
+    end
+
+    if line =~ %r[((\#\{prefix\}/share/man/|\#\{man\}/)(man[1-8]))]
+      problem "\"#{Regexp.last_match(1)}\" should be \"\#{#{Regexp.last_match(3)}}\""
+    end
+
+    if line =~ %r[((\#\{share\}/(man)))[/'"]]
+      problem "\"#{Regexp.last_match(1)}\" should be \"\#{#{Regexp.last_match(3)}}\""
+    end
+
+    if line =~ %r[(\#\{prefix\}/share/(info|man))]
+      problem "\"#{Regexp.last_match(1)}\" should be \"\#{#{Regexp.last_match(2)}}\""
+    end
+
+    if line =~ /depends_on :(automake|autoconf|libtool)/
+      problem ":#{Regexp.last_match(1)} is deprecated. Usage should be \"#{Regexp.last_match(1)}\""
+    end
+
+    if line =~ /depends_on :apr/
+      problem ":apr is deprecated. Usage should be \"apr-util\""
+    end
+
+    problem ":tex is deprecated" if line =~ /depends_on :tex/
+
+    if line =~ /depends_on\s+['"](.+)['"]\s+=>\s+:(lua|perl|python|ruby)(\d*)/
+      problem "#{Regexp.last_match(2)} modules should be vendored rather than use deprecated `depends_on \"#{Regexp.last_match(1)}\" => :#{Regexp.last_match(2)}#{Regexp.last_match(3)}`"
+    end
+
+    if line =~ /depends_on\s+['"](.+)['"]\s+=>\s+(.*)/
+      dep = Regexp.last_match(1)
+      Regexp.last_match(2).split(" ").map do |o|
+        break if ["if", "unless"].include?(o)
+        next unless o =~ /^\[?['"](.*)['"]/
+        problem "Dependency #{dep} should not use option #{Regexp.last_match(1)}"
+      end
+    end
+
+    # Commented-out depends_on
+    problem "Commented-out dep #{Regexp.last_match(1)}" if line =~ /#\s*depends_on\s+(.+)\s*$/
+
+    if line =~ /if\s+ARGV\.include\?\s+'--(HEAD|devel)'/
+      problem "Use \"if build.#{Regexp.last_match(1).downcase}?\" instead"
+    end
+
+    problem "Use separate make calls" if line.include?("make && make")
+
+    problem "Use spaces instead of tabs for indentation" if line =~ /^[ ]*\t/
+
+    if line.include?("ENV.x11")
+      problem "Use \"depends_on :x11\" instead of \"ENV.x11\""
+    end
+
+    # Avoid hard-coding compilers
+    if line =~ %r{(system|ENV\[.+\]\s?=)\s?['"](/usr/bin/)?(gcc|llvm-gcc|clang)['" ]}
+      problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{Regexp.last_match(3)}\""
+    end
+
+    if line =~ %r{(system|ENV\[.+\]\s?=)\s?['"](/usr/bin/)?((g|llvm-g|clang)\+\+)['" ]}
+      problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{Regexp.last_match(3)}\""
+    end
+
+    if line =~ /system\s+['"](env|export)(\s+|['"])/
+      problem "Use ENV instead of invoking '#{Regexp.last_match(1)}' to modify the environment"
+    end
+
+    if formula.name != "wine" && line =~ /ENV\.universal_binary/
+      problem "macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated."
+    end
+
+    if line =~ /build\.universal\?/
+      problem "macOS has been 64-bit only so build.universal? is deprecated."
+    end
+
+    if line =~ /version == ['"]HEAD['"]/
+      problem "Use 'build.head?' instead of inspecting 'version'"
+    end
+
+    if line =~ /build\.include\?[\s\(]+['"]\-\-(.*)['"]/
+      problem "Reference '#{Regexp.last_match(1)}' without dashes"
+    end
+
+    if line =~ /build\.include\?[\s\(]+['"]with(out)?-(.*)['"]/
+      problem "Use build.with#{Regexp.last_match(1)}? \"#{Regexp.last_match(2)}\" instead of build.include? 'with#{Regexp.last_match(1)}-#{Regexp.last_match(2)}'"
+    end
+
+    if line =~ /build\.with\?[\s\(]+['"]-?-?with-(.*)['"]/
+      problem "Don't duplicate 'with': Use `build.with? \"#{Regexp.last_match(1)}\"` to check for \"--with-#{Regexp.last_match(1)}\""
+    end
+
+    if line =~ /build\.without\?[\s\(]+['"]-?-?without-(.*)['"]/
+      problem "Don't duplicate 'without': Use `build.without? \"#{Regexp.last_match(1)}\"` to check for \"--without-#{Regexp.last_match(1)}\""
+    end
+
+    if line =~ /unless build\.with\?(.*)/
+      problem "Use if build.without?#{Regexp.last_match(1)} instead of unless build.with?#{Regexp.last_match(1)}"
+    end
+
+    if line =~ /unless build\.without\?(.*)/
+      problem "Use if build.with?#{Regexp.last_match(1)} instead of unless build.without?#{Regexp.last_match(1)}"
+    end
+
+    if line =~ /(not\s|!)\s*build\.with?\?/
+      problem "Don't negate 'build.with?': use 'build.without?'"
+    end
+
+    if line =~ /(not\s|!)\s*build\.without?\?/
+      problem "Don't negate 'build.without?': use 'build.with?'"
+    end
+
+    if line =~ /ARGV\.(?!(debug\?|verbose\?|value[\(\s]))/
+      problem "Use build instead of ARGV to check options"
+    end
+
+    problem "Use new-style option definitions" if line.include?("def options")
+
+    if line.end_with?("def test")
+      problem "Use new-style test definitions (test do)"
+    end
+
+    if line.include?("MACOS_VERSION")
+      problem "Use MacOS.version instead of MACOS_VERSION"
+    end
+
+    if line.include?("MACOS_FULL_VERSION")
+      problem "Use MacOS.full_version instead of MACOS_FULL_VERSION"
+    end
+
+    cats = %w[leopard snow_leopard lion mountain_lion].join("|")
+    if line =~ /MacOS\.(?:#{cats})\?/
+      problem "\"#{$&}\" is deprecated, use a comparison to MacOS.version instead"
+    end
+
+    if line =~ /skip_clean\s+:all/
+      problem "`skip_clean :all` is deprecated; brew no longer strips symbols\n" \
+              "\tPass explicit paths to prevent Homebrew from removing empty folders."
+    end
+
+    if line =~ /depends_on [A-Z][\w:]+\.new$/
+      problem "`depends_on` can take requirement classes instead of instances"
+    end
+
+    if line =~ /^def (\w+).*$/
+      problem "Define method #{Regexp.last_match(1).inspect} in the class body, not at the top-level"
+    end
+
+    if line.include?("ENV.fortran") && !formula.requirements.map(&:class).include?(FortranRequirement)
+      problem "Use `depends_on :fortran` instead of `ENV.fortran`"
+    end
+
+    if line =~ /JAVA_HOME/i && !formula.requirements.map(&:class).include?(JavaRequirement)
+      problem "Use `depends_on :java` to set JAVA_HOME"
+    end
+
+    if line =~ /depends_on :(.+) (if.+|unless.+)$/
+      conditional_dep_problems(Regexp.last_match(1).to_sym, Regexp.last_match(2), $&)
+    end
+
+    if line =~ /depends_on ['"](.+)['"] (if.+|unless.+)$/
+      conditional_dep_problems(Regexp.last_match(1), Regexp.last_match(2), $&)
+    end
+
+    if line =~ /(Dir\[("[^\*{},]+")\])/
+      problem "#{Regexp.last_match(1)} is unnecessary; just use #{Regexp.last_match(2)}"
+    end
+
+    if line =~ /system (["'](#{FILEUTILS_METHODS})["' ])/o
+      system = Regexp.last_match(1)
+      method = Regexp.last_match(2)
+      problem "Use the `#{method}` Ruby method instead of `system #{system}`"
+    end
+
+    if line =~ /assert [^!]+\.include?/
+      problem "Use `assert_match` instead of `assert ...include?`"
+    end
+
+    if line.include?('system "npm", "install"') && !line.include?("Language::Node") &&
+       formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
+      problem "Use Language::Node for npm install args"
+    end
+
+    if line.include?("fails_with :llvm")
+      problem "'fails_with :llvm' is now a no-op so should be removed"
+    end
+
+    if line =~ /system\s+['"](otool|install_name_tool|lipo)/ && formula.name != "cctools"
+      problem "Use ruby-macho instead of calling #{Regexp.last_match(1)}"
+    end
+
+    if formula.tap.to_s == "homebrew/core"
+      ["OS.mac?", "OS.linux?"].each do |check|
+        next unless line.include?(check)
+        problem "Don't use #{check}; Homebrew/core only supports macOS"
+      end
+    end
+
+    if line =~ /((revision|version_scheme)\s+0)/
+      problem "'#{Regexp.last_match(1)}' should be removed"
+    end
+
+    return unless @strict
+
+    problem "`#{Regexp.last_match(1)}` in formulae is deprecated" if line =~ /(env :(std|userpaths))/
+
+    if line =~ /system ((["'])[^"' ]*(?:\s[^"' ]*)+\2)/
+      bad_system = Regexp.last_match(1)
+      unless %w[| < > & ; *].any? { |c| bad_system.include? c }
+        good_system = bad_system.gsub(" ", "\", \"")
+        problem "Use `system #{good_system}` instead of `system #{bad_system}` "
+      end
+    end
+
+    problem "`#{Regexp.last_match(1)}` is now unnecessary" if line =~ /(require ["']formula["'])/
+
+    if line =~ %r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]}
+      problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
+    end
+
+    return unless line =~ %r{share(\s*[/+]\s*)(['"])#{Regexp.escape(formula.name)}(?:\2|/)}
+    problem "Use pkgshare instead of (share#{Regexp.last_match(1)}\"#{formula.name}\")"
+  end
+
+  def audit_reverse_migration
+    # Only enforce for new formula being re-added to core and official taps
+    return unless @strict
+    return unless formula.tap && formula.tap.official?
+    return unless formula.tap.tap_migrations.key?(formula.name)
+
+    problem <<-EOS.undent
+      #{formula.name} seems to be listed in tap_migrations.json!
+      Please remove #{formula.name} from present tap & tap_migrations.json
+      before submitting it to Homebrew/homebrew-#{formula.tap.repo}.
+    EOS
+  end
+
+  def audit_prefix_has_contents
+    return unless formula.prefix.directory?
+    return unless Keg.new(formula.prefix).empty_installation?
+
+    problem <<-EOS.undent
+      The installation seems to be empty. Please ensure the prefix
+      is set correctly and expected files are installed.
+      The prefix configure/make argument may be case-sensitive.
+    EOS
+  end
+
+  def conditional_dep_problems(dep, condition, line)
+    quoted_dep = quote_dep(dep)
+    dep = Regexp.escape(dep.to_s)
+
+    case condition
+    when /if build\.include\? ['"]with-#{dep}['"]$/, /if build\.with\? ['"]#{dep}['"]$/
+      problem %Q(Replace #{line.inspect} with "depends_on #{quoted_dep} => :optional")
+    when /unless build\.include\? ['"]without-#{dep}['"]$/, /unless build\.without\? ['"]#{dep}['"]$/
+      problem %Q(Replace #{line.inspect} with "depends_on #{quoted_dep} => :recommended")
+    end
+  end
+
+  def quote_dep(dep)
+    dep.is_a?(Symbol) ? dep.inspect : "'#{dep}'"
+  end
+
+  def problem_if_output(output)
+    problem(output) if output
+  end
+
+  def audit
+    only_audits = ARGV.value("only").to_s.split(",")
+    except_audits = ARGV.value("except").to_s.split(",")
+    if !only_audits.empty? && !except_audits.empty?
+      odie "--only and --except cannot be used simultaneously!"
+    end
+
+    methods.map(&:to_s).grep(/^audit_/).each do |audit_method_name|
+      name = audit_method_name.gsub(/^audit_/, "")
+      if !only_audits.empty?
+        next unless only_audits.include?(name)
+      elsif !except_audits.empty?
+        next if except_audits.include?(name)
+      end
+      send(audit_method_name)
+    end
+  end
+
+  private
+
+  def problem(p)
+    @problems << p
+  end
+
+  def head_only?(formula)
+    formula.head && formula.devel.nil? && formula.stable.nil?
+  end
+
+  def devel_only?(formula)
+    formula.devel && formula.stable.nil?
+  end
+end
+
+class ResourceAuditor
+  attr_reader :problems
+  attr_reader :version, :checksum, :using, :specs, :url, :mirrors, :name
+
+  def initialize(resource, options = {})
+    @name     = resource.name
+    @version  = resource.version
+    @checksum = resource.checksum
+    @url      = resource.url
+    @mirrors  = resource.mirrors
+    @using    = resource.using
+    @specs    = resource.specs
+    @online   = options[:online]
+    @strict   = options[:strict]
+    @problems = []
+  end
+
+  def audit
+    audit_version
+    audit_checksum
+    audit_download_strategy
+    audit_urls
+    self
+  end
+
+  def audit_version
+    if version.nil?
+      problem "missing version"
+    elsif version.to_s.empty?
+      problem "version is set to an empty string"
+    elsif !version.detected_from_url?
+      version_text = version
+      version_url = Version.detect(url, specs)
+      if version_url.to_s == version_text.to_s && version.instance_of?(Version)
+        problem "version #{version_text} is redundant with version scanned from URL"
+      end
+    end
+
+    if version.to_s.start_with?("v")
+      problem "version #{version} should not have a leading 'v'"
+    end
+
+    return unless version.to_s =~ /_\d+$/
+    problem "version #{version} should not end with an underline and a number"
+  end
+
+  def audit_checksum
+    return unless checksum
+
+    case checksum.hash_type
+    when :md5
+      problem "MD5 checksums are deprecated, please use SHA256"
+      return
+    when :sha1
+      problem "SHA1 checksums are deprecated, please use SHA256"
+      return
+    when :sha256 then len = 64
+    end
+
+    if checksum.empty?
+      problem "#{checksum.hash_type} is empty"
+    else
+      problem "#{checksum.hash_type} should be #{len} characters" unless checksum.hexdigest.length == len
+      problem "#{checksum.hash_type} contains invalid characters" unless checksum.hexdigest =~ /^[a-fA-F0-9]+$/
+      problem "#{checksum.hash_type} should be lowercase" unless checksum.hexdigest == checksum.hexdigest.downcase
+    end
+  end
+
+  def audit_download_strategy
+    if url =~ %r{^(cvs|bzr|hg|fossil)://} || url =~ %r{^(svn)\+http://}
+      problem "Use of the #{$&} scheme is deprecated, pass `:using => :#{Regexp.last_match(1)}` instead"
+    end
+
+    url_strategy = DownloadStrategyDetector.detect(url)
+
+    if using == :git || url_strategy == GitDownloadStrategy
+      if specs[:tag] && !specs[:revision]
+        problem "Git should specify :revision when a :tag is specified."
+      end
+    end
+
+    return unless using
+
+    if using == :ssl3 || \
+       (Object.const_defined?("CurlSSL3DownloadStrategy") && using == CurlSSL3DownloadStrategy)
+      problem "The SSL3 download strategy is deprecated, please choose a different URL"
+    elsif (Object.const_defined?("CurlUnsafeDownloadStrategy") && using == CurlUnsafeDownloadStrategy) || \
+          (Object.const_defined?("UnsafeSubversionDownloadStrategy") && using == UnsafeSubversionDownloadStrategy)
+      problem "#{using.name} is deprecated, please choose a different URL"
+    end
+
+    if using == :cvs
+      mod = specs[:module]
+
+      problem "Redundant :module value in URL" if mod == name
+
+      if url =~ %r{:[^/]+$}
+        mod = url.split(":").last
+
+        if mod == name
+          problem "Redundant CVS module appended to URL"
+        else
+          problem "Specify CVS module as `:module => \"#{mod}\"` instead of appending it to the URL"
+        end
+      end
+    end
+
+    return unless url_strategy == DownloadStrategyDetector.detect("", using)
+    problem "Redundant :using value in URL"
+  end
+
+  def audit_urls
+    # Check GNU urls; doesn't apply to mirrors
+    if url =~ %r{^(?:https?|ftp)://ftpmirror.gnu.org/(.*)}
+      problem "Please use \"https://ftp.gnu.org/gnu/#{Regexp.last_match(1)}\" instead of #{url}."
+    end
+
+    if mirrors.include?(url)
+      problem "URL should not be duplicated as a mirror: #{url}"
+    end
+
+    urls = [url] + mirrors
+
+    # Check a variety of SSL/TLS URLs that don't consistently auto-redirect
+    # or are overly common errors that need to be reduced & fixed over time.
+    urls.each do |p|
+      case p
+      when %r{^http://ftp\.gnu\.org/},
+           %r{^http://ftpmirror\.gnu\.org/},
+           %r{^http://download\.savannah\.gnu\.org/},
+           %r{^http://download-mirror\.savannah\.gnu\.org/},
+           %r{^http://[^/]*\.apache\.org/},
+           %r{^http://code\.google\.com/},
+           %r{^http://fossies\.org/},
+           %r{^http://mirrors\.kernel\.org/},
+           %r{^http://(?:[^/]*\.)?bintray\.com/},
+           %r{^http://tools\.ietf\.org/},
+           %r{^http://launchpad\.net/},
+           %r{^http://github\.com/},
+           %r{^http://bitbucket\.org/},
+           %r{^http://anonscm\.debian\.org/},
+           %r{^http://cpan\.metacpan\.org/},
+           %r{^http://hackage\.haskell\.org/},
+           %r{^http://(?:[^/]*\.)?archive\.org},
+           %r{^http://(?:[^/]*\.)?freedesktop\.org},
+           %r{^http://(?:[^/]*\.)?mirrorservice\.org/}
+        problem "Please use https:// for #{p}"
+      when %r{^http://search\.mcpan\.org/CPAN/(.*)}i
+        problem "#{p} should be `https://cpan.metacpan.org/#{Regexp.last_match(1)}`"
+      when %r{^(http|ftp)://ftp\.gnome\.org/pub/gnome/(.*)}i
+        problem "#{p} should be `https://download.gnome.org/#{Regexp.last_match(2)}`"
+      when %r{^git://anonscm\.debian\.org/users/(.*)}i
+        problem "#{p} should be `https://anonscm.debian.org/git/users/#{Regexp.last_match(1)}`"
+      end
+    end
+
+    # Prefer HTTP/S when possible over FTP protocol due to possible firewalls.
+    urls.each do |p|
+      case p
+      when %r{^ftp://ftp\.mirrorservice\.org}
+        problem "Please use https:// for #{p}"
+      when %r{^ftp://ftp\.cpan\.org/pub/CPAN(.*)}i
+        problem "#{p} should be `http://search.cpan.org/CPAN#{Regexp.last_match(1)}`"
+      end
+    end
+
+    # Check SourceForge urls
+    urls.each do |p|
+      # Skip if the URL looks like a SVN repo
+      next if p.include? "/svnroot/"
+      next if p.include? "svn.sourceforge"
+
+      # Is it a sourceforge http(s) URL?
+      next unless p =~ %r{^https?://.*\b(sourceforge|sf)\.(com|net)}
+
+      if p =~ /(\?|&)use_mirror=/
+        problem "Don't use #{Regexp.last_match(1)}use_mirror in SourceForge urls (url is #{p})."
+      end
+
+      if p.end_with?("/download")
+        problem "Don't use /download in SourceForge urls (url is #{p})."
+      end
+
+      if p =~ %r{^https?://sourceforge\.}
+        problem "Use https://downloads.sourceforge.net to get geolocation (url is #{p})."
+      end
+
+      if p =~ %r{^https?://prdownloads\.}
+        problem "Don't use prdownloads in SourceForge urls (url is #{p}).\n" \
+                "\tSee: http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/"
+      end
+
+      if p =~ %r{^http://\w+\.dl\.}
+        problem "Don't use specific dl mirrors in SourceForge urls (url is #{p})."
+      end
+
+      problem "Please use https:// for #{p}" if p.start_with? "http://downloads"
+    end
+
+    # Debian has an abundance of secure mirrors. Let's not pluck the insecure
+    # one out of the grab bag.
+    urls.each do |u|
+      next unless u =~ %r{^http://http\.debian\.net/debian/(.*)}i
+      problem <<-EOS.undent
+        Please use a secure mirror for Debian URLs.
+        We recommend:
+          https://mirrors.ocf.berkeley.edu/debian/#{Regexp.last_match(1)}
+      EOS
+    end
+
+    # Check for Google Code download urls, https:// is preferred
+    # Intentionally not extending this to SVN repositories due to certificate
+    # issues.
+    urls.grep(%r{^http://.*\.googlecode\.com/files.*}) do |u|
+      problem "Please use https:// for #{u}"
+    end
+
+    # Check for new-url Google Code download urls, https:// is preferred
+    urls.grep(%r{^http://code\.google\.com/}) do |u|
+      problem "Please use https:// for #{u}"
+    end
+
+    # Check for git:// GitHub repo urls, https:// is preferred.
+    urls.grep(%r{^git://[^/]*github\.com/}) do |u|
+      problem "Please use https:// for #{u}"
+    end
+
+    # Check for git:// Gitorious repo urls, https:// is preferred.
+    urls.grep(%r{^git://[^/]*gitorious\.org/}) do |u|
+      problem "Please use https:// for #{u}"
+    end
+
+    # Check for http:// GitHub repo urls, https:// is preferred.
+    urls.grep(%r{^http://github\.com/.*\.git$}) do |u|
+      problem "Please use https:// for #{u}"
+    end
+
+    # Check for master branch GitHub archives.
+    urls.grep(%r{^https://github\.com/.*archive/master\.(tar\.gz|zip)$}) do
+      problem "Use versioned rather than branch tarballs for stable checksums."
+    end
+
+    # Use new-style archive downloads
+    urls.each do |u|
+      next unless u =~ %r{https://.*github.*/(?:tar|zip)ball/} && u !~ /\.git$/
+      problem "Use /archive/ URLs for GitHub tarballs (url is #{u})."
+    end
+
+    # Don't use GitHub .zip files
+    urls.each do |u|
+      next unless u =~ %r{https://.*github.*/(archive|releases)/.*\.zip$} && u !~ %r{releases/download}
+      problem "Use GitHub tarballs rather than zipballs (url is #{u})."
+    end
+
+    # Don't use GitHub codeload URLs
+    urls.each do |u|
+      next unless u =~ %r{https?://codeload\.github\.com/(.+)/(.+)/(?:tar\.gz|zip)/(.+)}
+      problem <<-EOS.undent
+        use GitHub archive URLs:
+          https://github.com/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}/archive/#{Regexp.last_match(3)}.tar.gz
+        Rather than codeload:
+          #{u}
+      EOS
+    end
+
+    # Check for Maven Central urls, prefer HTTPS redirector over specific host
+    urls.each do |u|
+      next unless u =~ %r{https?://(?:central|repo\d+)\.maven\.org/maven2/(.+)$}
+      problem "#{u} should be `https://search.maven.org/remotecontent?filepath=#{Regexp.last_match(1)}`"
+    end
+
+    if name == "curl" && !urls.find { |u| u.start_with?("http://") }
+      problem "should always include at least one HTTP url"
+    end
+
+    # Check pypi urls
+    if @strict
+      urls.each do |p|
+        next unless p =~ %r{^https?://pypi.python.org/(.*)}
+        problem "#{p} should be `https://files.pythonhosted.org/#{Regexp.last_match(1)}`"
+      end
+    end
+
+    return unless @online
+    urls.each do |url|
+      next if !@strict && mirrors.include?(url)
+
+      strategy = DownloadStrategyDetector.detect(url, using)
+      if strategy <= CurlDownloadStrategy && !url.start_with?("file")
+        # A `brew mirror`'ed URL is usually not yet reachable at the time of
+        # pull request.
+        next if url =~ %r{^https://dl.bintray.com/homebrew/mirror/}
+        if http_content_problem = FormulaAuditor.check_http_content(url, name)
+          problem http_content_problem
+        end
+      elsif strategy <= GitDownloadStrategy
+        unless Utils.git_remote_exists url
+          problem "The URL #{url} is not a valid git URL"
+        end
+      elsif strategy <= SubversionDownloadStrategy
+        next unless DevelopmentTools.subversion_handles_most_https_certificates?
+        unless Utils.svn_remote_exists url
+          problem "The URL #{url} is not a valid svn URL"
+        end
+      end
+    end
+  end
+
+  def problem(text)
+    @problems << text
+  end
+end

--- a/testdata/issue20/core_unix.ml
+++ b/testdata/issue20/core_unix.ml
@@ -1,0 +1,3081 @@
+(* Core_unix wraps the standard unix functions with an exception handler that inserts an
+   informative string in the third field of Unix_error.  The problem with the standard
+   Unix_error that gets raised is that it doesn't include information about the arguments
+   to the function that failed. *)
+#import "config.h"
+
+open! Import
+
+module Time_ns = Core_kernel.Core_kernel_private.Time_ns_alternate_sexp
+
+(* 4.06 adds a [?cloexec] argument to all functions. It cannot be ignored for the
+   functions with labels, so to keep the code compatible with all supported versions of
+   OCaml, we sometimes use the non-labelled versions. *)
+module UnixNoLabels = Unix
+module Unix = UnixLabels
+
+let ( ^/ ) = Core_filename.concat
+
+let atom x = Sexp.Atom x
+let list x = Sexp.List x
+
+let record l =
+  list (List.map l ~f:(fun (name, value) -> list [atom name; value]))
+;;
+
+(* No need to include a counter here. It just doesn't make sense to think we are
+going to be receiving a steady stream of interrupts.
+   Glibc's macro doesn't have a counter either.
+*)
+let rec retry_until_no_eintr f =
+  try
+    f ()
+  with Unix.Unix_error (EINTR, _, _) ->
+    retry_until_no_eintr f
+
+(* This wrapper improves the content of the Unix_error exception raised by the standard
+   library (by including a sexp of the function arguments), and it optionally restarts
+   syscalls on EINTR. *)
+let improve ?(restart = false) f make_arg_sexps =
+  try
+    if restart then retry_until_no_eintr f else f ()
+  with
+  | Unix.Unix_error (e, s, _) ->
+    let buf = Buffer.create 100 in
+    let fmt = Format.formatter_of_buffer buf in
+    Format.pp_set_margin fmt 10000;
+    Sexp.pp_hum fmt (record (make_arg_sexps ()));
+    Format.pp_print_flush fmt ();
+    let arg_str = Buffer.contents buf in
+    raise (Unix.Unix_error (e, s, arg_str))
+;;
+
+module File_descr = struct
+  module M = struct
+    type t = Unix.file_descr
+    external to_int : t -> int = "%identity"
+    external of_int : int -> t = "%identity"
+    let of_string string = of_int (Int.of_string string)
+    let to_string t = Int.to_string (to_int t)
+    let sexp_of_t t = Int.sexp_of_t (to_int t)
+    let t_of_sexp sexp = of_int (Int.t_of_sexp sexp)
+    let hash t = Int.hash (to_int t)
+    let compare t1 t2 = Int.compare (to_int t1) (to_int t2)
+  end
+  include M
+  include (Hashable.Make (M))
+  include (Binable.Of_stringable (M))
+
+  (* Given that [to_int] and [of_int] are set to "%identity", this is considerably more
+     direct.  It's unfortunate, but despite [Caml.Unix] using [type t = int] in the
+     implementation, [Unix.file_descr] is abstract and cannot be tagged [@@immediate]. *)
+  let equal (t1 : t) t2 = phys_equal t1 t2
+end
+
+let sprintf = Printf.sprintf
+
+external sync : unit -> unit = "unix_sync"
+external fsync : Unix.file_descr -> unit = "unix_fsync"
+external fdatasync : Unix.file_descr -> unit = "unix_fdatasync"
+
+external dirfd : Unix.dir_handle -> File_descr.t = "unix_dirfd"
+
+external readdir_ino
+  : Unix.dir_handle -> string * nativeint = "unix_readdir_ino_stub"
+
+let readdir_ino_opt dh =
+  match readdir_ino dh with
+  | entry                 -> Some entry
+  | exception End_of_file -> None
+
+external unsetenv : string -> unit = "unix_unsetenv"
+
+external exit_immediately : int -> _ = "caml_sys_exit"
+
+external unsafe_read_assume_fd_is_nonblocking
+  : File_descr.t -> string -> pos : int -> len : int -> int
+  = "unix_read_assume_fd_is_nonblocking_stub"
+
+let check_string_args ~loc str ~pos ~len =
+  if pos < 0 then invalid_arg (loc ^ ": pos < 0");
+  if len < 0 then invalid_arg (loc ^ ": len < 0");
+  let str_len = String.length str in
+  if str_len < pos + len then
+    invalid_arg (Printf.sprintf "Unix_ext.%s: length(str) < pos + len" loc)
+
+let get_opt_pos ~loc = function
+  | Some pos ->
+    if pos < 0 then invalid_arg (Printf.sprintf "Unix_ext.%s: pos < 0" loc);
+    pos
+  | None -> 0
+
+let get_opt_len str ~pos = function
+  | Some len -> len
+  | None -> String.length str - pos
+
+let read_assume_fd_is_nonblocking fd ?pos ?len buf =
+  let loc = "read_assume_fd_is_nonblocking" in
+  let pos = get_opt_pos ~loc pos in
+  let len = get_opt_len buf ~pos len in
+  check_string_args ~loc buf ~pos ~len;
+  unsafe_read_assume_fd_is_nonblocking fd buf ~pos ~len
+;;
+
+external unsafe_write_assume_fd_is_nonblocking
+  : File_descr.t -> string -> pos : int -> len : int -> int
+  = "unix_write_assume_fd_is_nonblocking_stub"
+;;
+
+let write_assume_fd_is_nonblocking fd ?pos ?len buf =
+  let loc = "write_assume_fd_is_nonblocking" in
+  let pos = get_opt_pos ~loc pos in
+  let len = get_opt_len buf ~pos len in
+  check_string_args ~loc buf ~pos ~len;
+  unsafe_write_assume_fd_is_nonblocking fd buf ~pos ~len
+;;
+
+(* Filesystem functions *)
+
+external mknod
+  : string -> Unix.file_kind -> int -> int -> int -> unit = "unix_mknod_stub"
+
+let mknod
+    ?(file_kind = Unix.S_REG) ?(perm = 0o600) ?(major = 0) ?(minor = 0)
+    pathname =
+  mknod pathname file_kind perm major minor
+
+(* Resource limits *)
+
+module RLimit = struct
+  type limit = Limit of int64 | Infinity [@@deriving sexp]
+  type t = { cur : limit; max : limit } [@@deriving sexp]
+
+  type resource =
+    | Core_file_size
+    | Cpu_seconds
+    | Data_segment
+    | File_size
+    | Num_file_descriptors
+    | Stack
+    | Virtual_memory
+    | Nice
+  [@@deriving sexp] ;;
+
+  let core_file_size       = Core_file_size
+  let cpu_seconds          = Cpu_seconds
+  let data_segment         = Data_segment
+  let file_size            = File_size
+  let num_file_descriptors = Num_file_descriptors
+  let stack                = Stack
+  let virtual_memory       =
+#ifdef JSC_RLIMIT_AS
+      Ok Virtual_memory
+#else
+      Or_error.unimplemented "RLIMIT_AS is not supported on this system"
+#endif
+  let nice                 =
+#ifdef JSC_RLIMIT_NICE
+      Ok Nice
+#else
+      Or_error.unimplemented "RLIMIT_NICE is not supported on this system"
+#endif
+
+  let resource_of_sexp sexp =
+    match resource_of_sexp sexp with
+    | Nice ->
+      begin
+        match nice with
+        | Ok resource -> resource
+        | Error error -> of_sexp_error (Error.to_string_hum error) sexp
+      end
+    | Core_file_size | Cpu_seconds | Data_segment | File_size
+    | Num_file_descriptors | Stack | Virtual_memory as resource ->
+      resource
+
+  external get : resource -> t = "unix_getrlimit"
+  external set : resource -> t -> unit = "unix_setrlimit"
+
+  let get resource =
+    improve (fun () -> get resource)
+      (fun () -> [("resource", sexp_of_resource resource)])
+  ;;
+
+  let set resource t =
+    improve (fun () -> set resource t)
+      (fun () ->  [("resource", sexp_of_resource resource);
+                   ("limit", sexp_of_t t);
+                  ])
+  ;;
+end
+
+
+(* Resource usage *)
+
+module Resource_usage = struct
+  type t = {
+    utime : float;
+    stime : float;
+    maxrss : int64;
+    ixrss : int64;
+    idrss : int64;
+    isrss : int64;
+    minflt : int64;
+    majflt : int64;
+    nswap : int64;
+    inblock : int64;
+    oublock : int64;
+    msgsnd : int64;
+    msgrcv : int64;
+    nsignals : int64;
+    nvcsw : int64;
+    nivcsw : int64;
+  }
+  [@@deriving sexp, fields]
+
+  external getrusage : int -> t = "unix_getrusage"
+
+  let get who = getrusage (match who with `Self -> 0 | `Children -> 1)
+
+  let add t1 t2 = {
+    utime = t1.utime +. t2.utime;
+    stime = t1.stime +. t2.stime;
+    maxrss = Int64.(+) t1.maxrss t2.maxrss;
+    ixrss = Int64.(+) t1.ixrss t2.ixrss;
+    idrss = Int64.(+) t1.idrss t2.idrss;
+    isrss = Int64.(+) t1.isrss t2.isrss;
+    minflt = Int64.(+) t1.minflt t2.minflt;
+    majflt = Int64.(+) t1.majflt t2.majflt;
+    nswap = Int64.(+) t1.nswap t2.nswap;
+    inblock = Int64.(+) t1.inblock t2.inblock;
+    oublock = Int64.(+) t1.oublock t2.oublock;
+    msgsnd = Int64.(+) t1.msgsnd t2.msgsnd;
+    msgrcv = Int64.(+) t1.msgrcv t2.msgrcv;
+    nsignals = Int64.(+) t1.nsignals t2.nsignals;
+    nvcsw = Int64.(+) t1.nvcsw t2.nvcsw;
+    nivcsw = Int64.(+) t1.nivcsw t2.nivcsw;
+  }
+end
+
+
+(* System configuration *)
+type sysconf =
+  | ARG_MAX
+  | CHILD_MAX
+  | HOST_NAME_MAX
+  | LOGIN_NAME_MAX
+  | OPEN_MAX
+  | PAGESIZE
+  | RE_DUP_MAX
+  | STREAM_MAX
+  | SYMLOOP_MAX
+  | TTY_NAME_MAX
+  | TZNAME_MAX
+  | POSIX_VERSION
+  | PHYS_PAGES
+  | AVPHYS_PAGES
+  | IOV_MAX
+[@@deriving sexp]
+
+external sysconf : sysconf -> int64 = "unix_sysconf"
+
+
+(* I/O vectors *)
+
+module IOVec = struct
+  open Bigarray
+
+  (* NOTE: DO NOT CHANGE THE MEMORY LAYOUT OF THIS TYPE!!! *)
+  type 'buf t =
+    {
+      buf : 'buf;
+      pos : int;
+      len : int;
+    }
+  [@@deriving sexp]
+
+  type 'buf kind = 'buf
+
+  type bigstring = (char, int8_unsigned_elt, c_layout) Array1.t
+
+  let string_kind = ""
+  let bigstring_kind = Array1.create Bigarray.char c_layout 0
+
+  let empty kind =
+    {
+      buf = kind;
+      pos = 0;
+      len = 0;
+    }
+
+  let get_iovec loc ?pos ?len true_len buf =
+    let pos =
+      match pos with
+      | None -> 0
+      | Some pos ->
+          if pos < 0 then invalid_arg (loc ^ ": pos < 0");
+          pos
+    in
+    let len =
+      match len with
+      | None -> true_len
+      | Some len ->
+          if len < 0 then invalid_arg (loc ^ ": len < 0");
+          len
+    in
+    if pos + len > true_len then invalid_arg (loc ^ ": pos + len > length buf");
+    {
+      buf = buf;
+      pos = pos;
+      len = len;
+    }
+  ;;
+
+  let of_string ?pos ?len str =
+    let str_len = String.length str in
+    get_iovec "IOVec.of_string" ?pos ?len str_len str
+  ;;
+
+  let of_bigstring ?pos ?len bstr =
+    let bstr_len = Array1.dim bstr in
+    get_iovec "IOVec.of_bigstring" ?pos ?len bstr_len bstr
+  ;;
+
+  let drop iovec n =
+    if n > iovec.len then failwith "IOVec.drop: n > length iovec"
+    else
+      {
+        buf = iovec.buf;
+        pos = iovec.pos + n;
+        len = iovec.len - n;
+      }
+  ;;
+
+  let max_iovecs =
+    let n64 = sysconf IOV_MAX in
+    if n64 > Int64.of_int Array.max_length then Array.max_length
+    else Int64.to_int_exn n64
+  ;;
+end
+
+let get_iovec_count loc iovecs = function
+  | None -> Array.length iovecs
+  | Some count ->
+      if count < 0 then invalid_arg (loc ^ ": count < 0");
+      let n_iovecs = Array.length iovecs in
+      if count > n_iovecs then invalid_arg (loc ^ ": count > n_iovecs");
+      count
+;;
+
+external unsafe_writev_assume_fd_is_nonblocking
+  : File_descr.t -> string IOVec.t array -> int -> int
+  = "unix_writev_assume_fd_is_nonblocking_stub"
+;;
+
+let writev_assume_fd_is_nonblocking fd ?count iovecs =
+  let count = get_iovec_count "writev_assume_fd_is_nonblocking" iovecs count in
+  unsafe_writev_assume_fd_is_nonblocking fd iovecs count
+;;
+
+external unsafe_writev
+  : File_descr.t -> string IOVec.t array -> int -> int = "unix_writev_stub"
+;;
+
+let writev fd ?count iovecs =
+  let count = get_iovec_count "writev" iovecs count in
+  unsafe_writev fd iovecs count
+;;
+
+external pselect
+  :    File_descr.t list
+    -> File_descr.t list
+    -> File_descr.t list
+    -> float
+    -> int list
+    -> File_descr.t list * File_descr.t list * File_descr.t list
+  = "unix_pselect_stub"
+;;
+
+(* Temporary file and directory creation *)
+external mkstemp : string -> string * File_descr.t = "unix_mkstemp"
+external mkdtemp : string -> string = "unix_mkdtemp"
+
+(* Signal handling *)
+
+external abort : unit -> 'a = "unix_abort" [@@noalloc]
+
+(* User id, group id management *)
+
+external initgroups : string -> int -> unit = "unix_initgroups"
+
+external getgrouplist : string -> int -> int array = "unix_getgrouplist"
+
+(** Globbing and shell word expansion *)
+
+module Fnmatch_flags = struct
+  type _flag = [
+    | `No_escape
+    | `Pathname
+    | `Period
+    | `File_name
+    | `Leading_dir
+    | `Casefold
+  ]
+  [@@deriving sexp]
+
+  let flag_to_internal = function
+    | `No_escape -> 0
+    | `Pathname -> 1
+    | `Period -> 2
+    | `File_name -> 3
+    | `Leading_dir -> 4
+    | `Casefold -> 5
+  ;;
+
+  type t = int32 [@@deriving sexp]
+
+  external internal_make : int array -> t = "unix_fnmatch_make_flags"
+
+  let make = function
+    | None | Some [] -> Int32.zero
+    | Some flags -> internal_make (Array.map ~f:flag_to_internal (Array.of_list flags))
+  ;;
+end
+
+external fnmatch
+  : Fnmatch_flags.t -> pat : string -> string -> bool = "unix_fnmatch"
+;;
+
+let fnmatch ?flags ~pat fname = fnmatch (Fnmatch_flags.make flags) ~pat fname
+
+#ifdef JSC_WORDEXP
+
+module Wordexp_flags = struct
+  type _flag = [ `No_cmd | `Show_err | `Undef ] [@@deriving sexp]
+
+  let flag_to_internal = function
+    | `No_cmd -> 0
+    | `Show_err -> 1
+    | `Undef -> 2
+  ;;
+
+  type t = int32 [@@deriving sexp]
+
+  external internal_make : int array -> t = "unix_wordexp_make_flags"
+
+  let make = function
+    | None | Some [] -> Int32.zero
+    | Some flags -> internal_make (Array.map ~f:flag_to_internal (Array.of_list flags))
+  ;;
+end
+
+external wordexp : Wordexp_flags.t -> string -> string array = "unix_wordexp"
+
+let wordexp = Ok (fun ?flags str -> wordexp (Wordexp_flags.make flags) str)
+
+#else
+
+let wordexp = Or_error.unimplemented "Unix.wordexp"
+
+#endif
+
+(* System information *)
+
+module Utsname = struct
+  type t =
+    { sysname: string;
+      nodename: string;
+      release: string;
+      version: string;
+      machine: string;
+    }
+  [@@deriving fields, sexp]
+end
+
+external uname : unit -> Utsname.t = "unix_uname"
+
+module Scheduler = struct
+  module Policy = struct
+    type t = [ `Fifo | `Round_robin | `Other ] [@@deriving sexp]
+
+    module Ordered = struct
+      type t = Fifo | Round_robin | Other [@@deriving sexp]
+      let create = function
+        | `Fifo -> Fifo
+        | `Round_robin -> Round_robin
+        | `Other -> Other
+      ;;
+    end
+  end
+
+  external set
+    : pid : int -> policy : Policy.Ordered.t -> priority : int -> unit
+    = "unix_sched_setscheduler"
+  ;;
+
+  let set ~pid ~policy ~priority =
+    let pid =
+      match pid with
+      | None -> 0
+      | Some pid -> Pid.to_int pid
+    in
+    set ~pid ~policy:(Policy.Ordered.create policy) ~priority
+  ;;
+end
+
+module Priority = struct
+  external nice : int -> int = "unix_nice"
+end
+
+module Mman = struct
+  module Mcl_flags = struct
+    type t =
+      (* Do not change the ordering of this type without also
+         changing the C stub. *)
+      | Current
+      | Future
+    [@@deriving sexp]
+  end
+  external unix_mlockall   : Mcl_flags.t array -> unit = "unix_mlockall" ;;
+  external unix_munlockall : unit -> unit = "unix_munlockall" ;;
+
+  let mlockall flags = unix_mlockall (List.to_array flags) ;;
+  let munlockall = unix_munlockall ;;
+end ;;
+
+let dirname_r filename = ("dirname", atom filename)
+let filename_r filename = ("filename", atom filename)
+let file_perm_r perm = ("perm", atom (Printf.sprintf "0o%o" perm))
+let len_r len = ("len", Int.sexp_of_t len)
+let uid_r uid = ("uid", Int.sexp_of_t uid)
+let gid_r gid = ("gid", Int.sexp_of_t gid)
+let fd_r fd = ("fd", File_descr.sexp_of_t fd)
+let dir_handle_r handle =
+  let fd =
+    try File_descr.sexp_of_t (dirfd handle)
+    with _ -> Int.sexp_of_t (-1)
+  in
+  ("dir_handle", fd)
+;;
+
+let unary ?restart make_r f =
+  ();
+  fun x -> improve ?restart (fun () -> f x) (fun () -> [make_r x])
+;;
+
+let unary_fd ?restart f = unary ?restart fd_r f
+let unary_filename ?restart f = unary ?restart filename_r f
+let unary_dirname ?restart f = unary ?restart dirname_r f
+let unary_dir_handle ?restart f = unary ?restart dir_handle_r f
+
+include Unix_error
+
+module Syscall_result = Syscall_result
+
+exception Unix_error = Unix.Unix_error
+
+external unix_error : int -> string -> string -> _ = "unix_error_stub"
+let error_message = Unix.error_message
+let handle_unix_error f = Unix.handle_unix_error f ()
+let environment = Unix.environment
+
+module Error = struct
+  type t = Unix.error =
+    | E2BIG               (** Argument list too long *)
+    | EACCES              (** Permission denied *)
+    | EAGAIN              (** Resource temporarily unavailable; try again *)
+    | EBADF               (** Bad file descriptor *)
+    | EBUSY               (** Resource unavailable *)
+    | ECHILD              (** No child process *)
+    | EDEADLK             (** Resource deadlock would occur *)
+    | EDOM                (** Domain error for math functions, etc. *)
+    | EEXIST              (** File exists *)
+    | EFAULT              (** Bad address *)
+    | EFBIG               (** File too large *)
+    | EINTR               (** Function interrupted by signal *)
+    | EINVAL              (** Invalid argument *)
+    | EIO                 (** Hardware I/O error *)
+    | EISDIR              (** Is a directory *)
+    | EMFILE              (** Too many open files by the process *)
+    | EMLINK              (** Too many links *)
+    | ENAMETOOLONG        (** Filename too long *)
+    | ENFILE              (** Too many open files in the system *)
+    | ENODEV              (** No such device *)
+    | ENOENT              (** No such file or directory *)
+    | ENOEXEC             (** Not an executable file *)
+    | ENOLCK              (** No locks available *)
+    | ENOMEM              (** Not enough memory *)
+    | ENOSPC              (** No space left on device *)
+    | ENOSYS              (** Function not supported *)
+    | ENOTDIR             (** Not a directory *)
+    | ENOTEMPTY           (** Directory not empty *)
+    | ENOTTY              (** Inappropriate I/O control operation *)
+    | ENXIO               (** No such device or address *)
+    | EPERM               (** Operation not permitted *)
+    | EPIPE               (** Broken pipe *)
+    | ERANGE              (** Result too large *)
+    | EROFS               (** Read-only file system *)
+    | ESPIPE              (** Invalid seek e.g. on a pipe *)
+    | ESRCH               (** No such process *)
+    | EXDEV               (** Invalid link *)
+
+    | EWOULDBLOCK         (** Operation would block *)
+    | EINPROGRESS         (** Operation now in progress *)
+    | EALREADY            (** Operation already in progress *)
+    | ENOTSOCK            (** Socket operation on non-socket *)
+    | EDESTADDRREQ        (** Destination address required *)
+    | EMSGSIZE            (** Message too long *)
+    | EPROTOTYPE          (** Protocol wrong type for socket *)
+    | ENOPROTOOPT         (** Protocol not available *)
+    | EPROTONOSUPPORT     (** Protocol not supported *)
+    | ESOCKTNOSUPPORT     (** Socket type not supported *)
+    | EOPNOTSUPP          (** Operation not supported on socket *)
+    | EPFNOSUPPORT        (** Protocol family not supported *)
+    | EAFNOSUPPORT        (** Address family not supported by protocol family *)
+    | EADDRINUSE          (** Address already in use *)
+    | EADDRNOTAVAIL       (** Can't assign requested address *)
+    | ENETDOWN            (** Network is down *)
+    | ENETUNREACH         (** Network is unreachable *)
+    | ENETRESET           (** Network dropped connection on reset *)
+    | ECONNABORTED        (** Software caused connection abort *)
+    | ECONNRESET          (** Connection reset by peer *)
+    | ENOBUFS             (** No buffer space available *)
+    | EISCONN             (** Socket is already connected *)
+    | ENOTCONN            (** Socket is not connected *)
+    | ESHUTDOWN           (** Can't send after socket shutdown *)
+    | ETOOMANYREFS        (** Too many references: can't splice *)
+    | ETIMEDOUT           (** Connection timed out *)
+    | ECONNREFUSED        (** Connection refused *)
+    | EHOSTDOWN           (** Host is down *)
+    | EHOSTUNREACH        (** No route to host *)
+    | ELOOP               (** Too many levels of symbolic links *)
+    | EOVERFLOW           (** File size or position not representable *)
+
+    | EUNKNOWNERR of int  (** Unknown error *)
+  [@@deriving sexp]
+
+  let of_system_int ~errno = Unix_error.of_errno errno
+
+  let message = Unix.error_message
+end
+
+let putenv ~key ~data =
+  improve (fun () -> Unix.putenv key data)
+    (fun () -> [("key", atom key); ("data", atom data)])
+;;
+
+let unsetenv name =
+  (* The C unsetenv has only one error: EINVAL if name contains an '='
+     character. C strings are null terminated though so '\000' is also invalid.
+  *)
+  if String.contains name '\000' then
+    raise (Unix_error (EINVAL,"unsetenv",name));
+  unsetenv name
+;;
+
+type process_status = Unix.process_status =
+| WEXITED of int
+| WSIGNALED of int
+| WSTOPPED of int
+[@@deriving sexp]
+
+module Exit = struct
+  type error = [ `Exit_non_zero of int ] [@@deriving compare, sexp]
+
+  type t = (unit, error) Result.t [@@deriving compare, sexp]
+
+  let to_string_hum = function
+    | Ok () -> "exited normally"
+    | Error (`Exit_non_zero i) -> sprintf "exited with code %d" i
+  ;;
+
+  let code = function
+    | Ok () -> 0
+    | Error (`Exit_non_zero i) -> i
+  ;;
+
+  exception Exit_code_must_be_nonnegative of int [@@deriving sexp]
+
+  let of_code code =
+    if code < 0 then
+      raise (Exit_code_must_be_nonnegative code)
+    else if code = 0 then
+      Ok ()
+    else
+      Error (`Exit_non_zero code)
+  ;;
+
+  let or_error = function
+    | Ok _ as ok  -> ok
+    | Error error -> Or_error.error "Unix.Exit" error sexp_of_error
+  ;;
+end
+
+module Exit_or_signal = struct
+  type error = [ Exit.error | `Signal of Signal.t ] [@@deriving compare, sexp]
+
+  type t = (unit, error) Result.t [@@deriving compare, sexp]
+
+  let to_string_hum = function
+    | Ok () | Error #Exit.error as e -> Exit.to_string_hum e
+    | Error (`Signal s) ->
+      sprintf "died after receiving %s (signal number %d)"
+        (Signal.to_string s) (Signal.to_system_int s)
+  ;;
+
+  exception Of_unix_got_invalid_status of process_status [@@deriving sexp]
+
+  let of_unix = function
+    | WEXITED i -> if i = 0 then Ok () else Error (`Exit_non_zero i)
+    | WSIGNALED i -> Error (`Signal (Signal.of_caml_int i))
+    | WSTOPPED _ as status -> raise (Of_unix_got_invalid_status status)
+  ;;
+
+  let or_error = function
+    | Ok _ as ok  -> ok
+    | Error error -> Or_error.error "Unix.Exit_or_signal" error sexp_of_error
+  ;;
+end
+
+module Exit_or_signal_or_stop = struct
+  type error = [ Exit_or_signal.error | `Stop of Signal.t ] [@@deriving sexp]
+
+  type t = (unit, error) Result.t [@@deriving sexp]
+
+  let to_string_hum = function
+    | Ok () | Error #Exit_or_signal.error as e -> Exit_or_signal.to_string_hum e
+    | Error (`Stop s) ->
+        sprintf "stopped by %s (signal number %d)"
+          (Signal.to_string s) (Signal.to_system_int s)
+  ;;
+
+  let of_unix = function
+    | WEXITED i -> if i = 0 then Ok () else Error (`Exit_non_zero i)
+    | WSIGNALED i -> Error (`Signal (Signal.of_caml_int i))
+    | WSTOPPED i -> Error (`Stop (Signal.of_caml_int i))
+  ;;
+
+  let or_error = function
+    | Ok _ as ok  -> ok
+    | Error error -> Or_error.error "Unix.Exit_or_signal_or_stop" error sexp_of_error
+  ;;
+end
+
+let prog_r prog = ("prog", atom prog)
+let args_r argv = ("argv", sexp_of_array atom argv)
+let env_r env = ("env", sexp_of_array atom env)
+
+let execv ~prog ~argv =
+  improve (fun () -> Unix.execv ~prog ~args:argv)
+    (fun () -> [prog_r prog; args_r argv])
+;;
+
+let execve ~prog ~argv ~env =
+  improve (fun () -> Unix.execve ~prog ~args:argv ~env)
+    (fun () -> [prog_r prog; args_r argv; env_r env])
+;;
+
+let execvp ~prog ~argv =
+  improve (fun () -> Unix.execvp ~prog ~args:argv)
+    (fun () -> [prog_r prog; args_r argv])
+;;
+
+let execvpe ~prog ~argv ~env =
+  improve (fun () -> Unix.execvpe ~prog ~args:argv ~env)
+    (fun () -> [prog_r prog; args_r argv; env_r env])
+;;
+
+type env =
+  [ `Replace of (string * string) list
+  | `Extend of (string * string) list
+  | `Replace_raw of string list
+  ]
+[@@deriving sexp]
+
+let env_map env =
+  let current, env =
+    match env with
+    | `Replace env -> [], env
+    | `Extend env ->
+      let current =
+        List.map (Array.to_list (Unix.environment ()))
+          ~f:(fun s -> String.lsplit2_exn s ~on:'=')
+      in
+      current, env
+  in
+  List.fold_left (current @ env) ~init:String.Map.empty
+    ~f:(fun map (key, data) -> Map.add map ~key ~data)
+;;
+
+let env_assignments env =
+  match env with
+  | `Replace_raw env -> env
+  | `Replace _
+  | `Extend  _ as env ->
+    Map.fold (env_map env) ~init:[]
+      ~f:(fun ~key ~data acc -> (key ^ "=" ^ data) :: acc)
+;;
+
+(* Linux allows arbitrary strings to be passed as environment entries: they don't even
+   have to contain the '=' character.
+   You can also pass the same variable multiple times and that's somehow fine. Most
+   programs (in particular, C stdlib) will use the first entry if there are multiple. *)
+let lookup_raw env key =
+  List.find_map env ~f:(fun x ->
+    match String.lsplit2 x ~on:'=' with
+    | None -> None
+    | Some (key2, value) ->
+      if String.(=) key key2
+      then Some value
+      else None)
+;;
+
+let env_lookup env key =
+  match env with
+  | `Extend  _
+  | `Replace _ as env -> Map.find (env_map env) key
+  | `Replace_raw raw_env -> lookup_raw raw_env key
+;;
+
+let exec ~prog ~argv ?(use_path = true) ?env () =
+  let argv = Array.of_list argv in
+  let env = Option.map env ~f:(Fn.compose Array.of_list env_assignments) in
+  match use_path, env with
+  | false, None -> execv ~prog ~argv
+  | false, Some env -> execve ~prog ~argv ~env
+  | true, None -> execvp ~prog ~argv
+  | true, Some env -> execvpe ~prog ~argv ~env
+;;
+
+exception Fork_returned_negative_result of int [@@deriving sexp]
+
+let fork () =
+  let pid = Unix.fork () in
+  if pid < 0 then
+    raise (Fork_returned_negative_result pid)
+  else if pid = 0 then
+    `In_the_child
+  else
+    `In_the_parent (Pid.of_int pid)
+;;
+
+(* Same as [Pervasives.exit] but does not run at_exit handlers *)
+external sys_exit : int -> 'a = "caml_sys_exit"
+
+let fork_exec ~prog ~argv ?use_path ?env () =
+  match fork () with
+  | `In_the_child ->
+    never_returns (
+      try exec ~prog ~argv ?use_path ?env ()
+      with _ -> sys_exit 127
+    )
+  | `In_the_parent pid -> pid
+;;
+
+type wait_flag =
+  Unix.wait_flag =
+| WNOHANG
+| WUNTRACED
+[@@deriving sexp]
+
+type wait_on =
+  [ `Any
+  | `My_group
+  | `Group of Pid.t
+  | `Pid of Pid.t
+  ]
+[@@deriving sexp]
+
+type mode = wait_flag list [@@deriving sexp_of]
+type _t = mode
+
+type waitpid_result = (Pid.t * Exit_or_signal_or_stop.t) option [@@deriving sexp_of]
+
+let wait_gen
+    ~mode
+    (type a) (f : waitpid_result -> a option)
+    ~restart
+    wait_on : a =
+  let pid =
+    match wait_on with
+    | `Any -> -1
+    | `Group pid -> - (Pid.to_int pid)
+    | `My_group -> 0
+    | `Pid pid -> Pid.to_int pid
+  in
+  let (pid, status) =
+    improve ~restart
+      (fun () ->
+        let x, ps = Unix.waitpid ~mode pid in
+        (x, Exit_or_signal_or_stop.of_unix ps))
+      (fun () ->
+        [("mode", sexp_of_list sexp_of_wait_flag mode);
+         ("pid", Int.sexp_of_t pid)])
+  in
+  let waitpid_result =
+    if pid = 0 then
+      None
+    else begin
+      let pid = Pid.of_int pid in
+      Some (pid, status)
+    end
+  in
+  match f waitpid_result with
+  | Some a -> a
+  | None ->
+    failwiths "waitpid syscall returned invalid result for mode"
+      (pid, mode, waitpid_result)
+      ([%sexp_of: int * mode * waitpid_result])
+;;
+
+let wait ?(restart=true) pid =
+  let f = function
+    | Some ((_, (Ok _ | Error #Exit_or_signal.error)) as x) -> Some x
+    | _ -> None
+  in
+  wait_gen ~restart ~mode:[] f pid
+;;
+
+let wait_nohang pid =
+  let f = function
+    | None | Some ((_, (Ok _ | Error #Exit_or_signal.error))) as x -> Some x
+    | _ -> None
+  in
+  wait_gen ~mode:[WNOHANG] ~restart:true f pid
+;;
+
+let wait_untraced ?(restart=true) pid =
+  wait_gen ~restart ~mode:[WUNTRACED] Fn.id pid
+
+let wait_nohang_untraced pid =
+  wait_gen ~mode:[WNOHANG; WUNTRACED] Option.some ~restart:true pid
+
+let waitpid pid =
+  let (pid', exit_or_signal) = wait (`Pid pid) in
+  assert (pid = pid');
+  exit_or_signal;
+;;
+
+let waitpid_exn pid =
+  let exit_or_signal = waitpid pid in
+  if Result.is_error exit_or_signal then
+    failwiths "child process didn't exit with status zero"
+      (`Child_pid pid, exit_or_signal)
+      ([%sexp_of: [ `Child_pid of Pid.t ] * Exit_or_signal.t])
+;;
+
+let system s =
+  improve (fun () -> Exit_or_signal.of_unix (Unix.system s))
+    (fun () -> [("command", atom s)])
+;;
+
+let getpid () = Pid.of_int (Unix.getpid ())
+
+let getppid () =
+  match Unix.getppid () with
+  | x when x < 1 -> None
+  | x -> Some (Pid.of_int x)
+
+let getppid_exn () =
+  Option.value_exn ~message:"You don't have a parent process"
+    (getppid ())
+
+module Thread_id = Int
+
+#if JSC_THREAD_ID_METHOD > 0
+external gettid : unit -> Thread_id.t = "unix_gettid"
+let gettid = Ok gettid
+#else
+let gettid = Or_error.unimplemented "gettid is not supported on this system"
+#endif
+
+let nice i =
+  improve (fun () -> Unix.nice i)
+    (fun () -> [("priority", Int.sexp_of_t i)])
+;;
+
+let stdin = Unix.stdin
+let stdout = Unix.stdout
+let stderr = Unix.stderr
+
+type open_flag =
+Unix.open_flag =
+| O_RDONLY
+| O_WRONLY
+| O_RDWR
+| O_NONBLOCK
+| O_APPEND
+| O_CREAT
+| O_TRUNC
+| O_EXCL
+| O_NOCTTY
+| O_DSYNC
+| O_SYNC
+| O_RSYNC
+| O_SHARE_DELETE
+| O_CLOEXEC
+#if ocaml_version >= (4, 05, 0)
+| O_KEEPEXEC
+#endif
+[@@deriving sexp]
+
+type file_perm = int [@@deriving of_sexp]
+
+(* Prints out in octal, which is much more standard in Unix. *)
+let sexp_of_file_perm fp = Sexp.Atom (Printf.sprintf "0o%03o" fp)
+
+let is_rw_open_flag = function O_RDONLY | O_WRONLY | O_RDWR -> true | _ -> false
+
+let openfile ?(perm = 0o644) ~mode filename =
+  let mode_sexp () = sexp_of_list sexp_of_open_flag mode in
+  if not (List.exists mode ~f:is_rw_open_flag) then
+    failwithf "Unix.openfile: no read or write flag specified in mode: %s"
+      (Sexp.to_string (mode_sexp ())) ()
+  else
+    improve (fun () -> Unix.openfile filename ~mode ~perm)
+      (fun () -> [filename_r filename;
+                  ("mode", mode_sexp ());
+                  file_perm_r perm])
+;;
+
+let close ?restart = unary_fd ?restart Unix.close
+
+let with_close fd ~f = protect ~f:(fun () -> f fd) ~finally:(fun () -> close fd)
+
+let with_file ?perm file ~mode ~f = with_close (openfile file ~mode ?perm) ~f
+
+let read_write f ?restart ?pos ?len fd ~buf =
+  let pos, len =
+    Ordered_collection_common.get_pos_len_exn ?pos ?len ~length:(String.length buf)
+  in
+  improve ?restart (fun () -> f fd ~buf ~pos ~len)
+    (fun () -> [fd_r fd; ("pos", Int.sexp_of_t pos); len_r len])
+;;
+
+let read = read_write Unix.read
+
+let write = read_write Unix.write ?restart:None
+
+let single_write = read_write Unix.single_write
+
+let in_channel_of_descr = Unix.in_channel_of_descr
+let out_channel_of_descr = Unix.out_channel_of_descr
+let descr_of_in_channel = Unix.descr_of_in_channel
+let descr_of_out_channel = Unix.descr_of_out_channel
+
+type seek_command =
+Unix.seek_command =
+| SEEK_SET
+| SEEK_CUR
+| SEEK_END
+[@@deriving sexp]
+
+type file_kind = Unix.file_kind =
+| S_REG
+| S_DIR
+| S_CHR
+| S_BLK
+| S_LNK
+| S_FIFO
+| S_SOCK
+[@@deriving sexp]
+
+let isatty = unary_fd Unix.isatty
+
+module Native_file = struct
+  type stats =
+  Unix.stats = {
+    st_dev : int;
+    st_ino : int;
+    st_kind : file_kind;
+    st_perm : file_perm;
+    st_nlink : int;
+    st_uid : int;
+    st_gid : int;
+    st_rdev : int;
+    st_size : int;
+    st_atime : float;
+    st_mtime : float;
+    st_ctime : float;
+  } [@@deriving sexp]
+
+  let stat = unary_filename Unix.stat
+  let lstat = unary_filename Unix.lstat
+  let fstat = unary_fd Unix.fstat
+
+  let lseek fd pos ~mode =
+    improve (fun () -> Unix.lseek fd pos ~mode)
+      (fun () -> [fd_r fd;
+                  ("pos", Int.sexp_of_t pos);
+                  ("mode", sexp_of_seek_command mode)])
+  ;;
+
+  let truncate filename ~len =
+    improve (fun () -> Unix.truncate filename ~len)
+      (fun () -> [filename_r filename; len_r len])
+  ;;
+
+  let ftruncate fd ~len =
+    improve (fun () -> Unix.ftruncate fd ~len)
+      (fun () -> [fd_r fd; len_r len])
+  ;;
+end
+
+type lock_command =
+  Unix.lock_command =
+  | F_ULOCK
+  | F_LOCK
+  | F_TLOCK
+  | F_TEST
+  | F_RLOCK
+  | F_TRLOCK
+[@@deriving sexp]
+
+let lockf fd ~mode ~len =
+  let len =
+    try Int64.to_int_exn len with _ ->
+      failwith "~len passed to Unix.lockf too large to fit in native int"
+  in
+  improve (fun () -> Unix.lockf fd ~mode ~len)
+    (fun () -> [fd_r fd;
+                ("mode", sexp_of_lock_command mode);
+                len_r len])
+;;
+
+module Flock_command : sig
+  type t
+
+  val lock_shared : t
+  val lock_exclusive : t
+  val unlock : t
+end = struct
+  type t = int
+
+  (* The constants are used in the [core_unix_flock] C code. *)
+  let lock_shared = 0
+  let lock_exclusive = 1
+  let unlock = 2
+end
+
+external flock : File_descr.t -> Flock_command.t -> bool = "core_unix_flock"
+
+let lseek fd pos ~mode =
+  improve (fun () -> Unix.LargeFile.lseek fd pos ~mode)
+    (fun () -> [fd_r fd;
+                ("pos", Int64.sexp_of_t pos);
+                ("mode", sexp_of_seek_command mode)])
+;;
+
+let len64_r len = ("len", Int64.sexp_of_t len)
+
+let truncate filename ~len =
+  improve (fun () -> Unix.LargeFile.truncate filename ~len)
+    (fun () -> [filename_r filename; len64_r len])
+;;
+
+let ftruncate fd ~len =
+  improve (fun () -> Unix.LargeFile.ftruncate fd ~len)
+    (fun () -> [fd_r fd; len64_r len])
+;;
+
+type stats =
+Unix.LargeFile.stats = {
+  st_dev : int;
+  st_ino : int;
+  st_kind : file_kind;
+  st_perm : file_perm;
+  st_nlink : int;
+  st_uid : int;
+  st_gid : int;
+  st_rdev : int;
+  st_size : int64;
+  st_atime : float;
+  st_mtime : float;
+  st_ctime : float;
+} [@@deriving sexp]
+
+let stat  = unary_filename Unix.LargeFile.stat
+let lstat = unary_filename Unix.LargeFile.lstat
+let fstat = unary_fd       Unix.LargeFile.fstat
+
+let src_dst f ~src ~dst =
+  improve (fun () -> f ~src ~dst)
+    (fun () -> [("src", atom src); ("dst", atom dst)])
+;;
+
+let unlink = unary_filename Unix.unlink
+
+let rename = src_dst Unix.rename
+
+let link ?(force = false) ~target ~link_name () =
+  improve
+    (fun () ->
+      if force then begin
+        try Unix.unlink link_name
+        with Unix_error (Unix.ENOENT, _, _) -> ()
+      end;
+      Unix.link ~src:target ~dst:link_name)
+    (fun () -> [("target", atom target); ("link_name", atom link_name)])
+;;
+
+type access_permission = Unix.access_permission =
+  | R_OK
+  | W_OK
+  | X_OK
+  | F_OK
+[@@deriving sexp]
+
+let chmod filename ~perm =
+  improve (fun () -> Unix.chmod filename ~perm)
+    (fun () -> [filename_r filename; file_perm_r perm])
+;;
+
+let fchmod fd ~perm =
+  improve (fun () -> Unix.fchmod fd ~perm)
+    (fun () -> [fd_r fd; file_perm_r perm])
+;;
+
+let chown filename ~uid ~gid =
+  improve (fun () -> Unix.chown filename ~uid ~gid)
+    (fun () -> [filename_r filename; uid_r uid; gid_r gid])
+;;
+
+let fchown fd ~uid ~gid =
+  improve (fun () -> Unix.fchown fd ~uid ~gid)
+    (fun () -> [fd_r fd; uid_r uid; gid_r gid])
+;;
+
+let umask mode =
+  improve (fun () -> Unix.umask mode)
+    (fun () -> [("mode", atom (Printf.sprintf "0o%o" mode))])
+;;
+
+let access filename ~perm =
+  improve (fun () -> Unix.access filename ~perm)
+    (fun () -> [filename_r filename;
+                ("perm", sexp_of_list sexp_of_access_permission perm)])
+;;
+
+let access filename perm =
+  Result.try_with (fun () ->
+    access filename
+      ~perm:(List.map perm ~f:(function
+        | `Read -> Unix.R_OK
+        | `Write -> Unix.W_OK
+        | `Exec -> Unix.X_OK
+        | `Exists -> Unix.F_OK)))
+;;
+
+let access_exn filename perm = Result.ok_exn (access filename perm)
+
+external remove : string -> unit = "core_unix_remove"
+let remove = unary_filename remove
+
+let%test _ =
+  let dir = Core_filename.temp_dir "remove_test" "" in
+  let file = dir ^/ "test" in
+  Out_channel.write_all (dir ^ "/test") ~data:"testing Core.Unix.remove";
+  remove file;
+  remove dir;
+  Result.is_error (access file [`Exists])
+  && Result.is_error (access dir [`Exists])
+
+let dup = unary_fd Unix.dup
+
+let dup2 ~src ~dst =
+  improve (fun () -> UnixNoLabels.dup2 src dst)
+    (fun () -> [("src", File_descr.sexp_of_t src);
+                ("dst", File_descr.sexp_of_t dst)])
+;;
+
+let%test_unit "fork_exec ~env last binding takes precedence" =
+  protectx ~finally:remove (Filename.temp_file "test" "fork_exec.env.last-wins")
+    ~f:(fun temp_file ->
+      let env = [ "VAR", "first"; "VAR", "last" ] in
+      List.iter
+        [ `Replace_raw (List.map env ~f:(fun (v, s) -> v ^ "=" ^ s))
+        ; `Replace env
+        ; `Extend env
+        ]
+        ~f:(fun env ->
+          waitpid_exn
+            (fork_exec () ~env ~prog:"sh"
+               ~argv:[ "sh"; "-c"; "echo $VAR > " ^ temp_file ]);
+          [%test_result: string] ~expect:"last\n" (In_channel.read_all temp_file)))
+
+let set_nonblock = unary_fd Unix.set_nonblock
+let clear_nonblock = unary_fd Unix.clear_nonblock
+let set_close_on_exec = unary_fd Unix.set_close_on_exec
+let clear_close_on_exec = unary_fd Unix.clear_close_on_exec
+
+module Open_flags = struct
+  external append    : unit -> Int63.t = "unix_O_APPEND"
+  external async     : unit -> Int63.t = "unix_O_ASYNC"
+  external cloexec   : unit -> Int63.t = "unix_O_CLOEXEC"
+  external creat     : unit -> Int63.t = "unix_O_CREAT"
+  external direct    : unit -> Int63.t = "unix_O_DIRECT"
+  external directory : unit -> Int63.t = "unix_O_DIRECTORY"
+  external dsync     : unit -> Int63.t = "unix_O_DSYNC"
+  external excl      : unit -> Int63.t = "unix_O_EXCL"
+  external noatime   : unit -> Int63.t = "unix_O_NOATIME"
+  external noctty    : unit -> Int63.t = "unix_O_NOCTTY"
+  external nofollow  : unit -> Int63.t = "unix_O_NOFOLLOW"
+  external nonblock  : unit -> Int63.t = "unix_O_NONBLOCK"
+  external rdonly    : unit -> Int63.t = "unix_O_RDONLY"
+  external rdwr      : unit -> Int63.t = "unix_O_RDWR"
+  external rsync     : unit -> Int63.t = "unix_O_RSYNC"
+  external sync      : unit -> Int63.t = "unix_O_SYNC"
+  external trunc     : unit -> Int63.t = "unix_O_TRUNC"
+  external wronly    : unit -> Int63.t = "unix_O_WRONLY"
+
+  let append    = append    ()
+  let async     = async     ()
+  let cloexec   = cloexec   ()
+  let creat     = creat     ()
+  let direct    = direct    ()
+  let directory = directory ()
+  let dsync     = dsync     ()
+  let excl      = excl      ()
+  let noatime   = noatime   ()
+  let noctty    = noctty    ()
+  let nofollow  = nofollow  ()
+  let nonblock  = nonblock  ()
+  let rdonly    = rdonly    ()
+  let rdwr      = rdwr      ()
+  let rsync     = rsync     ()
+  let sync      = sync      ()
+  let trunc     = trunc     ()
+  let wronly    = wronly    ()
+
+  let known =
+    [
+      append,    "append";
+      async,     "async";
+      cloexec,   "cloexec";
+      creat,     "creat";
+      direct,    "direct";
+      directory, "directory";
+      dsync,     "dsync";
+      excl,      "excl";
+      noatime,   "noatime";
+      noctty,    "noctty";
+      nofollow,  "nofollow";
+      nonblock,  "nonblock";
+      rsync,     "rsync";
+      sync,      "sync";
+      trunc,     "trunc";
+
+    (* We handle the access modes separately from the standard [Flags.sexp_of_t],
+       because they are multibit and include the [rdonly] flag, which is zero, which
+       [Flags] doesn't allow. *)
+
+    ]
+  ;;
+
+  let access_modes =
+    [ rdonly,    "rdonly";
+      rdwr,      "rdwr";
+      wronly,    "wronly";
+    ]
+  ;;
+
+  include Flags.Make (struct
+    let allow_intersecting = true
+    let should_print_error = true
+    let known = known
+    let remove_zero_flags = true
+    (* remove non existing flags, like cloexec on centos5 *)
+  end)
+
+  (* The lower two bits of the open flags are used to specify the access mode:
+     rdonly, wronly, rdwr.  So, we have some code to treat those two bits together rather
+     than as two separate bit flags. *)
+
+  let access_mode t = Int63.bit_and t (Int63.of_int 3)
+
+  let can_read t = access_mode t = rdonly || access_mode t = rdwr
+
+  let%test _ = can_read rdonly
+  let%test _ = can_read rdwr
+  let%test _ = not (can_read wronly)
+
+  let can_write t = access_mode t = wronly || access_mode t = rdwr
+
+  let%test _ = can_write wronly
+  let%test _ = can_write rdwr
+  let%test _ = not (can_write rdonly)
+
+  let sexp_of_t t =
+    let a = access_mode t in
+    let t, prefix =
+      match List.find access_modes ~f:(fun (a', _) -> a = a') with
+      | None -> t, []
+      | Some (_, name) -> t - a, [Sexp.Atom name]
+    in
+    let rest =
+      match sexp_of_t t with
+      | Sexp.Atom _ as s -> [s]
+      | Sexp.List l -> l
+    in
+    Sexp.List (prefix @ rest)
+  ;;
+
+  let check t string =
+    let sexp1 = sexp_of_t t in
+    let sexp2 = Sexp.of_string string in
+    if Sexp.(<>) sexp1 sexp2 then
+      failwiths "unequal sexps" (sexp1, sexp2) [%sexp_of: Sexp.t * Sexp.t];
+  ;;
+
+  let%test_unit _ = check rdonly            "(rdonly)"
+  let%test_unit _ = check wronly            "(wronly)"
+  let%test_unit _ = check rdwr              "(rdwr)"
+  let%test_unit _ = check append            "(rdonly append)"
+  let%test_unit _ = check (wronly + append) "(wronly append)"
+end
+
+let fcntl_getfl, fcntl_setfl =
+  let module M = struct
+    external unix_fcntl : Unix.file_descr -> Int63.t -> Int63.t -> Int63.t = "unix_fcntl"
+    external getfl : unit -> Int63.t = "unix_F_GETFL"
+    external setfl : unit -> Int63.t = "unix_F_SETFL"
+    let getfl = getfl ()
+    let setfl = setfl ()
+  end in
+  let open M in
+  let fcntl_getfl fd = unix_fcntl fd getfl Int63.zero in
+  let fcntl_setfl fd flags =
+    let result = unix_fcntl fd setfl flags in
+    (* [unix_fcntl] raised if there was an error, so if we're here, it must have returned
+       zero. *)
+    assert (result = Int63.zero);
+  in
+  fcntl_getfl, fcntl_setfl
+;;
+
+let%test_unit _ =
+  let test = "unix_test_file" in
+  let rm_test () = try unlink test with _ -> () in
+  rm_test ();
+  let fd = openfile test ~mode:[O_CREAT; O_WRONLY] in
+  let flags = fcntl_getfl fd in
+  assert (Open_flags.do_intersect flags Open_flags.wronly);
+  assert (Open_flags.are_disjoint flags Open_flags.append);
+  fcntl_setfl fd (Open_flags.(+) flags Open_flags.append);
+  assert (Open_flags.do_intersect (fcntl_getfl fd) Open_flags.append);
+  rm_test ()
+;;
+
+let mkdir ?(perm=0o777) dirname =
+  improve (fun () -> Unix.mkdir dirname ~perm)
+    (fun () -> [dirname_r dirname; file_perm_r perm])
+;;
+
+let mkdir_p ?perm dirname =
+  let mkdir_if_missing ?perm dir =
+    try
+      mkdir ?perm dir
+    with
+    (* [mkdir] on MacOSX returns [EISDIR] instead of [EEXIST] if the directory already
+       exists. *)
+    | Unix_error ((EEXIST | EISDIR), _, _) -> ()
+    | e -> raise e
+  in
+  let init,dirs =
+    match Core_filename.parts dirname with
+    | [] -> assert false
+    | init :: dirs -> (init, dirs)
+  in
+  mkdir_if_missing ?perm init;
+  let (_:string) = (* just using the fold for the side effects and accumulator *)
+    (* This must be [fold_left], not [fold_right]. *)
+    List.fold_left dirs ~init ~f:(fun acc dir ->
+      let dir = Filename.concat acc dir in
+      mkdir_if_missing ?perm dir;
+      dir)
+  in
+  ()
+;;
+
+let rmdir = unary_dirname Unix.rmdir
+let chdir = unary_dirname Unix.chdir
+let getcwd = Unix.getcwd
+let chroot = unary_dirname Unix.chroot
+
+type dir_handle = Unix.dir_handle
+
+let opendir ?restart = unary_dirname ?restart Unix.opendir
+let readdir = unary_dir_handle Unix.readdir (* Non-intr *)
+let readdir_opt dh =
+  match readdir dh with
+  | entry                 -> Some entry
+  | exception End_of_file -> None
+let rewinddir = unary_dir_handle Unix.rewinddir (* Non-intr *)
+(* if closedir is passed an already closed file handle it will try to call
+  dirfd on it to get a file descriptor for the error message, which will fail
+  with invalid argument because closedir sets the fd to null *)
+let closedir = (* Non-intr *)
+  unary_dir_handle (fun dh ->
+    try Unix.closedir dh with | Invalid_argument _ -> ())
+
+let pipe () = UnixNoLabels.pipe ()
+
+let mkfifo name ~perm =
+  improve (fun () -> Unix.mkfifo name ~perm)
+    (fun () -> [("name", atom name); file_perm_r perm])
+;;
+
+module Process_info = struct
+  (* Any change to the order of these fields must be accompanied by a
+     corresponding change to unix_stubs.c:ml_create_process. *)
+  type t =
+    { pid : Pid.t;
+      stdin : File_descr.t;
+      stdout : File_descr.t;
+      stderr : File_descr.t;
+    }
+  [@@deriving sexp]
+end
+
+let create_process_backend = ref (
+  match Core_sys.getenv "CORE_CREATE_PROCESS_DONT_USE_SPAWN_BACKEND_UNLESS_TOLD_TO" with
+  | None ->
+    `spawn_vfork
+  | Some _ ->
+    match Core_sys.getenv "CORE_CREATE_PROCESS_USE_SPAWN_BACKEND" with
+    | None -> `ml_create_process
+    | Some _ ->
+      `spawn_vfork)
+;;
+
+external create_process_old
+  :  ?working_dir : string
+  -> prog        : string
+  -> args : string array
+  -> env : string array
+  -> search_path : bool
+  -> Process_info.t
+  = "ml_create_process"
+;;
+
+let create_process_internal
+  :  working_dir : string option
+  -> prog        : string
+  -> argv        : string list
+  -> env         : string list
+  -> Process_info.t
+  =
+  fun ~working_dir ~prog ~argv ~env ->
+    let close_on_err = ref [] in
+    let safe_pipe () =
+      let (fd_read, fd_write) as result = Spawn.safe_pipe () in
+      close_on_err := fd_read :: fd_write :: !close_on_err;
+      result
+    in
+    try
+      let in_read,  in_write  = safe_pipe () in
+      let out_read, out_write = safe_pipe () in
+      let err_read, err_write = safe_pipe () in
+      let pid =
+        Spawn.spawn
+          ?cwd:(Option.map working_dir ~f:(fun x -> Spawn.Working_dir.Path x))
+          ~prog
+          ~argv
+          ~env
+          ~stdin:in_read
+          ~stdout:out_write
+          ~stderr:err_write
+          ()
+        |> Pid.of_int
+      in
+      close in_read; close out_write; close err_write;
+      { pid; stdin = in_write; stdout = out_read; stderr = err_read; }
+    with exn ->
+      List.iter !close_on_err ~f:(fun x -> try close x with _ -> ());
+      raise exn
+;;
+
+module Execvp_emulation : sig
+  (* This is a reimplementation of execvp semantics with two main differences:
+     - it does [spawn] instead of [execve] and returns its result on success
+     - it checks file existence and access rights before trying to spawn.
+     This optimization is valuable because a failed [spawn] is much more expensive than a
+     failed [execve]. *)
+  val run
+    :  working_dir : string option
+    -> spawn       : (prog:string -> argv:string list -> 'a)
+    -> env_lookup  : (string -> string option)
+    -> prog        : string
+    -> args        : string list
+    -> 'a
+
+end = struct
+
+  let get_path env_lookup =
+    env_lookup "PATH"
+    |> Option.value_map ~f:(String.split ~on:':') ~default:[""; "/bin"; "/usr/bin"]
+    |> List.map ~f:(function
+      | "" -> "."
+      | x  -> x)
+  ;;
+
+  let candidate_paths ~env_lookup prog =
+    (* [assert] is to make bugs less subtle if we try to make this
+       portable to non-POSIX in the future. *)
+    assert (Filename.dir_sep = "/");
+    if String.contains prog '/' then
+      [ prog ]
+    else
+      List.map (get_path env_lookup) ~f:(fun h -> h ^/ prog)
+  ;;
+
+  type 'a spawn1_result =
+    | Eaccess           of exn
+    | Enoent_or_similar of exn
+    | Ok                of 'a
+
+  let run ~working_dir ~spawn ~env_lookup ~prog ~args =
+    let argv = prog :: args in
+    let spawn1 candidate =
+      match
+        (try
+           Unix.access
+             (if not (Filename.is_relative candidate) then
+                candidate
+              else
+                match working_dir with
+                | Some working_dir -> working_dir ^/ candidate
+                | None -> candidate)
+             ~perm:[Unix.X_OK]
+         with Unix_error (code, _, args) ->
+           raise (Unix_error (code, "Core.Unix.create_process", args)));
+        spawn ~prog:candidate ~argv
+      with
+      | exception Unix_error (ENOEXEC, _, _) -> Ok (
+        (* As crazy as it looks, this is what execvp does. It's even documented in the man
+           page. *)
+        spawn
+          ~prog:"/bin/sh"
+          ~argv:("/bin/sh" :: candidate :: args))
+      | exception (Unix_error (EACCES, _, _) as exn) ->
+        Eaccess exn
+      | exception (Unix_error (
+        (ENOENT | (* ESTALE | *) ENOTDIR | ENODEV | ETIMEDOUT), _, _) as exn) ->
+        Enoent_or_similar exn
+      | pid -> Ok pid
+    in
+    let rec go first_eaccess = function
+      | [] -> assert false (* [candidate_paths] can't return an empty list *)
+      | [ candidate ] ->
+        (match spawn1 candidate with
+         | Eaccess exn
+         | Enoent_or_similar exn ->
+           raise (Option.value first_eaccess ~default:exn)
+         | Ok pid -> pid)
+      | candidate :: (_ :: _ as candidates) ->
+        match spawn1 candidate with
+        | Eaccess exn ->
+          let first_eaccess = Some (Option.value first_eaccess ~default:exn) in
+          go first_eaccess candidates
+        | Enoent_or_similar _exn ->
+          go first_eaccess candidates
+        | Ok pid -> pid
+    in
+    go None (candidate_paths ~env_lookup prog)
+  ;;
+end
+
+let create_process_env ?working_dir ~prog ~args ~env () =
+  let env_assignments = env_assignments env in
+  match !create_process_backend with
+  | `spawn_vfork ->
+    Execvp_emulation.run
+      ~prog
+      ~args
+      ~env_lookup:(env_lookup env)
+      ~working_dir
+      ~spawn:(fun ~prog ~argv ->
+        create_process_internal
+          ~working_dir
+          ~prog
+          ~argv
+          ~env:env_assignments)
+  | `ml_create_process ->
+    create_process_old
+      ?working_dir
+      ~search_path:true
+      ~prog
+      ~args:(Array.of_list args)
+      ~env:(Array.of_list env_assignments)
+
+let create_process_env ?working_dir ~prog ~args ~env () =
+  improve (fun () -> create_process_env ?working_dir ~prog ~args ~env ())
+    (fun () ->
+      [("prog", atom prog);
+       ("args", sexp_of_list atom args);
+       ("env", sexp_of_env env)])
+
+let create_process ~prog ~args =
+  improve (fun () -> create_process_env ~prog ~args ~env:(`Extend []) ())
+    (fun () ->
+      [("prog", atom prog);
+       ("args", sexp_of_list atom args)])
+
+let make_open_process f command =
+  improve (fun () -> f command)
+    (fun () -> [("command", atom command)])
+
+let open_process_in = make_open_process Unix.open_process_in
+let open_process_out = make_open_process Unix.open_process_out
+let open_process = make_open_process Unix.open_process
+
+module Process_channels = struct
+  type t = {
+    stdin : Out_channel.t;
+    stdout : In_channel.t;
+    stderr : In_channel.t;
+  }
+end
+
+let open_process_full command ~env =
+  improve (fun () ->
+    let stdout, stdin, stderr = Unix.open_process_full command ~env in
+    { Process_channels.stdin = stdin; stdout = stdout; stderr = stderr })
+    (fun () -> [("command", atom command);
+                ("env", sexp_of_array atom env)])
+;;
+
+let close_process_in ic = Exit_or_signal.of_unix (Unix.close_process_in ic)
+let close_process_out oc = Exit_or_signal.of_unix (Unix.close_process_out oc)
+
+let close_process (ic, oc) = Exit_or_signal.of_unix (Unix.close_process (ic, oc))
+
+let close_process_full c =
+  let module C = Process_channels in
+  Exit_or_signal.of_unix (Unix.close_process_full (c.C.stdout, c.C.stdin, c.C.stderr))
+;;
+
+let symlink = src_dst (fun ~src ~dst -> Unix.symlink ?to_dir:None ~src ~dst)
+let readlink = unary_filename Unix.readlink
+
+module Select_fds = struct
+  type t =
+    { read : File_descr.t list;
+      write : File_descr.t list;
+      except : File_descr.t list;
+    }
+  [@@deriving sexp_of]
+
+  let empty = { read = []; write = []; except = [] }
+end
+
+type select_timeout = [ `Never | `Immediately | `After of Time_ns.Span.t ]
+[@@deriving sexp_of]
+
+let select ?restart ~read ~write ~except ~timeout () =
+  improve ?restart (fun () ->
+    let timeout =
+      match timeout with
+      | `Never -> -1.
+      | `Immediately -> 0.
+      | `After span ->
+        if Time_ns.Span.( < ) span Time_ns.Span.zero
+        then 0.
+        else Time_ns.Span.to_sec span
+    in
+    let read, write, except = Unix.select ~read ~write ~except ~timeout in
+    { Select_fds. read; write; except })
+    (fun () ->
+       [("read", sexp_of_list File_descr.sexp_of_t read);
+        ("write", sexp_of_list File_descr.sexp_of_t write);
+        ("except", sexp_of_list File_descr.sexp_of_t except);
+        ("timeout", [%sexp_of: select_timeout] timeout)])
+;;
+
+let pause = Unix.pause
+
+type process_times =
+  Unix.process_times = {
+  tms_utime  : float;
+  tms_stime  : float;
+  tms_cutime : float;
+  tms_cstime : float;
+}
+[@@deriving sexp]
+
+
+type tm =
+    Unix.tm = {
+    (* DON'T CHANGE THIS RECORD WITHOUT UPDATING unix_time_stubs.c!!!
+
+       The compiler will notice if the runtime's Unix.tm changes, and we must then update
+       unix_time_stubs.c, not just this copy of the definition. *)
+    tm_sec   : int;
+    tm_min   : int;
+    tm_hour  : int;
+    tm_mday  : int;
+    tm_mon   : int;
+    tm_year  : int;
+    tm_wday  : int;
+    tm_yday  : int;
+    tm_isdst : bool;
+  } [@@deriving sexp]
+
+let time = Unix.time
+let gettimeofday = Unix.gettimeofday
+
+external strftime : Unix.tm -> string -> string = "core_time_ns_strftime"
+external localtime : float -> Unix.tm = "core_localtime"
+external gmtime    : float -> Unix.tm = "core_gmtime"
+external timegm    : Unix.tm -> float = "core_timegm" (* the inverse of gmtime *)
+
+let mktime = Unix.mktime
+let alarm  = Unix.alarm
+let sleep  = Unix.sleep
+let times  = Unix.times
+let utimes = Unix.utimes
+
+external strptime : fmt:string -> string -> Unix.tm = "unix_strptime"
+
+let%test_unit "record format hasn't changed" =
+  (* Exclude the time zone (%Z) because it depends on the location. *)
+  [%test_result: string] ~expect:"1907-07-05 04:03:08; wday=2; yday=010"
+    (strftime
+       { tm_sec = 8; tm_min = 3; tm_hour = 4; tm_mday = 5; tm_mon = 6; tm_year = 7;
+         tm_wday = 2; tm_yday = 9; tm_isdst = true }
+       "%F %T; wday=%u; yday=%j")
+
+let%test _ =
+  let res = strptime ~fmt:"%Y-%m-%d %H:%M:%S" "2012-05-23 10:14:23" in
+  let res =
+    (* fill in optional fields if they are missing *)
+    let tm_wday = if res.Unix.tm_wday = 0 then 3   else res.Unix.tm_wday in
+    let tm_yday = if res.Unix.tm_yday = 0 then 143 else res.Unix.tm_yday in
+    { res with Unix. tm_wday; tm_yday }
+  in
+  res = {Unix.
+    tm_sec   = 23;
+    tm_min   = 14;
+    tm_hour  = 10;
+    tm_mday  = 23;
+    tm_mon   = 4;
+    tm_year  = 2012 - 1900;
+    tm_wday  = 3;
+    tm_yday  = 143;
+    tm_isdst = false; }
+
+let%test _ =
+  try
+    ignore (strptime ~fmt:"%Y-%m-%d" "2012-05-");
+    false
+  with
+  | _ -> true
+
+type interval_timer = Unix.interval_timer =
+  | ITIMER_REAL
+  | ITIMER_VIRTUAL
+  | ITIMER_PROF
+[@@deriving sexp]
+
+type interval_timer_status = Unix.interval_timer_status = {
+  it_interval : float;
+  it_value : float;
+}
+[@@deriving sexp]
+
+let getitimer = Unix.getitimer
+let setitimer = Unix.setitimer
+
+let getuid = Unix.getuid
+let geteuid = Unix.geteuid
+
+let setuid uid =
+  improve (fun () -> Unix.setuid uid)
+    (fun () -> [("uid", Int.sexp_of_t uid)])
+
+let getgid = Unix.getgid
+let getegid = Unix.getegid
+
+let setgid gid =
+  improve (fun () -> Unix.setgid gid)
+    (fun () -> [("gid", Int.sexp_of_t gid)])
+
+let getgroups = Unix.getgroups
+
+let make_by f make_exn =
+  let normal arg = try Some (f arg) with Not_found -> None in
+  let exn arg = try f arg with Not_found -> raise (make_exn arg) in
+  (normal, exn)
+;;
+
+module Passwd = struct
+  type t =
+    { name : string;
+      passwd : string;
+      uid : int;
+      gid : int;
+      gecos : string;
+      dir : string;
+      shell : string;
+    }
+  [@@deriving compare, sexp]
+
+  let of_unix u =
+    let module U = Unix in
+    { name = u.U.pw_name;
+      passwd = u.U.pw_passwd;
+      uid = u.U.pw_uid;
+      gid = u.U.pw_gid;
+      gecos = u.U.pw_gecos;
+      dir = u.U.pw_dir;
+      shell = u.U.pw_shell;
+    }
+  ;;
+
+  exception Getbyname of string [@@deriving sexp]
+
+  let (getbyname, getbyname_exn) =
+    make_by
+      (fun name -> of_unix (Unix.getpwnam name))
+      (fun s -> Getbyname s)
+  ;;
+
+  exception Getbyuid of int [@@deriving sexp]
+
+  let (getbyuid, getbyuid_exn) =
+    make_by
+      (fun uid -> of_unix (Unix.getpwuid uid))
+      (fun s -> Getbyuid s)
+  ;;
+
+  module Low_level = struct
+    external core_setpwent : unit -> unit = "core_setpwent" ;;
+    external core_endpwent : unit -> unit = "core_endpwent" ;;
+    external core_getpwent : unit -> Unix.passwd_entry = "core_getpwent" ;;
+    let setpwent = core_setpwent ;;
+
+    let getpwent_exn () = of_unix (core_getpwent ()) ;;
+    let getpwent () = Option.try_with (fun () -> getpwent_exn ()) ;;
+    let endpwent = core_endpwent ;;
+  end ;;
+
+  let pwdb_lock = Mutex0.create () ;;
+
+  let getpwents () =
+    Mutex0.critical_section pwdb_lock ~f:(fun () ->
+      begin
+        Low_level.setpwent ();
+        Exn.protect
+          ~f:(fun () ->
+            let rec loop acc =
+              try
+                let ent = Low_level.getpwent_exn () in
+                loop (ent :: acc)
+              with
+              | End_of_file -> List.rev acc
+            in
+            loop [])
+          ~finally:(fun () -> Low_level.endpwent ())
+      end)
+  ;;
+end
+
+module Group = struct
+  type t =
+    { name : string;
+      passwd : string;
+      gid : int;
+      mem : string array;
+    }
+  [@@deriving sexp_of]
+
+  let of_unix u =
+    { name = u.Unix.gr_name;
+      passwd = u.Unix.gr_passwd;
+      gid = u.Unix.gr_gid;
+      mem = u.Unix.gr_mem;
+    }
+  ;;
+
+  exception Getbyname of string [@@deriving sexp]
+
+  let (getbyname, getbyname_exn) =
+    make_by (fun name -> of_unix (Unix.getgrnam name)) (fun s -> Getbyname s)
+  ;;
+
+  exception Getbygid of int [@@deriving sexp]
+
+  let (getbygid, getbygid_exn) =
+    make_by (fun gid -> of_unix (Unix.getgrgid gid)) (fun s -> Getbygid s)
+  ;;
+end
+
+(* The standard getlogin function goes through utmp which is unreliable,
+   see the BUGS section of getlogin(3) *)
+let _getlogin_orig = Unix.getlogin
+let getlogin () = (Unix.getpwuid (getuid ())).Unix.pw_name
+
+module Protocol_family = struct
+  type t = [ `Unix | `Inet | `Inet6 ]
+  [@@deriving bin_io, sexp]
+
+  let of_unix = function
+    | Unix.PF_UNIX -> `Unix
+    | Unix.PF_INET -> `Inet
+    | Unix.PF_INET6 -> `Inet6
+  ;;
+end
+
+let gethostname = Unix.gethostname
+
+module Inet_addr0 = struct
+  module Stable = struct
+    module V1 = struct
+      module T0 = struct
+        type t = Unix.inet_addr
+
+        let of_string = Unix.inet_addr_of_string
+        let to_string = Unix.string_of_inet_addr
+
+        (* Unix.inet_addr is represented as either a "struct in_addr" or a "struct
+           in6_addr" stuffed into an O'Caml string, so polymorphic compare will work. *)
+        let compare = Pervasives.compare
+        let hash_fold_t hash t = hash_fold_int hash (Hashtbl.hash t)
+        let hash = Ppx_hash_lib.Std.Hash.of_fold hash_fold_t
+      end
+      module T1 = struct
+        include T0
+        include Sexpable.Of_stringable (T0)
+        include Binable.Of_stringable  (T0)
+      end
+      include T1
+      include Comparable.Make(T1)
+    end
+  end
+  include Stable.V1
+  include Stable_unit_test.Make (struct
+      type nonrec t = t [@@deriving sexp, bin_io]
+      let equal = equal
+      ;;
+
+      let tests =
+        (* IPv4 *)
+        [ of_string "0.0.0.0"        , "0.0.0.0"        , "\0070.0.0.0"
+        ; of_string "10.0.0.0"       , "10.0.0.0"       , "\00810.0.0.0"
+        ; of_string "127.0.0.1"      , "127.0.0.1"      , "\009127.0.0.1"
+        ; of_string "192.168.1.101"  , "192.168.1.101"  , "\013192.168.1.101"
+        ; of_string "255.255.255.255", "255.255.255.255", "\015255.255.255.255"
+        (* IPv6 *)
+        ; of_string "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+          "2001:db8:85a3::8a2e:370:7334",
+          "\0282001:db8:85a3::8a2e:370:7334"
+        ; of_string "2001:db8:85a3:0:0:8a2e:370:7334",
+          "2001:db8:85a3::8a2e:370:7334",
+          "\0282001:db8:85a3::8a2e:370:7334"
+        ; of_string "2001:db8:85a3::8a2e:370:7334",
+          "2001:db8:85a3::8a2e:370:7334",
+          "\0282001:db8:85a3::8a2e:370:7334"
+        ; of_string "0:0:0:0:0:0:0:1", "::1", "\003::1"
+        ; of_string "::1"            , "::1", "\003::1"
+        ; of_string "0:0:0:0:0:0:0:0", "::", "\002::"
+        ; of_string "::"             , "::", "\002::"
+        ; of_string "::ffff:c000:0280"  , "::ffff:192.0.2.128", "\018::ffff:192.0.2.128"
+        ; of_string "::ffff:192.0.2.128", "::ffff:192.0.2.128", "\018::ffff:192.0.2.128"
+        ; of_string "2001:0db8::0001", "2001:db8::1"  , "\0112001:db8::1"
+        ; of_string "2001:db8::1"    , "2001:db8::1"  , "\0112001:db8::1"
+        ; of_string "2001:db8::2:1"  , "2001:db8::2:1", "\0132001:db8::2:1"
+        ; of_string "2001:db8:0000:1:1:1:1:1",
+          "2001:db8:0:1:1:1:1:1",
+          "\0202001:db8:0:1:1:1:1:1"
+        ; of_string "2001:db8::1:1:1:1:1",
+          "2001:db8:0:1:1:1:1:1",
+          "\0202001:db8:0:1:1:1:1:1"
+        ; of_string "2001:db8:0:1:1:1:1:1",
+          "2001:db8:0:1:1:1:1:1",
+          "\0202001:db8:0:1:1:1:1:1"
+        ; of_string "2001:db8:0:0:1:0:0:1", "2001:db8::1:0:0:1", "\0172001:db8::1:0:0:1"
+        ; of_string "2001:db8:0:0:1::1"   , "2001:db8::1:0:0:1", "\0172001:db8::1:0:0:1"
+        ; of_string "2001:db8::1:0:0:1"   , "2001:db8::1:0:0:1", "\0172001:db8::1:0:0:1"
+        ; of_string "2001:DB8::1", "2001:db8::1", "\0112001:db8::1"
+        ; of_string "2001:db8::1", "2001:db8::1", "\0112001:db8::1"
+        ]
+      ;;
+    end)
+end
+
+module Host = struct
+  type t =
+    { name : string;
+      aliases : string array;
+      family : Protocol_family.t;
+      addresses : Inet_addr0.t array;
+    }
+  [@@deriving sexp_of]
+
+  let of_unix u =
+    { name = u.Unix.h_name;
+      aliases = u.Unix.h_aliases;
+      family = Protocol_family.of_unix u.Unix.h_addrtype;
+      addresses = u.Unix.h_addr_list;
+    }
+  ;;
+
+  exception Getbyname of string [@@deriving sexp]
+
+  let (getbyname, getbyname_exn) =
+    make_by (fun name -> of_unix (Unix.gethostbyname name)) (fun s -> Getbyname s)
+  ;;
+
+  exception Getbyaddr of Inet_addr0.t [@@deriving sexp]
+
+  let (getbyaddr, getbyaddr_exn) =
+    make_by (fun addr -> of_unix (Unix.gethostbyaddr addr)) (fun a -> Getbyaddr a)
+  ;;
+
+  let have_address_in_common h1 h2 =
+    let addrs1 = Inet_addr0.Set.of_array h1.addresses in
+    let addrs2 = Inet_addr0.Set.of_array h2.addresses in
+    not (Inet_addr0.Set.is_empty (Inet_addr0.Set.inter addrs1 addrs2))
+  ;;
+end
+
+module Inet_addr = struct
+  include Inet_addr0
+
+  exception Get_inet_addr of string * string [@@deriving sexp]
+
+  let of_string_or_getbyname name =
+    try of_string name
+    with Failure _ ->
+      match Host.getbyname name with
+      | None -> raise (Get_inet_addr (name, "host not found"))
+      | Some host ->
+        match host.Host.family with
+        | `Unix -> assert false  (* impossible *)
+        | `Inet | `Inet6 ->
+          let addrs = host.Host.addresses in
+          if Int.(>) (Array.length addrs) 0 then addrs.(0)
+          else raise (Get_inet_addr (name, "empty addrs"))
+  ;;
+
+  module Blocking_sexp = struct
+    module T = struct
+      include Inet_addr0
+      let of_string = of_string_or_getbyname
+    end
+    include T
+    include Sexpable.Of_stringable (T)
+  end
+  ;;
+
+  let t_of_sexp = Blocking_sexp.t_of_sexp
+
+  let bind_any       = Unix.inet_addr_any
+  let bind_any_inet6 = Unix.inet6_addr_any
+  let localhost       = Unix.inet_addr_loopback
+  let localhost_inet6 = Unix.inet6_addr_loopback
+
+  let int32_to_ipv4_string =
+    let open Int.O in
+    let octet_digits octet =
+      if octet >= 100 then 3 else
+      if octet >=  10 then 2 else
+        1
+    in
+    let char_of_digit digit =
+      Char.of_int_exn (Char.to_int '0' + digit)
+    in
+    let write_char string ~pos char =
+      string.[pos] <- char;
+      Int.succ pos
+    in
+    let write_digit string ~pos digit =
+      write_char string ~pos (char_of_digit digit)
+    in
+    let write_octet string ~pos octet =
+      let pos =
+        if octet >= 100
+        then write_digit string ~pos (octet / 100)
+        else pos
+      in
+      let pos =
+        if octet >= 10
+        then write_digit string ~pos ((octet / 10) % 10)
+        else pos
+      in
+      write_digit string ~pos (octet % 10)
+    in
+    fun int32 ->
+      let open Int32.O in
+      let octet1 = (int32 lsr 24) land 0xFFl |> Int32.to_int_exn in
+      let octet2 = (int32 lsr 16) land 0xFFl |> Int32.to_int_exn in
+      let octet3 = (int32 lsr  8) land 0xFFl |> Int32.to_int_exn in
+      let octet4 = (int32 lsr  0) land 0xFFl |> Int32.to_int_exn in
+      let open Int.O in
+      let len =
+        octet_digits octet1 +
+        octet_digits octet2 +
+        octet_digits octet3 +
+        octet_digits octet4 +
+        3
+      in
+      let string = String.create len in
+      let pos = 0 in
+      let pos = write_octet string ~pos octet1 in
+      let pos = write_char  string ~pos '.'    in
+      let pos = write_octet string ~pos octet2 in
+      let pos = write_char  string ~pos '.'    in
+      let pos = write_octet string ~pos octet3 in
+      let pos = write_char  string ~pos '.'    in
+      let pos = write_octet string ~pos octet4 in
+      assert (Int.equal pos len);
+      string
+
+  let int32_of_ipv4_string =
+    let open Int.O in
+    let [@inline never] invalid string =
+      raise_s [%message "not a valid IPv4 address" string]
+    in
+    let rec find_sep string ~len ~pos =
+      if pos < len && not (Char.equal '.' (String.unsafe_get string pos))
+      then find_sep string ~len ~pos:(pos + 1)
+      else pos
+    in
+    let find_sep_exn string ~len ~pos =
+      let pos = find_sep string ~len ~pos in
+      if pos >= len then invalid string;
+      pos
+    in
+    let find_end_exn string ~len ~pos =
+      let pos = find_sep string ~len ~pos in
+      if pos < len then invalid string
+    in
+    let read_digit string pos =
+      match String.unsafe_get string pos with
+      | '0'..'9' as char -> Char.to_int char - Char.to_int '0'
+      | _                -> invalid string
+    in
+    let rec read_int string start until ~prefix =
+      if start = until
+      then prefix
+      else begin
+        read_int string (start + 1) until
+          ~prefix:((prefix * 10) + (read_digit string start))
+      end
+    in
+    let read_octet string start until =
+      let len = until - start in
+      if len < 1 || len > 3 then invalid string;
+      let int = read_int string start until ~prefix:0 in
+      if int < 0 || int > 255 then invalid string;
+      int
+    in
+    let int32_of_octets octet1 octet2 octet3 octet4 =
+      let open Int32.O in
+      ((Caml.Int32.of_int octet1) lsl 24) lor
+      ((Caml.Int32.of_int octet2) lsl 16) lor
+      ((Caml.Int32.of_int octet3) lsl  8) lor
+      ((Caml.Int32.of_int octet4) lsl  0)
+    in
+    fun string ->
+      let len = String.length string in
+      let sep1 = find_sep_exn string ~len ~pos:0          in
+      let sep2 = find_sep_exn string ~len ~pos:(sep1 + 1) in
+      let sep3 = find_sep_exn string ~len ~pos:(sep2 + 1) in
+      let ()   = find_end_exn string ~len ~pos:(sep3 + 1) in
+      let octet1 = read_octet string 0          sep1 in
+      let octet2 = read_octet string (sep1 + 1) sep2 in
+      let octet3 = read_octet string (sep2 + 1) sep3 in
+      let octet4 = read_octet string (sep3 + 1) len  in
+      int32_of_octets octet1 octet2 octet3 octet4
+
+  let inet4_addr_of_int32 int32 =
+    of_string (int32_to_ipv4_string int32)
+
+  let inet4_addr_to_int32_exn addr =
+    int32_of_ipv4_string (to_string addr)
+
+  (* Can we convert ip addr to an int? *)
+  let test_inet4_addr_to_int32 str num =
+    let inet = of_string str in
+    [%test_result: Int32.t] (inet4_addr_to_int32_exn inet) ~expect:num
+
+  let%test_unit _ = test_inet4_addr_to_int32 "0.0.0.1"                  1l
+  let%test_unit _ = test_inet4_addr_to_int32 "1.0.0.0"          0x1000000l
+  let%test_unit _ = test_inet4_addr_to_int32 "255.255.255.255" 0xffffffffl
+  let%test_unit _ = test_inet4_addr_to_int32 "172.25.42.1"     0xac192a01l
+  let%test_unit _ = test_inet4_addr_to_int32 "4.2.2.1"          0x4020201l
+  let%test_unit _ = test_inet4_addr_to_int32 "8.8.8.8"          0x8080808l
+  let%test_unit _ = test_inet4_addr_to_int32 "173.194.73.103"  0xadc24967l
+  let%test_unit _ = test_inet4_addr_to_int32 "98.139.183.24"   0x628bb718l
+  let%test_unit _ = test_inet4_addr_to_int32 "0.0.0.0"                  0l
+  let%test_unit _ = test_inet4_addr_to_int32 "127.0.0.1"       0x7F000001l
+  let%test_unit _ = test_inet4_addr_to_int32 "239.0.0.0"       0xEF000000l
+  let%test_unit _ = test_inet4_addr_to_int32 "255.255.255.255" 0xFFFFFFFFl
+
+  (* And from an int to a string? *)
+  let test_inet4_addr_of_int32 num str =
+    let inet = of_string str in
+    [%test_result: t] (inet4_addr_of_int32 num) ~expect:inet
+
+  let%test_unit _ = test_inet4_addr_of_int32 0xffffffffl "255.255.255.255"
+  let%test_unit _ = test_inet4_addr_of_int32          0l "0.0.0.0"
+  let%test_unit _ = test_inet4_addr_of_int32 0x628bb718l "98.139.183.24"
+  let%test_unit _ = test_inet4_addr_of_int32 0xadc24967l "173.194.73.103"
+
+  (* And round trip for kicks *)
+  let%test_unit _ =
+    let inet  = of_string "4.2.2.1" in
+    let inet' = inet4_addr_of_int32 (inet4_addr_to_int32_exn inet) in
+    if inet <> inet' then
+      failwithf "round-tripping %s produced %s"
+        (to_string inet) (to_string inet') ()
+end
+
+(** IPv6 addresses are not supported.
+    The RFC regarding how to properly format an IPv6 string is...painful.
+
+    Note the 0010 and 0000:
+    # "2a03:2880:0010:1f03:face:b00c:0000:0025" |> Unix.Inet_addr.of_string |!
+      Unix.Inet_addr.to_string ;;
+      - : string = "2a03:2880:10:1f03:face:b00c:0:25"
+*)
+
+module Cidr = struct
+  module Stable = struct
+    module V1 = struct
+      module T0 = struct
+        (* [address] is always normalized such that the (32 - [bits]) least-significant
+           bits are zero. *)
+        type t =
+          { address : int32; (* IPv4 only *)
+            bits    : int;
+          }
+        [@@deriving fields, bin_io, compare, hash, compare]
+
+        let normalized_address ~base ~bits =
+          if bits = 0
+          then 0l
+          else
+            let shift = 32 - bits in
+            Int32.(shift_left (shift_right_logical base shift) shift)
+
+        let create ~base_address ~bits =
+          if bits < 0 || bits > 32 then
+            failwithf "%d is an invalid number of mask bits (0 <= bits <= 32)" bits ();
+          let base = Inet_addr.inet4_addr_to_int32_exn base_address in
+          let address = normalized_address ~base ~bits in
+          { address; bits }
+
+        let of_string s =
+          match String.split ~on:'/' s with
+          | [s_inet_address ; s_bits] ->
+            create
+              ~base_address:(Inet_addr.of_string s_inet_address)
+              ~bits:(Int.of_string s_bits)
+          | _ -> failwithf "Couldn't parse '%s' into a CIDR address/bits pair" s ()
+
+        let to_string t =
+          let addr = Inet_addr.inet4_addr_of_int32 t.address in
+          sprintf "%s/%d" (Inet_addr.to_string addr) t.bits
+      end
+      module T1 = Sexpable.Stable.Of_stringable.V1(T0)
+      module T2 = Comparator.Stable.V1.Make(struct include T0 include T1 end)
+      module T3 = Comparable.Stable.V1.Make(struct include T0 include T1 include T2 end)
+      include T0
+      include T1
+      include T2
+      include T3
+    end
+  end
+
+  include Stable.V1.T0
+  include Stable.V1.T1
+  include Stable.V1.T2
+
+  let invariant t =
+    assert (t.bits >= 0 && t.bits <= 32);
+    assert (Int32.equal t.address (normalized_address ~base:t.address ~bits:t.bits))
+
+  let base_address t =
+    Inet_addr.inet4_addr_of_int32 t.address
+
+  let netmask_of_bits t =
+    Int32.shift_left 0xffffffffl (32 - t.bits) |> Inet_addr.inet4_addr_of_int32
+
+  let does_match_int32 t address =
+    Int32.equal t.address (normalized_address ~base:address ~bits:t.bits)
+
+  let does_match t inet_addr =
+    match Inet_addr.inet4_addr_to_int32_exn inet_addr with
+    | exception _ -> false (* maybe they tried to use IPv6 *)
+    | address     -> does_match_int32 t address
+
+  let multicast = of_string "224.0.0.0/4"
+
+  let is_subset t ~of_ =
+    bits of_ <= bits t
+    && does_match_int32 of_ t.address
+
+  let all_matching_addresses t =
+    Sequence.unfold ~init:t.address ~f:(fun address ->
+      if does_match_int32 t address
+      then Some (Inet_addr.inet4_addr_of_int32 address, Int32.succ address)
+      else None)
+
+  include Identifiable.Make_using_comparator(struct
+    let module_name = "Core.Unix.Cidr"
+    include Stable.V1.T0
+    include Stable.V1.T1
+    include Stable.V1.T2
+  end)
+end
+
+module Protocol = struct
+  type t =
+    { name : string;
+      aliases : string array;
+      proto : int;
+    }
+  [@@deriving sexp]
+
+  let of_unix u =
+    { name = u.Unix.p_name;
+      aliases = u.Unix.p_aliases;
+      proto = u.Unix.p_proto;
+    }
+
+  exception Getbyname of string [@@deriving sexp]
+  let (getbyname, getbyname_exn) =
+    make_by (fun name -> of_unix (Unix.getprotobyname name))
+      (fun s -> Getbyname s)
+  ;;
+
+  exception Getbynumber of int [@@deriving sexp]
+  let (getbynumber, getbynumber_exn) =
+    make_by (fun i -> of_unix (Unix.getprotobynumber i))
+      (fun i -> Getbynumber i)
+  ;;
+end
+
+module Service = struct
+  type t =
+    { name : string;
+      aliases : string array;
+      port : int;
+      proto : string;
+    }
+  [@@deriving sexp]
+
+  let of_unix u =
+    { name = u.Unix.s_name;
+      aliases = u.Unix.s_aliases;
+      port = u.Unix.s_port;
+      proto = u.Unix.s_proto;
+    }
+
+  exception Getbyname of string * string [@@deriving sexp]
+
+  let getbyname_exn name ~protocol =
+    try of_unix (Unix.getservbyname name ~protocol)
+    with Not_found -> raise (Getbyname (name, protocol))
+  ;;
+
+  let getbyname name ~protocol =
+    try Some (of_unix (Unix.getservbyname name ~protocol))
+    with _ -> None
+  ;;
+
+  exception Getbyport of int * string [@@deriving sexp]
+
+  let getbyport_exn num ~protocol =
+    try of_unix (Unix.getservbyport num ~protocol)
+    with Not_found -> raise (Getbyport (num, protocol))
+  ;;
+
+  let getbyport num ~protocol =
+    try Some (of_unix (Unix.getservbyport num ~protocol))
+    with Not_found -> None
+  ;;
+end
+
+type socket_domain = Unix.socket_domain =
+  | PF_UNIX
+  | PF_INET
+  | PF_INET6
+[@@deriving sexp, bin_io]
+
+type socket_type = Unix.socket_type =
+  | SOCK_STREAM
+  | SOCK_DGRAM
+  | SOCK_RAW
+  | SOCK_SEQPACKET
+[@@deriving sexp, bin_io]
+
+type sockaddr = Unix.sockaddr =
+  | ADDR_UNIX of string
+  | ADDR_INET of Inet_addr.t * int
+[@@deriving sexp_of, bin_io]
+
+type sockaddr_blocking_sexp = Unix.sockaddr =
+  | ADDR_UNIX of string
+  | ADDR_INET of Inet_addr.Blocking_sexp.t * int
+[@@deriving sexp, bin_io]
+
+let sockaddr_of_sexp = sockaddr_blocking_sexp_of_sexp
+
+let domain_of_sockaddr = Unix.domain_of_sockaddr
+
+let addr_r addr = ("addr", sexp_of_sockaddr addr)
+
+let socket_or_pair f ~domain ~kind ~protocol =
+  improve (fun () -> f domain kind protocol)
+    (fun () -> [("domain", sexp_of_socket_domain domain);
+                ("kind", sexp_of_socket_type kind);
+                ("protocol", Int.sexp_of_t protocol)])
+;;
+
+let socket =
+  socket_or_pair
+    (fun domain kind protocol -> UnixNoLabels.socket domain kind protocol)
+let socketpair =
+  socket_or_pair
+    (fun domain kind protocol -> UnixNoLabels.socketpair domain kind protocol)
+
+let accept fd =
+  let fd, addr = unary_fd Unix.accept fd in
+  let addr =
+    match addr with
+    | ADDR_UNIX _ -> ADDR_UNIX ""
+    | ADDR_INET _ -> addr
+  in
+  fd, addr
+
+let bind fd ~addr =
+  improve (fun () -> Unix.bind fd ~addr)
+    (fun () -> [fd_r fd; addr_r addr])
+;;
+
+let connect fd ~addr =
+  improve (fun () -> Unix.connect fd ~addr)
+    (fun () -> [fd_r fd; addr_r addr])
+;;
+
+let listen fd ~backlog =
+  improve (fun () -> Unix.listen fd ~max:backlog)
+    (fun () -> [fd_r fd; ("backlog", Int.sexp_of_t backlog)])
+;;
+
+type shutdown_command = Unix.shutdown_command =
+  | SHUTDOWN_RECEIVE
+  | SHUTDOWN_SEND
+  | SHUTDOWN_ALL
+[@@deriving sexp]
+
+let shutdown fd ~mode =
+  improve (fun () ->
+    try
+      Unix.shutdown fd ~mode
+    with
+    (* the error below is benign, it means that the other side disconnected *)
+    | Unix.Unix_error (Unix.ENOTCONN, _, _) -> ())
+    (fun () -> [fd_r fd; ("mode", sexp_of_shutdown_command mode)])
+;;
+
+let getsockname = unary_fd Unix.getsockname
+
+let getpeername = unary_fd Unix.getpeername
+
+type msg_flag =
+Unix.msg_flag =
+| MSG_OOB
+| MSG_DONTROUTE
+| MSG_PEEK
+[@@deriving sexp]
+
+let recv_send f fd ~buf ~pos ~len ~mode =
+  improve (fun () -> f fd ~buf ~pos ~len ~mode)
+    (fun () ->
+      [fd_r fd;
+       ("pos", Int.sexp_of_t pos);
+       len_r len;
+       ("mode", sexp_of_list sexp_of_msg_flag mode)])
+;;
+
+let recv = recv_send Unix.recv
+let recvfrom = recv_send Unix.recvfrom
+let send = recv_send Unix.send
+
+let sendto fd ~buf ~pos ~len ~mode ~addr =
+  improve (fun () -> Unix.sendto fd ~buf ~pos ~len ~mode ~addr)
+    (fun () ->
+      [fd_r fd;
+       ("pos", Int.sexp_of_t pos);
+       len_r len;
+       ("mode", sexp_of_list sexp_of_msg_flag mode);
+       ("addr", sexp_of_sockaddr addr)])
+;;
+
+type socket_bool_option = Unix.socket_bool_option =
+  | SO_DEBUG
+  | SO_BROADCAST
+  | SO_REUSEADDR
+  | SO_KEEPALIVE
+  | SO_DONTROUTE
+  | SO_OOBINLINE
+  | SO_ACCEPTCONN
+  | TCP_NODELAY
+  | IPV6_ONLY
+[@@deriving sexp]
+
+type socket_int_option = Unix.socket_int_option =
+  | SO_SNDBUF
+  | SO_RCVBUF
+  | SO_ERROR
+  | SO_TYPE
+  | SO_RCVLOWAT
+  | SO_SNDLOWAT
+[@@deriving sexp]
+
+type socket_optint_option = Unix.socket_optint_option =
+  | SO_LINGER
+[@@deriving sexp]
+
+type socket_float_option = Unix.socket_float_option =
+  | SO_RCVTIMEO
+  | SO_SNDTIMEO
+[@@deriving sexp]
+
+let make_sockopt get set sexp_of_opt sexp_of_val =
+  let getsockopt fd opt =
+    improve (fun () -> get fd opt)
+      (fun () -> [fd_r fd; ("opt", sexp_of_opt opt)])
+  in
+  let setsockopt fd opt value =
+    improve (fun () -> set fd opt value)
+      (fun () ->
+        [fd_r fd; ("opt", sexp_of_opt opt); ("val", sexp_of_val value)])
+  in
+  (getsockopt, setsockopt)
+;;
+
+let (getsockopt, setsockopt) =
+  make_sockopt Unix.getsockopt Unix.setsockopt
+    sexp_of_socket_bool_option sexp_of_bool
+;;
+
+let (getsockopt_int, setsockopt_int) =
+  make_sockopt Unix.getsockopt_int Unix.setsockopt_int
+    sexp_of_socket_int_option sexp_of_int
+;;
+
+let (getsockopt_optint, setsockopt_optint) =
+  make_sockopt Unix.getsockopt_optint Unix.setsockopt_optint
+    sexp_of_socket_optint_option (sexp_of_option sexp_of_int)
+;;
+
+let (getsockopt_float, setsockopt_float) =
+  make_sockopt Unix.getsockopt_float Unix.setsockopt_float
+    sexp_of_socket_float_option sexp_of_float
+;;
+
+(* Additional IP functionality *)
+
+external if_indextoname : int -> string = "unix_if_indextoname"
+
+module Mcast_action = struct
+  (* Keep this in sync with the VAL_MCAST_ACTION_* #defines in unix_stubs.c *)
+  type t =
+    | Add
+    | Drop
+end
+
+external mcast_modify
+  :  Mcast_action.t
+  -> ?ifname : string
+  -> ?source : Inet_addr.t
+  -> File_descr.t
+  -> Unix.sockaddr
+  -> unit
+  = "core_unix_mcast_modify"
+;;
+
+let mcast_join ?ifname ?source fd sockaddr =
+  mcast_modify Mcast_action.Add ?ifname ?source fd sockaddr
+;;
+
+let mcast_leave ?ifname fd sockaddr =
+  mcast_modify Mcast_action.Drop ?ifname fd sockaddr
+;;
+
+external get_mcast_ttl : File_descr.t -> int = "unix_mcast_get_ttl"
+
+external set_mcast_ttl : File_descr.t -> int -> unit = "unix_mcast_set_ttl"
+
+external get_mcast_loop : File_descr.t -> bool = "unix_mcast_get_loop"
+
+external set_mcast_loop : File_descr.t -> bool -> unit = "unix_mcast_set_loop"
+
+external set_mcast_ifname : File_descr.t -> string -> unit = "unix_mcast_set_ifname"
+
+let open_connection addr =
+  improve (fun () -> Unix.open_connection addr) (fun () -> [addr_r addr])
+;;
+
+let shutdown_connection = Unix.shutdown_connection
+
+let establish_server handle_connection ~addr =
+  improve (fun () -> Unix.establish_server handle_connection ~addr)
+    (fun () -> [addr_r addr])
+;;
+
+type addr_info = Unix.addr_info =
+  { ai_family    : socket_domain
+  ; ai_socktype  : socket_type
+  ; ai_protocol  : int
+  ; ai_addr      : sockaddr
+  ; ai_canonname : string
+  } [@@deriving sexp_of]
+
+type addr_info_blocking_sexp = Unix.addr_info =
+  { ai_family    : socket_domain
+  ; ai_socktype  : socket_type
+  ; ai_protocol  : int
+  ; ai_addr      : sockaddr_blocking_sexp
+  ; ai_canonname : string
+  } [@@deriving sexp]
+
+type getaddrinfo_option = Unix.getaddrinfo_option =
+  | AI_FAMILY of socket_domain
+  | AI_SOCKTYPE of socket_type
+  | AI_PROTOCOL of int
+  | AI_NUMERICHOST
+  | AI_CANONNAME
+  | AI_PASSIVE
+[@@deriving sexp]
+
+let getaddrinfo host service opts =
+  improve (fun () -> Unix.getaddrinfo host service opts)
+    (fun () ->
+      [("host", atom host);
+       ("service", atom service);
+       ("opts", sexp_of_list sexp_of_getaddrinfo_option opts)])
+;;
+
+type name_info =
+Unix.name_info = {
+  ni_hostname : string;
+  ni_service : string;
+}
+[@@deriving sexp]
+
+type getnameinfo_option =
+Unix.getnameinfo_option =
+| NI_NOFQDN
+| NI_NUMERICHOST
+| NI_NAMEREQD
+| NI_NUMERICSERV
+| NI_DGRAM
+[@@deriving sexp]
+
+let getnameinfo addr opts =
+  improve (fun () -> Unix.getnameinfo addr opts)
+    (fun () ->
+      [("addr", sexp_of_sockaddr addr);
+       ("opts", sexp_of_list sexp_of_getnameinfo_option opts)])
+;;
+
+module Terminal_io = struct
+  type t = Unix.terminal_io = {
+    mutable c_ignbrk : bool;
+    mutable c_brkint : bool;
+    mutable c_ignpar : bool;
+    mutable c_parmrk : bool;
+    mutable c_inpck : bool;
+    mutable c_istrip : bool;
+    mutable c_inlcr : bool;
+    mutable c_igncr : bool;
+    mutable c_icrnl : bool;
+    mutable c_ixon : bool;
+    mutable c_ixoff : bool;
+    mutable c_opost : bool;
+    mutable c_obaud : int;
+    mutable c_ibaud : int;
+    mutable c_csize : int;
+    mutable c_cstopb : int;
+    mutable c_cread : bool;
+    mutable c_parenb : bool;
+    mutable c_parodd : bool;
+    mutable c_hupcl : bool;
+    mutable c_clocal : bool;
+    mutable c_isig : bool;
+    mutable c_icanon : bool;
+    mutable c_noflsh : bool;
+    mutable c_echo : bool;
+    mutable c_echoe : bool;
+    mutable c_echok : bool;
+    mutable c_echonl : bool;
+    mutable c_vintr : char;
+    mutable c_vquit : char;
+    mutable c_verase : char;
+    mutable c_vkill : char;
+    mutable c_veof : char;
+    mutable c_veol : char;
+    mutable c_vmin : int;
+    mutable c_vtime : int;
+    mutable c_vstart : char;
+    mutable c_vstop : char;
+  }
+  [@@deriving sexp]
+
+  let tcgetattr = unary_fd Unix.tcgetattr
+
+  type setattr_when = Unix.setattr_when =
+    | TCSANOW
+    | TCSADRAIN
+    | TCSAFLUSH
+  [@@deriving sexp]
+
+  let tcsetattr t fd ~mode =
+    improve (fun () -> Unix.tcsetattr fd ~mode t)
+      (fun () -> [fd_r fd;
+                  ("mode", sexp_of_setattr_when mode);
+                  ("termios", sexp_of_t t)])
+  ;;
+
+  let tcsendbreak fd ~duration =
+    improve (fun () -> Unix.tcsendbreak fd ~duration)
+      (fun () -> [fd_r fd;
+                  ("duration", Int.sexp_of_t duration)])
+  ;;
+
+  let tcdrain = unary_fd Unix.tcdrain
+
+  type flush_queue = Unix.flush_queue =
+    | TCIFLUSH
+    | TCOFLUSH
+    | TCIOFLUSH
+  [@@deriving sexp]
+
+  let tcflush fd ~mode =
+    improve (fun () -> Unix.tcflush fd ~mode)
+      (fun () -> [fd_r fd; ("mode", sexp_of_flush_queue mode)])
+  ;;
+
+  type flow_action = Unix.flow_action =
+    | TCOOFF
+    | TCOON
+    | TCIOFF
+    | TCION
+  [@@deriving sexp]
+
+  let tcflow fd ~mode =
+    improve (fun () -> Unix.tcflow fd ~mode)
+      (fun () -> [fd_r fd; ("mode", sexp_of_flow_action mode)])
+  ;;
+
+  let setsid = Unix.setsid
+end
+
+let get_sockaddr name port = ADDR_INET (Inet_addr.of_string_or_getbyname name, port)
+
+let set_in_channel_timeout ic rcv_timeout =
+  let s = descr_of_in_channel ic in
+  setsockopt_float s SO_RCVTIMEO rcv_timeout
+
+let set_out_channel_timeout oc snd_timeout =
+  let s = descr_of_out_channel oc in
+  setsockopt_float s SO_SNDTIMEO snd_timeout
+
+external nanosleep : float -> float = "core_time_ns_nanosleep" ;;
+
+module Syslog = Syslog
+
+let () = Sexplib_unix.Sexplib_unix_conv.linkme
+
+(* Test the Sexplib_unix exn converter was added correctly *)
+let%test_unit "Sexplib_unix sexp converter" =
+  let open Sexp.O in
+  match sexp_of_exn (Unix.Unix_error (E2BIG, "loc", "arg")) with
+  | (List [ Atom "Unix.Unix_error"
+          ; Atom _human_readable_message
+          ; Atom "loc"
+          ; Atom "arg"
+          ]) -> ()
+  | something_else ->
+      failwithf "sexp_of_exn (Unix_error ...) gave %s" (Sexp.to_string something_else) ()
+;;
+
+module Ifaddr = struct
+  module Broadcast_or_destination = struct
+    type t =
+      | Broadcast   of Inet_addr.t
+      | Destination of Inet_addr.t
+    [@@deriving sexp_of]
+  end
+
+  (* THE ORDER OF THESE IS IMPORTANT, SEE unix_stubs.c!!! *)
+  module Family = struct
+    type t = Packet | Inet4 | Inet6 [@@deriving sexp, bin_io]
+  end
+
+  module Flag = struct
+    (* THE ORDER OF FLAGS IS IMPORTANT TO MATCH unix_stubs.c!!! *)
+    module T = struct
+      type t =
+        | Allmulti
+        | Automedia
+        | Broadcast
+        | Debug
+        | Dynamic
+        | Loopback
+        | Master
+        | Multicast
+        | Noarp
+        | Notrailers
+        | Pointopoint
+        | Portsel
+        | Promisc
+        | Running
+        | Slave
+        | Up
+      [@@deriving sexp, compare, enumerate]
+    end
+    include T
+    include Comparable.Make(T)
+
+    external core_unix_iff_to_int : t -> int  = "core_unix_iff_to_int"
+
+    let set_of_int bitmask =
+      List.fold all
+        ~init:Set.empty
+        ~f:(fun flags t ->
+          let v = core_unix_iff_to_int t in
+          match bitmask land v with
+          | 0 -> flags
+          | _ -> Set.add flags t)
+    ;;
+
+    let int_of_set =
+      Set.fold ~init:0 ~f:(fun acc t -> acc lor (core_unix_iff_to_int t))
+    ;;
+
+    let to_int = core_unix_iff_to_int
+
+    let%test_unit _ = [%test_result: Set.t] (set_of_int 0) ~expect:Set.empty
+
+    let%test_unit _ =
+      List.iter all ~f:(fun t ->
+        let x = to_int t in
+        if Int.(<>) (Int.ceil_pow2 x) x
+        then failwiths "Flag is not a power of 2" t sexp_of_t)
+
+    let%test_unit _ =
+      List.iter all ~f:(fun t ->
+        [%test_result: Set.t] (set_of_int (int_of_set (Set.singleton t)))
+          ~expect:(Set.singleton t))
+
+    let%test_unit _ =
+      [%test_result: Set.t] (set_of_int (int_of_set (Set.of_list all)))
+        ~expect:(Set.of_list all)
+  end
+
+  type t =
+    { name                     : string
+    ; family                   : Family.t
+    ; flags                    : Flag.Set.t
+    ; address                  : Inet_addr.t                sexp_option
+    ; netmask                  : Inet_addr.t                sexp_option
+    ; broadcast_or_destination : Broadcast_or_destination.t sexp_option
+    }
+  [@@deriving sexp_of, fields]
+
+  (* THE ORDER AND NUMBER OF THESE IS IMPORTANT, SEE unix_stubs.c!!! *)
+  type ifaddrs =
+    { name               : string
+    ; family             : Family.t
+    ; flags              : int
+    ; addr_octets        : string
+    ; netmask_octets     : string
+    ; broadcast_octets   : string
+    ; destination_octets : string
+    }
+  external core_unix_getifaddrs : unit -> ifaddrs list = "core_unix_getifaddrs"
+
+  let inet4_to_inet_addr addr =
+    match String.length addr with
+    | 0 -> None
+    | 4 ->
+      sprintf "%d.%d.%d.%d"
+        (Char.to_int addr.[0])
+        (Char.to_int addr.[1])
+        (Char.to_int addr.[2])
+        (Char.to_int addr.[3])
+      |> Inet_addr.of_string
+      |> Option.return
+    | addrlen -> failwithf "IPv4 address is length %d!" addrlen ()
+  ;;
+
+  let inet6_to_inet_addr addr =
+    match String.length addr with
+    | 0  -> None
+    | 16 ->
+      sprintf "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x"
+        (Char.to_int addr.[ 0])
+        (Char.to_int addr.[ 1])
+        (Char.to_int addr.[ 2])
+        (Char.to_int addr.[ 3])
+        (Char.to_int addr.[ 4])
+        (Char.to_int addr.[ 5])
+        (Char.to_int addr.[ 6])
+        (Char.to_int addr.[ 7])
+        (Char.to_int addr.[ 8])
+        (Char.to_int addr.[ 9])
+        (Char.to_int addr.[10])
+        (Char.to_int addr.[11])
+        (Char.to_int addr.[12])
+        (Char.to_int addr.[13])
+        (Char.to_int addr.[14])
+        (Char.to_int addr.[15])
+      |> Inet_addr.of_string
+      |> Option.return
+    | addrlen -> failwithf "IPv6 address is length %d!" addrlen ()
+  ;;
+
+  let addr_to_inet_addr family addr =
+    match family with
+    | Family.Packet -> None
+    | Family.Inet4  -> inet4_to_inet_addr addr
+    | Family.Inet6  -> inet6_to_inet_addr addr
+  ;;
+
+  let test_and_convert ifa =
+    let flags = Flag.set_of_int ifa.flags in
+    let broadcast_or_destination_convert ifa =
+      if Set.mem flags Broadcast
+      then
+        Option.map (addr_to_inet_addr ifa.family ifa.broadcast_octets)
+          ~f:(fun x -> Broadcast_or_destination.Broadcast x)
+      else if Set.mem flags Pointopoint
+      then
+        Option.map (addr_to_inet_addr ifa.family ifa.destination_octets)
+          ~f:(fun x -> Broadcast_or_destination.Destination x)
+      else None
+    in
+    { address                  = addr_to_inet_addr ifa.family ifa.addr_octets
+    ; netmask                  = addr_to_inet_addr ifa.family ifa.netmask_octets
+    ; broadcast_or_destination = broadcast_or_destination_convert ifa
+    ; flags                    = flags
+    ; name                     = ifa.name
+    ; family                   = ifa.family
+    }
+  ;;
+end
+
+let getifaddrs () =
+  List.map (Ifaddr.core_unix_getifaddrs ()) ~f:Ifaddr.test_and_convert
+;;
+
+module Stable = struct
+  module Inet_addr = Inet_addr.Stable
+  module Cidr = Cidr.Stable
+end

--- a/testdata/issue20/download_strategy.rb
+++ b/testdata/issue20/download_strategy.rb
@@ -1,0 +1,1196 @@
+require "json"
+require "rexml/document"
+require "time"
+
+class AbstractDownloadStrategy
+  include FileUtils
+
+  attr_reader :meta, :name, :version, :resource
+  attr_reader :shutup
+
+  def initialize(name, resource)
+    @name = name
+    @resource = resource
+    @url = resource.url
+    @version = resource.version
+    @meta = resource.specs
+  end
+
+  # Download and cache the resource as {#cached_location}.
+  def fetch
+  end
+
+  # Suppress output
+  def shutup!
+    @shutup = true
+  end
+
+  def puts(*args)
+    super(*args) unless shutup
+  end
+
+  def ohai(*args)
+    super(*args) unless shutup
+  end
+
+  # Unpack {#cached_location} into the current working directory, and possibly
+  # chdir into the newly-unpacked directory.
+  # Unlike {Resource#stage}, this does not take a block.
+  def stage
+  end
+
+  # @!attribute [r] cached_location
+  # The path to the cached file or directory associated with the resource.
+  def cached_location
+  end
+
+  # @!attribute [r]
+  # return most recent modified time for all files in the current working directory after stage.
+  def source_modified_time
+    Pathname.pwd.to_enum(:find).select(&:file?).map(&:mtime).max
+  end
+
+  # Remove {#cached_location} and any other files associated with the resource
+  # from the cache.
+  def clear_cache
+    rm_rf(cached_location)
+  end
+
+  def expand_safe_system_args(args)
+    args = args.dup
+    args.each_with_index do |arg, ii|
+      next unless arg.is_a? Hash
+      if ARGV.verbose?
+        args.delete_at ii
+      else
+        args[ii] = arg[:quiet_flag]
+      end
+      return args
+    end
+    # 2 as default because commands are eg. svn up, git pull
+    args.insert(2, "-q") unless ARGV.verbose?
+    args
+  end
+
+  def safe_system(*args)
+    if @shutup
+      quiet_system(*args) || raise(ErrorDuringExecution.new(args.shift, *args))
+    else
+      super(*args)
+    end
+  end
+
+  def quiet_safe_system(*args)
+    safe_system(*expand_safe_system_args(args))
+  end
+
+  private
+
+  def xzpath
+    "#{HOMEBREW_PREFIX}/opt/xz/bin/xz"
+  end
+
+  def lzippath
+    "#{HOMEBREW_PREFIX}/opt/lzip/bin/lzip"
+  end
+
+  def lhapath
+    "#{HOMEBREW_PREFIX}/opt/lha/bin/lha"
+  end
+
+  def cvspath
+    @cvspath ||= %W[
+      /usr/bin/cvs
+      #{HOMEBREW_PREFIX}/bin/cvs
+      #{HOMEBREW_PREFIX}/opt/cvs/bin/cvs
+      #{which("cvs")}
+    ].find { |p| File.executable? p }
+  end
+
+  def hgpath
+    @hgpath ||= %W[
+      #{which("hg")}
+      #{HOMEBREW_PREFIX}/bin/hg
+      #{HOMEBREW_PREFIX}/opt/mercurial/bin/hg
+    ].find { |p| File.executable? p }
+  end
+
+  def bzrpath
+    @bzrpath ||= %W[
+      #{which("bzr")}
+      #{HOMEBREW_PREFIX}/bin/bzr
+      #{HOMEBREW_PREFIX}/opt/bazaar/bin/bzr
+    ].find { |p| File.executable? p }
+  end
+
+  def fossilpath
+    @fossilpath ||= %W[
+      #{which("fossil")}
+      #{HOMEBREW_PREFIX}/bin/fossil
+      #{HOMEBREW_PREFIX}/opt/fossil/bin/fossil
+    ].find { |p| File.executable? p }
+  end
+end
+
+class VCSDownloadStrategy < AbstractDownloadStrategy
+  REF_TYPES = [:tag, :branch, :revisions, :revision].freeze
+
+  def initialize(name, resource)
+    super
+    @ref_type, @ref = extract_ref(meta)
+    @revision = meta[:revision]
+    @clone = HOMEBREW_CACHE/cache_filename
+  end
+
+  def fetch
+    ohai "Cloning #{@url}"
+
+    if cached_location.exist? && repo_valid?
+      puts "Updating #{cached_location}"
+      update
+    elsif cached_location.exist?
+      puts "Removing invalid repository from cache"
+      clear_cache
+      clone_repo
+    else
+      clone_repo
+    end
+
+    version.update_commit(last_commit) if head?
+
+    return unless @ref_type == :tag
+    return unless @revision && current_revision
+    return if current_revision == @revision
+    raise <<-EOS.undent
+      #{@ref} tag should be #{@revision}
+      but is actually #{current_revision}
+    EOS
+  end
+
+  def fetch_last_commit
+    fetch
+    last_commit
+  end
+
+  def commit_outdated?(commit)
+    @last_commit ||= fetch_last_commit
+    commit != @last_commit
+  end
+
+  def cached_location
+    @clone
+  end
+
+  def head?
+    version.head?
+  end
+
+  # Return last commit's unique identifier for the repository.
+  # Return most recent modified timestamp unless overridden.
+  def last_commit
+    source_modified_time.to_i.to_s
+  end
+
+  private
+
+  def cache_tag
+    "__UNKNOWN__"
+  end
+
+  def cache_filename
+    "#{name}--#{cache_tag}"
+  end
+
+  def repo_valid?
+    true
+  end
+
+  def clone_repo
+  end
+
+  def update
+  end
+
+  def current_revision
+  end
+
+  def extract_ref(specs)
+    key = REF_TYPES.find { |type| specs.key?(type) }
+    [key, specs[key]]
+  end
+end
+
+class AbstractFileDownloadStrategy < AbstractDownloadStrategy
+  def stage
+    case type = cached_location.compression_type
+    when :zip
+      with_system_path { quiet_safe_system "unzip", "-qq", cached_location }
+      chdir
+    when :gzip_only
+      with_system_path { buffered_write("gunzip") }
+    when :bzip2_only
+      with_system_path { buffered_write("bunzip2") }
+    when :gzip, :bzip2, :xz, :compress, :tar
+      tar_flags = "x"
+      if type == :gzip
+        tar_flags << "z"
+      elsif type == :bzip2
+        tar_flags << "j"
+      elsif type == :xz
+        tar_flags << "J"
+      end
+      tar_flags << "f"
+      with_system_path do
+        if type == :xz && DependencyCollector.tar_needs_xz_dependency?
+          pipe_to_tar(xzpath)
+        else
+          safe_system "tar", tar_flags, cached_location
+        end
+      end
+      chdir
+    when :lzip
+      with_system_path { pipe_to_tar(lzippath) }
+      chdir
+    when :lha
+      safe_system lhapath, "x", cached_location
+    when :xar
+      safe_system "/usr/bin/xar", "-xf", cached_location
+    when :rar
+      quiet_safe_system "unrar", "x", "-inul", cached_location
+    when :p7zip
+      safe_system "7zr", "x", cached_location
+    else
+      cp cached_location, basename_without_params, preserve: true
+    end
+  end
+
+  private
+
+  def chdir
+    entries = Dir["*"]
+    case entries.length
+    when 0 then raise "Empty archive"
+    when 1 then begin
+        Dir.chdir entries.first
+      rescue
+        nil
+      end
+    end
+  end
+
+  def pipe_to_tar(tool)
+    Utils.popen_read(tool, "-dc", cached_location.to_s) do |rd|
+      Utils.popen_write("tar", "xf", "-") do |wr|
+        buf = ""
+        wr.write(buf) while rd.read(16384, buf)
+      end
+    end
+  end
+
+  # gunzip and bunzip2 write the output file in the same directory as the input
+  # file regardless of the current working directory, so we need to write it to
+  # the correct location ourselves.
+  def buffered_write(tool)
+    target = File.basename(basename_without_params, cached_location.extname)
+
+    Utils.popen_read(tool, "-f", cached_location.to_s, "-c") do |pipe|
+      File.open(target, "wb") do |f|
+        buf = ""
+        f.write(buf) while pipe.read(16384, buf)
+      end
+    end
+  end
+
+  def basename_without_params
+    # Strip any ?thing=wad out of .c?thing=wad style extensions
+    File.basename(@url)[/[^?]+/]
+  end
+
+  def ext
+    # We need a Pathname because we've monkeypatched extname to support double
+    # extensions (e.g. tar.gz).
+    # We can't use basename_without_params, because given a URL like
+    #   https://example.com/download.php?file=foo-1.0.tar.gz
+    # the extension we want is ".tar.gz", not ".php".
+    Pathname.new(@url).extname[/[^?]+/]
+  end
+end
+
+class CurlDownloadStrategy < AbstractFileDownloadStrategy
+  attr_reader :mirrors, :tarball_path, :temporary_path
+
+  def initialize(name, resource)
+    super
+    @mirrors = resource.mirrors.dup
+    @tarball_path = HOMEBREW_CACHE/"#{name}-#{version}#{ext}"
+    @temporary_path = Pathname.new("#{cached_location}.incomplete")
+  end
+
+  def fetch
+    ohai "Downloading #{@url}"
+
+    if cached_location.exist?
+      puts "Already downloaded: #{cached_location}"
+    else
+      had_incomplete_download = temporary_path.exist?
+      begin
+        _fetch
+      rescue ErrorDuringExecution
+        # 33 == range not supported
+        # try wiping the incomplete download and retrying once
+        unless $CHILD_STATUS.exitstatus == 33 && had_incomplete_download
+          raise CurlDownloadStrategyError, @url
+        end
+
+        ohai "Trying a full download"
+        temporary_path.unlink
+        had_incomplete_download = false
+        retry
+      end
+      ignore_interrupts { temporary_path.rename(cached_location) }
+    end
+  rescue CurlDownloadStrategyError
+    raise if mirrors.empty?
+    puts "Trying a mirror..."
+    @url = mirrors.shift
+    retry
+  end
+
+  def cached_location
+    tarball_path
+  end
+
+  def clear_cache
+    super
+    rm_rf(temporary_path)
+  end
+
+  private
+
+  # Private method, can be overridden if needed.
+  def _fetch
+    url = @url
+
+    if ENV["HOMEBREW_ARTIFACT_DOMAIN"]
+      url = url.sub(%r{^((ht|f)tps?://)?}, ENV["HOMEBREW_ARTIFACT_DOMAIN"].chomp("/") + "/")
+      ohai "Downloading from #{url}"
+    end
+
+    urls = actual_urls(url)
+    unless urls.empty?
+      ohai "Downloading from #{urls.last}"
+      if !ENV["HOMEBREW_NO_INSECURE_REDIRECT"].nil? && url.start_with?("https://") &&
+         urls.any? { |u| !u.start_with? "https://" }
+        puts "HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set."
+        raise CurlDownloadStrategyError, url
+      end
+      url = urls.last
+    end
+
+    curl url, "-C", downloaded_size, "-o", temporary_path
+  end
+
+  # Curl options to be always passed to curl,
+  # with raw head calls (`curl -I`) or with actual `fetch`.
+  def _curl_opts
+    copts = []
+    copts << "--user" << meta.fetch(:user) if meta.key?(:user)
+    copts
+  end
+
+  def actual_urls(url)
+    urls = []
+    curl_args = _curl_opts << "-I" << "-L" << url
+    Utils.popen_read("curl", *curl_args).scan(/^Location: (.+)$/).map do |m|
+      urls << URI.join(urls.last || url, m.first.chomp).to_s
+    end
+    urls
+  end
+
+  def downloaded_size
+    temporary_path.size? || 0
+  end
+
+  def curl(*args)
+    args.concat _curl_opts
+    args << "--connect-timeout" << "5" unless mirrors.empty?
+    super
+  end
+end
+
+# Detect and download from Apache Mirror
+class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
+  def apache_mirrors
+    rd, wr = IO.pipe
+    buf = ""
+
+    pid = fork do
+      ENV.delete "HOMEBREW_CURL_VERBOSE"
+      rd.close
+      $stdout.reopen(wr)
+      $stderr.reopen(wr)
+      curl "#{@url}&asjson=1"
+    end
+    wr.close
+
+    rd.readline if ARGV.verbose? # Remove Homebrew output
+    buf << rd.read until rd.eof?
+    rd.close
+    Process.wait(pid)
+    buf
+  end
+
+  def _fetch
+    return super if @tried_apache_mirror
+    @tried_apache_mirror = true
+
+    mirrors = JSON.parse(apache_mirrors)
+    path_info = mirrors.fetch("path_info")
+    @url = mirrors.fetch("preferred") + path_info
+    @mirrors |= %W[https://archive.apache.org/dist/#{path_info}]
+
+    ohai "Best Mirror #{@url}"
+    super
+  rescue IndexError, JSON::ParserError
+    raise CurlDownloadStrategyError, "Couldn't determine mirror, try again later."
+  end
+end
+
+# Download via an HTTP POST.
+# Query parameters on the URL are converted into POST parameters
+class CurlPostDownloadStrategy < CurlDownloadStrategy
+  def _fetch
+    base_url, data = @url.split("?")
+    curl base_url, "-d", data, "-C", downloaded_size, "-o", temporary_path
+  end
+end
+
+# Use this strategy to download but not unzip a file.
+# Useful for installing jars.
+class NoUnzipCurlDownloadStrategy < CurlDownloadStrategy
+  def stage
+    cp cached_location, basename_without_params, preserve: true
+  end
+end
+
+# This strategy extracts our binary packages.
+class CurlBottleDownloadStrategy < CurlDownloadStrategy
+  def stage
+    ohai "Pouring #{cached_location.basename}"
+    super
+  end
+end
+
+# This strategy extracts local binary packages.
+class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy
+  attr_reader :cached_location
+
+  def initialize(path)
+    @cached_location = path
+  end
+
+  def stage
+    ohai "Pouring #{cached_location.basename}"
+    super
+  end
+end
+
+# S3DownloadStrategy downloads tarballs from AWS S3.
+# To use it, add ":using => S3DownloadStrategy" to the URL section of your
+# formula.  This download strategy uses AWS access tokens (in the
+# environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
+# to sign the request.  This strategy is good in a corporate setting,
+# because it lets you use a private S3 bucket as a repo for internal
+# distribution.  (It will work for public buckets as well.)
+class S3DownloadStrategy < CurlDownloadStrategy
+  def _fetch
+    # Put the aws gem requirement here (vs top of file) so it's only
+    # a dependency of S3 users, not all Homebrew users
+    require "rubygems"
+    begin
+      require "aws-sdk-v1"
+    rescue LoadError
+      onoe "Install the aws-sdk gem into the gem repo used by brew."
+      raise
+    end
+
+    if @url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$}
+      raise "Bad S3 URL: " + @url
+    end
+    bucket = Regexp.last_match(1)
+    key = Regexp.last_match(2)
+
+    ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
+    ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]
+
+    obj = AWS::S3.new.buckets[bucket].objects[key]
+    begin
+      s3url = obj.url_for(:get)
+    rescue AWS::Errors::MissingCredentialsError
+      ohai "AWS credentials missing, trying public URL instead."
+      s3url = obj.public_url
+    end
+
+    curl s3url, "-C", downloaded_size, "-o", temporary_path
+  end
+end
+
+# GitHubPrivateRepositoryDownloadStrategy downloads contents from GitHub
+# Private Repository. To use it, add
+# ":using => GitHubPrivateRepositoryDownloadStrategy" to the URL section of
+# your formula. This download strategy uses GitHub access tokens (in the
+# environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.  This
+# strategy is suitable for corporate use just like S3DownloadStrategy, because
+# it lets you use a private GitHub repository for internal distribution.  It
+# works with public one, but in that case simply use CurlDownloadStrategy.
+class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
+  require "utils/formatter"
+  require "utils/github"
+
+  def initialize(name, resource)
+    super
+    parse_url_pattern
+    set_github_token
+  end
+
+  def parse_url_pattern
+    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/(\S+)}
+    unless @url =~ url_pattern
+      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Repository."
+    end
+
+    _, @owner, @repo, @filepath = *@url.match(url_pattern)
+  end
+
+  def download_url
+    "https://#{@github_token}@github.com/#{@owner}/#{@repo}/#{@filepath}"
+  end
+
+  def _fetch
+    curl download_url, "-C", downloaded_size, "-o", temporary_path
+  end
+
+  private
+
+  def set_github_token
+    @github_token = ENV["HOMEBREW_GITHUB_API_TOKEN"]
+    unless @github_token
+      raise CurlDownloadStrategyError, "Environmental variable HOMEBREW_GITHUB_API_TOKEN is required."
+    end
+    validate_github_repository_access!
+  end
+
+  def validate_github_repository_access!
+    # Test access to the repository
+    GitHub.repository(@owner, @repo)
+  rescue GitHub::HTTPNotFoundError
+    # We only handle HTTPNotFoundError here,
+    # becase AuthenticationFailedError is handled within util/github.
+    message = <<-EOS.undent
+        HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
+        This token may not have permission to access the repository or the url of formula may be incorrect.
+    EOS
+    raise CurlDownloadStrategyError, message
+  end
+end
+
+# GitHubPrivateRepositoryReleaseDownloadStrategy downloads tarballs from GitHub
+# Release assets. To use it, add
+# ":using => GitHubPrivateRepositoryReleaseDownloadStrategy" to the URL section
+# of your formula. This download strategy uses GitHub access tokens (in the
+# environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
+class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
+  def parse_url_pattern
+    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
+    unless @url =~ url_pattern
+      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
+    end
+
+    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
+  end
+
+  def download_url
+    "https://#{@github_token}@api.github.com/repos/#{@owner}/#{@repo}/releases/assets/#{asset_id}"
+  end
+
+  def _fetch
+    # HTTP request header `Accept: application/octet-stream` is required.
+    # Without this, the GitHub API will respond with metadata, not binary.
+    curl download_url, "-C", downloaded_size, "-o", temporary_path, "-H", "Accept: application/octet-stream"
+  end
+
+  private
+
+  def asset_id
+    @asset_id ||= resolve_asset_id
+  end
+
+  def resolve_asset_id
+    release_metadata = fetch_release_metadata
+    assets = release_metadata["assets"].select { |a| a["name"] == @filename }
+    raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
+
+    assets.first["id"]
+  end
+
+  def fetch_release_metadata
+    release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
+    GitHub.open(release_url)
+  end
+end
+
+class SubversionDownloadStrategy < VCSDownloadStrategy
+  def initialize(name, resource)
+    super
+    @url = @url.sub("svn+http://", "")
+  end
+
+  def fetch
+    clear_cache unless @url.chomp("/") == repo_url || quiet_system("svn", "switch", @url, cached_location)
+    super
+  end
+
+  def stage
+    super
+    quiet_safe_system "svn", "export", "--force", cached_location, Dir.pwd
+  end
+
+  def source_modified_time
+    xml = REXML::Document.new(Utils.popen_read("svn", "info", "--xml", cached_location.to_s))
+    Time.parse REXML::XPath.first(xml, "//date/text()").to_s
+  end
+
+  def last_commit
+    Utils.popen_read("svn", "info", "--show-item", "revision", cached_location.to_s).strip
+  end
+
+  private
+
+  def repo_url
+    Utils.popen_read("svn", "info", cached_location.to_s).strip[/^URL: (.+)$/, 1]
+  end
+
+  def externals
+    Utils.popen_read("svn", "propget", "svn:externals", @url).chomp.each_line do |line|
+      name, url = line.split(/\s+/)
+      yield name, url
+    end
+  end
+
+  def fetch_repo(target, url, revision = nil, ignore_externals = false)
+    # Use "svn up" when the repository already exists locally.
+    # This saves on bandwidth and will have a similar effect to verifying the
+    # cache as it will make any changes to get the right revision.
+    svncommand = target.directory? ? "up" : "checkout"
+    args = ["svn", svncommand]
+    args << url unless target.directory?
+    args << target
+    if revision
+      ohai "Checking out #{@ref}"
+      args << "-r" << revision
+    end
+    args << "--ignore-externals" if ignore_externals
+    quiet_safe_system(*args)
+  end
+
+  def cache_tag
+    head? ? "svn-HEAD" : "svn"
+  end
+
+  def repo_valid?
+    (cached_location/".svn").directory?
+  end
+
+  def clone_repo
+    case @ref_type
+    when :revision
+      fetch_repo cached_location, @url, @ref
+    when :revisions
+      # nil is OK for main_revision, as fetch_repo will then get latest
+      main_revision = @ref[:trunk]
+      fetch_repo cached_location, @url, main_revision, true
+
+      externals do |external_name, external_url|
+        fetch_repo cached_location/external_name, external_url, @ref[external_name], true
+      end
+    else
+      fetch_repo cached_location, @url
+    end
+  end
+  alias update clone_repo
+end
+
+class GitDownloadStrategy < VCSDownloadStrategy
+  SHALLOW_CLONE_WHITELIST = [
+    %r{git://},
+    %r{https://github\.com},
+    %r{http://git\.sv\.gnu\.org},
+    %r{http://llvm\.org},
+  ].freeze
+
+  def initialize(name, resource)
+    super
+    @ref_type ||= :branch
+    @ref ||= "master"
+    @shallow = meta.fetch(:shallow) { true }
+  end
+
+  def stage
+    super
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
+  end
+
+  def source_modified_time
+    Time.parse Utils.popen_read("git", "--git-dir", git_dir, "show", "-s", "--format=%cD")
+  end
+
+  def last_commit
+    Utils.popen_read("git", "--git-dir", git_dir, "rev-parse", "--short=7", "HEAD").chomp
+  end
+
+  private
+
+  def cache_tag
+    "git"
+  end
+
+  def cache_version
+    0
+  end
+
+  def update
+    cached_location.cd do
+      config_repo
+      update_repo
+      checkout
+      reset
+      update_submodules if submodules?
+    end
+  end
+
+  def shallow_clone?
+    @shallow && support_depth?
+  end
+
+  def shallow_dir?
+    (git_dir/"shallow").exist?
+  end
+
+  def support_depth?
+    @ref_type != :revision && SHALLOW_CLONE_WHITELIST.any? { |regex| @url =~ regex }
+  end
+
+  def git_dir
+    cached_location/".git"
+  end
+
+  def ref?
+    quiet_system "git", "--git-dir", git_dir, "rev-parse", "-q", "--verify", "#{@ref}^{commit}"
+  end
+
+  def current_revision
+    Utils.popen_read("git", "--git-dir", git_dir, "rev-parse", "-q", "--verify", "HEAD").strip
+  end
+
+  def repo_valid?
+    quiet_system "git", "--git-dir", git_dir, "status", "-s"
+  end
+
+  def submodules?
+    (cached_location/".gitmodules").exist?
+  end
+
+  def clone_args
+    args = %w[clone]
+    args << "--depth" << "1" if shallow_clone?
+
+    case @ref_type
+    when :branch, :tag
+      args << "--branch" << @ref
+    end
+
+    args << @url << cached_location
+  end
+
+  def refspec
+    case @ref_type
+    when :branch then "+refs/heads/#{@ref}:refs/remotes/origin/#{@ref}"
+    when :tag    then "+refs/tags/#{@ref}:refs/tags/#{@ref}"
+    else              "+refs/heads/master:refs/remotes/origin/master"
+    end
+  end
+
+  def config_repo
+    safe_system "git", "config", "remote.origin.url", @url
+    safe_system "git", "config", "remote.origin.fetch", refspec
+  end
+
+  def update_repo
+    return unless @ref_type == :branch || !ref?
+
+    if !shallow_clone? && shallow_dir?
+      quiet_safe_system "git", "fetch", "origin", "--unshallow"
+    else
+      quiet_safe_system "git", "fetch", "origin"
+    end
+  end
+
+  def clone_repo
+    safe_system "git", *clone_args
+    cached_location.cd do
+      safe_system "git", "config", "homebrew.cacheversion", cache_version
+      checkout
+      update_submodules if submodules?
+    end
+  end
+
+  def checkout
+    ohai "Checking out #{@ref_type} #{@ref}" if @ref_type && @ref
+    quiet_safe_system "git", "checkout", "-f", @ref, "--"
+  end
+
+  def reset_args
+    ref = case @ref_type
+    when :branch
+      "origin/#{@ref}"
+    when :revision, :tag
+      @ref
+    end
+
+    %W[reset --hard #{ref}]
+  end
+
+  def reset
+    quiet_safe_system "git", *reset_args
+  end
+
+  def update_submodules
+    quiet_safe_system "git", "submodule", "foreach", "--recursive", "git submodule sync"
+    quiet_safe_system "git", "submodule", "update", "--init", "--recursive"
+    fix_absolute_submodule_gitdir_references!
+  end
+
+  def fix_absolute_submodule_gitdir_references!
+    # When checking out Git repositories with recursive submodules, some Git
+    # versions create `.git` files with absolute instead of relative `gitdir:`
+    # pointers. This works for the cached location, but breaks various Git
+    # operations once the affected Git resource is staged, i.e. recursively
+    # copied to a new location. (This bug was introduced in Git 2.7.0 and fixed
+    # in 2.8.3. Clones created with affected version remain broken.)
+    # See https://github.com/Homebrew/homebrew-core/pull/1520 for an example.
+    submodule_dirs = Utils.popen_read(
+      "git", "submodule", "--quiet", "foreach", "--recursive", "pwd"
+    )
+    submodule_dirs.lines.map(&:chomp).each do |submodule_dir|
+      work_dir = Pathname.new(submodule_dir)
+
+      # Only check and fix if `.git` is a regular file, not a directory.
+      dot_git = work_dir/".git"
+      next unless dot_git.file?
+
+      git_dir = dot_git.read.chomp[/^gitdir: (.*)$/, 1]
+      if git_dir.nil?
+        onoe "Failed to parse '#{dot_git}'." if ARGV.homebrew_developer?
+        next
+      end
+
+      # Only attempt to fix absolute paths.
+      next unless git_dir.start_with?("/")
+
+      # Make the `gitdir:` reference relative to the working directory.
+      relative_git_dir = Pathname.new(git_dir).relative_path_from(work_dir)
+      dot_git.atomic_write("gitdir: #{relative_git_dir}\n")
+    end
+  end
+end
+
+class GitHubGitDownloadStrategy < GitDownloadStrategy
+  def initialize(name, resource)
+    super
+
+    return unless %r{^https?://github\.com/(?<user>[^/]+)/(?<repo>[^/]+)\.git$} =~ @url
+    @user = user
+    @repo = repo
+  end
+
+  def github_last_commit
+    return if ENV["HOMEBREW_NO_GITHUB_API"]
+
+    output, _, status = curl_output "-H", "Accept: application/vnd.github.v3.sha", \
+      "-I", "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{@ref}"
+
+    commit = output[/^ETag: \"(\h+)\"/, 1] if status.success?
+    version.update_commit(commit) if commit
+    commit
+  end
+
+  def multiple_short_commits_exist?(commit)
+    return if ENV["HOMEBREW_NO_GITHUB_API"]
+    output, _, status = curl_output "-H", "Accept: application/vnd.github.v3.sha", \
+      "-I", "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{commit}"
+
+    !(status.success? && output && output[/^Status: (200)/, 1] == "200")
+  end
+
+  def commit_outdated?(commit)
+    @last_commit ||= github_last_commit
+    if !@last_commit
+      super
+    else
+      return true unless commit
+      return true unless @last_commit.start_with?(commit)
+      if multiple_short_commits_exist?(commit)
+        true
+      else
+        version.update_commit(commit)
+        false
+      end
+    end
+  end
+end
+
+class CVSDownloadStrategy < VCSDownloadStrategy
+  def initialize(name, resource)
+    super
+    @url = @url.sub(%r{^cvs://}, "")
+
+    if meta.key?(:module)
+      @module = meta.fetch(:module)
+    elsif @url !~ %r{:[^/]+$}
+      @module = name
+    else
+      @module, @url = split_url(@url)
+    end
+  end
+
+  def source_modified_time
+    # Filter CVS's files because the timestamp for each of them is the moment
+    # of clone.
+    max_mtime = Time.at(0)
+    cached_location.find do |f|
+      Find.prune if f.directory? && f.basename.to_s == "CVS"
+      next unless f.file?
+      mtime = f.mtime
+      max_mtime = mtime if mtime > max_mtime
+    end
+    max_mtime
+  end
+
+  def stage
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
+  end
+
+  private
+
+  def cache_tag
+    "cvs"
+  end
+
+  def repo_valid?
+    (cached_location/"CVS").directory?
+  end
+
+  def clone_repo
+    HOMEBREW_CACHE.cd do
+      # Login is only needed (and allowed) with pserver; skip for anoncvs.
+      quiet_safe_system cvspath, { quiet_flag: "-Q" }, "-d", @url, "login" if @url.include? "pserver"
+      quiet_safe_system cvspath, { quiet_flag: "-Q" }, "-d", @url, "checkout", "-d", cache_filename, @module
+    end
+  end
+
+  def update
+    cached_location.cd { quiet_safe_system cvspath, { quiet_flag: "-Q" }, "up" }
+  end
+
+  def split_url(in_url)
+    parts = in_url.split(/:/)
+    mod = parts.pop
+    url = parts.join(":")
+    [mod, url]
+  end
+end
+
+class MercurialDownloadStrategy < VCSDownloadStrategy
+  def initialize(name, resource)
+    super
+    @url = @url.sub(%r{^hg://}, "")
+  end
+
+  def stage
+    super
+
+    dst = Dir.getwd
+    cached_location.cd do
+      if @ref_type && @ref
+        ohai "Checking out #{@ref_type} #{@ref}" if @ref_type && @ref
+        safe_system hgpath, "archive", "--subrepos", "-y", "-r", @ref, "-t", "files", dst
+      else
+        safe_system hgpath, "archive", "--subrepos", "-y", "-t", "files", dst
+      end
+    end
+  end
+
+  def source_modified_time
+    Time.parse Utils.popen_read("hg", "tip", "--template", "{date|isodate}", "-R", cached_location.to_s)
+  end
+
+  def last_commit
+    Utils.popen_read("hg", "parent", "--template", "{node|short}", "-R", cached_location.to_s)
+  end
+
+  private
+
+  def cache_tag
+    "hg"
+  end
+
+  def repo_valid?
+    (cached_location/".hg").directory?
+  end
+
+  def clone_repo
+    safe_system hgpath, "clone", @url, cached_location
+  end
+
+  def update
+    cached_location.cd { quiet_safe_system hgpath, "pull", "--update" }
+  end
+end
+
+class BazaarDownloadStrategy < VCSDownloadStrategy
+  def initialize(name, resource)
+    super
+    @url = @url.sub(%r{^bzr://}, "")
+  end
+
+  def stage
+    # The export command doesn't work on checkouts
+    # See https://bugs.launchpad.net/bzr/+bug/897511
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
+    rm_r ".bzr"
+  end
+
+  def source_modified_time
+    Time.parse Utils.popen_read("bzr", "log", "-l", "1", "--timezone=utc", cached_location.to_s)[/^timestamp: (.+)$/, 1]
+  end
+
+  def last_commit
+    Utils.popen_read("bzr", "revno", cached_location.to_s).chomp
+  end
+
+  private
+
+  def cache_tag
+    "bzr"
+  end
+
+  def repo_valid?
+    (cached_location/".bzr").directory?
+  end
+
+  def clone_repo
+    # "lightweight" means history-less
+    safe_system bzrpath, "checkout", "--lightweight", @url, cached_location
+  end
+
+  def update
+    cached_location.cd { quiet_safe_system bzrpath, "update" }
+  end
+end
+
+class FossilDownloadStrategy < VCSDownloadStrategy
+  def initialize(name, resource)
+    super
+    @url = @url.sub(%r{^fossil://}, "")
+  end
+
+  def stage
+    super
+    args = [fossilpath, "open", cached_location]
+    args << @ref if @ref_type && @ref
+    safe_system(*args)
+  end
+
+  def source_modified_time
+    Time.parse Utils.popen_read("fossil", "info", "tip", "-R", cached_location.to_s)[/^uuid: +\h+ (.+)$/, 1]
+  end
+
+  def last_commit
+    Utils.popen_read("fossil", "info", "tip", "-R", cached_location.to_s)[/^uuid: +(\h+) .+$/, 1]
+  end
+
+  private
+
+  def cache_tag
+    "fossil"
+  end
+
+  def clone_repo
+    safe_system fossilpath, "clone", @url, cached_location
+  end
+
+  def update
+    safe_system fossilpath, "pull", "-R", cached_location
+  end
+end
+
+class DownloadStrategyDetector
+  def self.detect(url, strategy = nil)
+    if strategy.nil?
+      detect_from_url(url)
+    elsif strategy.is_a?(Class) && strategy < AbstractDownloadStrategy
+      strategy
+    elsif strategy.is_a?(Symbol)
+      detect_from_symbol(strategy)
+    else
+      raise TypeError,
+        "Unknown download strategy specification #{strategy.inspect}"
+    end
+  end
+
+  def self.detect_from_url(url)
+    case url
+    when %r{^https?://github\.com/[^/]+/[^/]+\.git$}
+      GitHubGitDownloadStrategy
+    when %r{^https?://.+\.git$}, %r{^git://}
+      GitDownloadStrategy
+    when %r{^https?://www\.apache\.org/dyn/closer\.cgi}, %r{^https?://www\.apache\.org/dyn/closer\.lua}
+      CurlApacheMirrorDownloadStrategy
+    when %r{^https?://(.+?\.)?googlecode\.com/svn}, %r{^https?://svn\.}, %r{^svn://}, %r{^https?://(.+?\.)?sourceforge\.net/svnroot/}
+      SubversionDownloadStrategy
+    when %r{^cvs://}
+      CVSDownloadStrategy
+    when %r{^https?://(.+?\.)?googlecode\.com/hg}
+      MercurialDownloadStrategy
+    when %r{^hg://}
+      MercurialDownloadStrategy
+    when %r{^bzr://}
+      BazaarDownloadStrategy
+    when %r{^fossil://}
+      FossilDownloadStrategy
+    when %r{^http://svn\.apache\.org/repos/}, %r{^svn\+http://}
+      SubversionDownloadStrategy
+    when %r{^https?://(.+?\.)?sourceforge\.net/hgweb/}
+      MercurialDownloadStrategy
+    else
+      CurlDownloadStrategy
+    end
+  end
+
+  def self.detect_from_symbol(symbol)
+    case symbol
+    when :hg      then MercurialDownloadStrategy
+    when :nounzip then NoUnzipCurlDownloadStrategy
+    when :git     then GitDownloadStrategy
+    when :bzr     then BazaarDownloadStrategy
+    when :svn     then SubversionDownloadStrategy
+    when :curl    then CurlDownloadStrategy
+    when :ssl3    then CurlSSL3DownloadStrategy
+    when :cvs     then CVSDownloadStrategy
+    when :post    then CurlPostDownloadStrategy
+    when :fossil  then FossilDownloadStrategy
+    else
+      raise "Unknown download strategy #{symbol} was requested."
+    end
+  end
+end

--- a/testdata/issue20/formula.rb
+++ b/testdata/issue20/formula.rb
@@ -1,0 +1,2492 @@
+require "formula_support"
+require "lock_file"
+require "formula_pin"
+require "hardware"
+require "utils/bottles"
+require "utils/shell"
+require "build_environment"
+require "build_options"
+require "formulary"
+require "software_spec"
+require "install_renamed"
+require "pkg_version"
+require "tap"
+require "keg"
+require "migrator"
+require "extend/ENV"
+
+# A formula provides instructions and metadata for Homebrew to install a piece
+# of software. Every Homebrew formula is a {Formula}.
+# All subclasses of {Formula} (and all Ruby classes) have to be named
+# `UpperCase` and `not-use-dashes`.
+# A formula specified in `this-formula.rb` should have a class named
+# `ThisFormula`. Homebrew does enforce that the name of the file and the class
+# correspond.
+# Make sure you check with `brew search` that the name is free!
+# @abstract
+# @see SharedEnvExtension
+# @see FileUtils
+# @see Pathname
+# @see http://docs.brew.sh/Formula-Cookbook.html Formula Cookbook
+# @see https://github.com/styleguide/ruby Ruby Style Guide
+#
+# <pre>class Wget < Formula
+#   homepage "https://www.gnu.org/software/wget/"
+#   url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz"
+#   sha256 "52126be8cf1bddd7536886e74c053ad7d0ed2aa89b4b630f76785bac21695fcd"
+#
+#   def install
+#     system "./configure", "--prefix=#{prefix}"
+#     system "make", "install"
+#   end
+# end</pre>
+class Formula
+  include FileUtils
+  include Utils::Inreplace
+  include Utils::Shell
+  extend Enumerable
+
+  # @!method inreplace(paths, before = nil, after = nil)
+  # Actually implemented in {Utils::Inreplace.inreplace}.
+  # Sometimes we have to change a bit before we install. Mostly we
+  # prefer a patch but if you need the `prefix` of this formula in the
+  # patch you have to resort to `inreplace`, because in the patch
+  # you don't have access to any var defined by the formula. Only
+  # HOMEBREW_PREFIX is available in the embedded patch.
+  # inreplace supports regular expressions.
+  # <pre>inreplace "somefile.cfg", /look[for]what?/, "replace by #{bin}/tool"</pre>
+  # @see Utils::Inreplace.inreplace
+
+  # The name of this {Formula}.
+  # e.g. `this-formula`
+  attr_reader :name
+
+  # The path to the alias that was used to identify this {Formula}.
+  # e.g. `/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/another-name-for-this-formula`
+  attr_reader :alias_path
+
+  # The name of the alias that was used to identify this {Formula}.
+  # e.g. `another-name-for-this-formula`
+  attr_reader :alias_name
+
+  # The fully-qualified name of this {Formula}.
+  # For core formula it's the same as {#name}.
+  # e.g. `homebrew/tap-name/this-formula`
+  attr_reader :full_name
+
+  # The fully-qualified alias referring to this {Formula}.
+  # For core formula it's the same as {#alias_name}.
+  # e.g. `homebrew/tap-name/another-name-for-this-formula`
+  attr_reader :full_alias_name
+
+  # The full path to this {Formula}.
+  # e.g. `/usr/local/Library/Taps/homebrew/homebrew-core/Formula/this-formula.rb`
+  attr_reader :path
+
+  # The {Tap} instance associated with this {Formula}.
+  # If it's <code>nil</code>, then this formula is loaded from path or URL.
+  # @private
+  attr_reader :tap
+
+  # The stable (and default) {SoftwareSpec} for this {Formula}
+  # This contains all the attributes (e.g. URL, checksum) that apply to the
+  # stable version of this formula.
+  # @private
+  attr_reader :stable
+
+  # The development {SoftwareSpec} for this {Formula}.
+  # Installed when using `brew install --devel`
+  # `nil` if there is no development version.
+  # @see #stable
+  # @private
+  attr_reader :devel
+
+  # The HEAD {SoftwareSpec} for this {Formula}.
+  # Installed when using `brew install --HEAD`
+  # This is always installed with the version `HEAD` and taken from the latest
+  # commit in the version control system.
+  # `nil` if there is no HEAD version.
+  # @see #stable
+  # @private
+  attr_reader :head
+
+  # The currently active {SoftwareSpec}.
+  # @see #determine_active_spec
+  attr_reader :active_spec
+  protected :active_spec
+
+  # A symbol to indicate currently active {SoftwareSpec}.
+  # It's either :stable, :devel or :head
+  # @see #active_spec
+  # @private
+  attr_reader :active_spec_sym
+
+  # most recent modified time for source files
+  # @private
+  attr_reader :source_modified_time
+
+  # Used for creating new Homebrew versions of software without new upstream
+  # versions.
+  # @see .revision
+  attr_reader :revision
+
+  # Used to change version schemes for packages
+  attr_reader :version_scheme
+
+  # The current working directory during builds.
+  # Will only be non-`nil` inside {#install}.
+  attr_reader :buildpath
+
+  # The current working directory during tests.
+  # Will only be non-`nil` inside {#test}.
+  attr_reader :testpath
+
+  # When installing a bottle (binary package) from a local path this will be
+  # set to the full path to the bottle tarball. If not, it will be `nil`.
+  # @private
+  attr_accessor :local_bottle_path
+
+  # When performing a build, test, or other loggable action, indicates which
+  # log file location to use.
+  # @private
+  attr_reader :active_log_type
+
+  # The {BuildOptions} for this {Formula}. Lists the arguments passed and any
+  # {#options} in the {Formula}. Note that these may differ at different times
+  # during the installation of a {Formula}. This is annoying but the result of
+  # state that we're trying to eliminate.
+  # @return [BuildOptions]
+  attr_accessor :build
+
+  # A {Boolean} indicating whether this formula should be considered outdated
+  # if the target of the alias it was installed with has since changed.
+  # Defaults to true.
+  # @return [Boolean]
+  attr_accessor :follow_installed_alias
+  alias follow_installed_alias? follow_installed_alias
+
+  # @private
+  def initialize(name, path, spec, alias_path: nil)
+    @name = name
+    @path = path
+    @alias_path = alias_path
+    @alias_name = File.basename(alias_path) if alias_path
+    @revision = self.class.revision || 0
+    @version_scheme = self.class.version_scheme || 0
+
+    @tap = if path == Formulary.core_path(name)
+      CoreTap.instance
+    elsif path.to_s =~ HOMEBREW_TAP_PATH_REGEX
+      Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
+    end
+
+    @full_name = full_name_with_optional_tap(name)
+    @full_alias_name = full_name_with_optional_tap(@alias_name)
+
+    spec_eval :stable
+    spec_eval :devel
+    spec_eval :head
+
+    @active_spec = determine_active_spec(spec)
+    @active_spec_sym = if head?
+      :head
+    elsif devel?
+      :devel
+    else
+      :stable
+    end
+    validate_attributes!
+    @build = active_spec.build
+    @pin = FormulaPin.new(self)
+    @follow_installed_alias = true
+    @prefix_returns_versioned_prefix = false
+  end
+
+  # @private
+  def active_spec=(spec_sym)
+    spec = send(spec_sym)
+    raise FormulaSpecificationError, "#{spec_sym} spec is not available for #{full_name}" unless spec
+    @active_spec = spec
+    @active_spec_sym = spec_sym
+    validate_attributes!
+    @build = active_spec.build
+  end
+
+  private
+
+  # Allow full name logic to be re-used between names, aliases,
+  # and installed aliases.
+  def full_name_with_optional_tap(name)
+    if name.nil? || @tap.nil? || @tap.core_tap?
+      name
+    else
+      "#{@tap}/#{name}"
+    end
+  end
+
+  def spec_eval(name)
+    spec = self.class.send(name)
+    return unless spec.url
+    spec.owner = self
+    instance_variable_set("@#{name}", spec)
+  end
+
+  def determine_active_spec(requested)
+    spec = send(requested) || stable || devel || head
+    spec || raise(FormulaSpecificationError, "formulae require at least a URL")
+  end
+
+  def validate_attributes!
+    if name.nil? || name.empty? || name =~ /\s/
+      raise FormulaValidationError.new(full_name, :name, name)
+    end
+
+    url = active_spec.url
+    if url.nil? || url.empty? || url =~ /\s/
+      raise FormulaValidationError.new(full_name, :url, url)
+    end
+
+    val = version.respond_to?(:to_str) ? version.to_str : version
+    return unless val.nil? || val.empty? || val =~ /\s/
+    raise FormulaValidationError.new(full_name, :version, val)
+  end
+
+  public
+
+  # The alias path that was used to install this formula, if it exists.
+  # Can differ from alias_path, which is the alias used to find the formula,
+  # and is specified to this instance.
+  def installed_alias_path
+    path = build.source["path"] if build.is_a?(Tab)
+    return unless path =~ %r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases}
+    return unless File.symlink?(path)
+    path
+  end
+
+  def installed_alias_name
+    File.basename(installed_alias_path) if installed_alias_path
+  end
+
+  def full_installed_alias_name
+    full_name_with_optional_tap(installed_alias_name)
+  end
+
+  # The path that was specified to find this formula.
+  def specified_path
+    alias_path || path
+  end
+
+  # The name specified to find this formula.
+  def specified_name
+    alias_name || name
+  end
+
+  # The name (including tap) specified to find this formula.
+  def full_specified_name
+    full_alias_name || full_name
+  end
+
+  # The name specified to install this formula.
+  def installed_specified_name
+    installed_alias_name || name
+  end
+
+  # The name (including tap) specified to install this formula.
+  def full_installed_specified_name
+    full_installed_alias_name || full_name
+  end
+
+  # Is the currently active {SoftwareSpec} a {#stable} build?
+  # @private
+  def stable?
+    active_spec == stable
+  end
+
+  # Is the currently active {SoftwareSpec} a {#devel} build?
+  # @private
+  def devel?
+    active_spec == devel
+  end
+
+  # Is the currently active {SoftwareSpec} a {#head} build?
+  # @private
+  def head?
+    active_spec == head
+  end
+
+  # @private
+  def bottle_unneeded?
+    active_spec.bottle_unneeded?
+  end
+
+  # @private
+  def bottle_disabled?
+    active_spec.bottle_disabled?
+  end
+
+  # @private
+  def bottle_disable_reason
+    active_spec.bottle_disable_reason
+  end
+
+  # Does the currently active {SoftwareSpec} have any bottle?
+  # @private
+  def bottle_defined?
+    active_spec.bottle_defined?
+  end
+
+  # Does the currently active {SoftwareSpec} have an installable bottle?
+  # @private
+  def bottled?
+    active_spec.bottled?
+  end
+
+  # @private
+  def bottle_specification
+    active_spec.bottle_specification
+  end
+
+  # The Bottle object for the currently active {SoftwareSpec}.
+  # @private
+  def bottle
+    Bottle.new(self, bottle_specification) if bottled?
+  end
+
+  # The description of the software.
+  # @see .desc
+  def desc
+    self.class.desc
+  end
+
+  # The homepage for the software.
+  # @see .homepage
+  def homepage
+    self.class.homepage
+  end
+
+  # The version for the currently active {SoftwareSpec}.
+  # The version is autodetected from the URL and/or tag so only needs to be
+  # declared if it cannot be autodetected correctly.
+  # @see .version
+  def version
+    active_spec.version
+  end
+
+  def update_head_version
+    return unless head?
+    return unless head.downloader.is_a?(VCSDownloadStrategy)
+    return unless head.downloader.cached_location.exist?
+
+    head.version.update_commit(head.downloader.last_commit)
+  end
+
+  # The {PkgVersion} for this formula with {version} and {#revision} information.
+  def pkg_version
+    PkgVersion.new(version, revision)
+  end
+
+  # If this is a `@`-versioned formula.
+  def versioned_formula?
+    name.include?("@")
+  end
+
+  # A named Resource for the currently active {SoftwareSpec}.
+  # Additional downloads can be defined as {#resource}s.
+  # {Resource#stage} will create a temporary directory and yield to a block.
+  # <pre>resource("additional_files").stage { bin.install "my/extra/tool" }</pre>
+  def resource(name)
+    active_spec.resource(name)
+  end
+
+  # An old name for the formula
+  def oldname
+    @oldname ||= if tap
+      formula_renames = tap.formula_renames
+      formula_renames.to_a.rassoc(name).first if formula_renames.value?(name)
+    end
+  end
+
+  # All of aliases for the formula
+  def aliases
+    @aliases ||= if tap
+      tap.alias_reverse_table[full_name] || []
+    else
+      []
+    end
+  end
+
+  # The {Resource}s for the currently active {SoftwareSpec}.
+  def resources
+    active_spec.resources.values
+  end
+
+  # The {Dependency}s for the currently active {SoftwareSpec}.
+  # @private
+  def deps
+    active_spec.deps
+  end
+
+  # The {Requirement}s for the currently active {SoftwareSpec}.
+  # @private
+  def requirements
+    active_spec.requirements
+  end
+
+  # The cached download for the currently active {SoftwareSpec}.
+  # @private
+  def cached_download
+    active_spec.cached_download
+  end
+
+  # Deletes the download for the currently active {SoftwareSpec}.
+  # @private
+  def clear_cache
+    active_spec.clear_cache
+  end
+
+  # The list of patches for the currently active {SoftwareSpec}.
+  # @private
+  def patchlist
+    active_spec.patches
+  end
+
+  # The options for the currently active {SoftwareSpec}.
+  # @private
+  def options
+    active_spec.options
+  end
+
+  # The deprecated options for the currently active {SoftwareSpec}.
+  # @private
+  def deprecated_options
+    active_spec.deprecated_options
+  end
+
+  # The deprecated option flags for the currently active {SoftwareSpec}.
+  # @private
+  def deprecated_flags
+    active_spec.deprecated_flags
+  end
+
+  # If a named option is defined for the currently active {SoftwareSpec}.
+  def option_defined?(name)
+    active_spec.option_defined?(name)
+  end
+
+  # All the {.fails_with} for the currently active {SoftwareSpec}.
+  # @private
+  def compiler_failures
+    active_spec.compiler_failures
+  end
+
+  # If this {Formula} is installed.
+  # This is actually just a check for if the {#installed_prefix} directory
+  # exists and is not empty.
+  # @private
+  def installed?
+    (dir = installed_prefix).directory? && !dir.children.empty?
+  end
+
+  # If at least one version of {Formula} is installed.
+  # @private
+  def any_version_installed?
+    require "tab"
+    installed_prefixes.any? { |keg| (keg/Tab::FILENAME).file? }
+  end
+
+  # @private
+  # The link status symlink directory for this {Formula}.
+  # You probably want {#opt_prefix} instead.
+  def linked_keg
+    HOMEBREW_LINKED_KEGS/name
+  end
+
+  def latest_head_version
+    head_versions = installed_prefixes.map do |pn|
+      pn_pkgversion = PkgVersion.parse(pn.basename.to_s)
+      pn_pkgversion if pn_pkgversion.head?
+    end.compact
+
+    head_versions.max_by do |pn_pkgversion|
+      [Tab.for_keg(prefix(pn_pkgversion)).source_modified_time, pn_pkgversion.revision]
+    end
+  end
+
+  def latest_head_prefix
+    head_version = latest_head_version
+    prefix(head_version) if head_version
+  end
+
+  def head_version_outdated?(version, options = {})
+    tab = Tab.for_keg(prefix(version))
+
+    return true if tab.version_scheme < version_scheme
+    return true if stable && tab.stable_version && tab.stable_version < stable.version
+    return true if devel && tab.devel_version && tab.devel_version < devel.version
+
+    if options[:fetch_head]
+      return false unless head && head.downloader.is_a?(VCSDownloadStrategy)
+      downloader = head.downloader
+      downloader.shutup! unless ARGV.verbose?
+      downloader.commit_outdated?(version.version.commit)
+    else
+      false
+    end
+  end
+
+  # The latest prefix for this formula. Checks for {#head}, then {#devel}
+  # and then {#stable}'s {#prefix}
+  # @private
+  def installed_prefix
+    if head && (head_version = latest_head_version) && !head_version_outdated?(head_version)
+      latest_head_prefix
+    elsif devel && (devel_prefix = prefix(PkgVersion.new(devel.version, revision))).directory?
+      devel_prefix
+    elsif stable && (stable_prefix = prefix(PkgVersion.new(stable.version, revision))).directory?
+      stable_prefix
+    else
+      prefix
+    end
+  end
+
+  # The currently installed version for this formula. Will raise an exception
+  # if the formula is not installed.
+  # @private
+  def installed_version
+    Keg.new(installed_prefix).version
+  end
+
+  # The directory in the cellar that the formula is installed to.
+  # This directory points to {#opt_prefix} if it exists and if #{prefix} is not
+  # called from within the same formula's {#install} or {#post_install} methods.
+  # Otherwise, return the full path to the formula's versioned cellar.
+  def prefix(v = pkg_version)
+    versioned_prefix = versioned_prefix(v)
+    if !@prefix_returns_versioned_prefix && v == pkg_version &&
+       versioned_prefix.directory? && Keg.new(versioned_prefix).optlinked?
+      opt_prefix
+    else
+      versioned_prefix
+    end
+  end
+
+  # Is the formula linked?
+  def linked?
+    linked_keg.symlink?
+  end
+
+  # Is the formula linked to opt?
+  def optlinked?
+    opt_prefix.symlink?
+  end
+
+  # Is formula's linked keg points to the prefix.
+  def prefix_linked?(v = pkg_version)
+    return false unless linked?
+    linked_keg.resolved_path == versioned_prefix(v)
+  end
+
+  # {PkgVersion} of the linked keg for the formula.
+  def linked_version
+    return unless linked?
+    Keg.for(linked_keg).version
+  end
+
+  # The parent of the prefix; the named directory in the cellar containing all
+  # installed versions of this software
+  # @private
+  def rack
+    Pathname.new("#{HOMEBREW_CELLAR}/#{name}")
+  end
+
+  # All currently installed prefix directories.
+  # @private
+  def installed_prefixes
+    rack.directory? ? rack.subdirs : []
+  end
+
+  # All currently installed kegs.
+  # @private
+  def installed_kegs
+    installed_prefixes.map { |dir| Keg.new(dir) }
+  end
+
+  # The directory where the formula's binaries should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # Need to install into the {.bin} but the makefile doesn't mkdir -p prefix/bin?
+  # <pre>bin.mkpath</pre>
+  #
+  # No `make install` available?
+  # <pre>bin.install "binary1"</pre>
+  def bin
+    prefix/"bin"
+  end
+
+  # The directory where the formula's documentation should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def doc
+    share/"doc"/name
+  end
+
+  # The directory where the formula's headers should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # No `make install` available?
+  # <pre>include.install "example.h"</pre>
+  def include
+    prefix/"include"
+  end
+
+  # The directory where the formula's info files should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def info
+    share/"info"
+  end
+
+  # The directory where the formula's libraries should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # No `make install` available?
+  # <pre>lib.install "example.dylib"</pre>
+  def lib
+    prefix/"lib"
+  end
+
+  # The directory where the formula's binaries should be installed.
+  # This is not symlinked into `HOMEBREW_PREFIX`.
+  # It is also commonly used to install files that we do not wish to be
+  # symlinked into HOMEBREW_PREFIX from one of the other directories and
+  # instead manually create symlinks or wrapper scripts into e.g. {#bin}.
+  def libexec
+    prefix/"libexec"
+  end
+
+  # The root directory where the formula's manual pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  # Often one of the more specific `man` functions should be used instead
+  # e.g. {#man1}
+  def man
+    share/"man"
+  end
+
+  # The directory where the formula's man1 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # No `make install` available?
+  # <pre>man1.install "example.1"</pre>
+  def man1
+    man/"man1"
+  end
+
+  # The directory where the formula's man2 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man2
+    man/"man2"
+  end
+
+  # The directory where the formula's man3 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # No `make install` available?
+  # <pre>man3.install "man.3"</pre>
+  def man3
+    man/"man3"
+  end
+
+  # The directory where the formula's man4 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man4
+    man/"man4"
+  end
+
+  # The directory where the formula's man5 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man5
+    man/"man5"
+  end
+
+  # The directory where the formula's man6 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man6
+    man/"man6"
+  end
+
+  # The directory where the formula's man7 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man7
+    man/"man7"
+  end
+
+  # The directory where the formula's man8 pages should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def man8
+    man/"man8"
+  end
+
+  # The directory where the formula's `sbin` binaries should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  # Generally we try to migrate these to {#bin} instead.
+  def sbin
+    prefix/"sbin"
+  end
+
+  # The directory where the formula's shared files should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # Need a custom directory?
+  # <pre>(share/"concept").mkpath</pre>
+  #
+  # Installing something into another custom directory?
+  # <pre>(share/"concept2").install "ducks.txt"</pre>
+  #
+  # Install `./example_code/simple/ones` to share/demos
+  # <pre>(share/"demos").install "example_code/simple/ones"</pre>
+  #
+  # Install `./example_code/simple/ones` to share/demos/examples
+  # <pre>(share/"demos").install "example_code/simple/ones" => "examples"</pre>
+  def share
+    prefix/"share"
+  end
+
+  # The directory where the formula's shared files should be installed,
+  # with the name of the formula appended to avoid linking conflicts.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  #
+  # No `make install` available?
+  # <pre>pkgshare.install "examples"</pre>
+  def pkgshare
+    prefix/"share"/name
+  end
+
+  # The directory where Emacs Lisp files should be installed, with the
+  # formula name appended to avoid linking conflicts.
+  #
+  # Install an Emacs mode included with a software package:
+  # <pre>elisp.install "contrib/emacs/example-mode.el"</pre>
+  def elisp
+    prefix/"share/emacs/site-lisp"/name
+  end
+
+  # The directory where the formula's Frameworks should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  # This is not symlinked into `HOMEBREW_PREFIX`.
+  def frameworks
+    prefix/"Frameworks"
+  end
+
+  # The directory where the formula's kernel extensions should be installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  # This is not symlinked into `HOMEBREW_PREFIX`.
+  def kext_prefix
+    prefix/"Library/Extensions"
+  end
+
+  # The directory where the formula's configuration files should be installed.
+  # Anything using `etc.install` will not overwrite other files on e.g. upgrades
+  # but will write a new file named `*.default`.
+  # This directory is not inside the `HOMEBREW_CELLAR` so it is persisted
+  # across upgrades.
+  def etc
+    (HOMEBREW_PREFIX/"etc").extend(InstallRenamed)
+  end
+
+  # The directory where the formula's variable files should be installed.
+  # This directory is not inside the `HOMEBREW_CELLAR` so it is persisted
+  # across upgrades.
+  def var
+    HOMEBREW_PREFIX/"var"
+  end
+
+  # The directory where the formula's ZSH function files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def zsh_function
+    share/"zsh/site-functions"
+  end
+
+  # The directory where the formula's fish function files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def fish_function
+    share/"fish/vendor_functions.d"
+  end
+
+  # The directory where the formula's Bash completion files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def bash_completion
+    prefix/"etc/bash_completion.d"
+  end
+
+  # The directory where the formula's ZSH completion files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def zsh_completion
+    share/"zsh/site-functions"
+  end
+
+  # The directory where the formula's fish completion files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def fish_completion
+    share/"fish/vendor_completions.d"
+  end
+
+  # The directory used for as the prefix for {#etc} and {#var} files on
+  # installation so, despite not being in `HOMEBREW_CELLAR`, they are installed
+  # there after pouring a bottle.
+  # @private
+  def bottle_prefix
+    prefix/".bottle"
+  end
+
+  # The directory where the formula's installation or test logs will be written.
+  # @private
+  def logs
+    HOMEBREW_LOGS + name
+  end
+
+  # The prefix, if any, to use in filenames for logging current activity
+  def active_log_prefix
+    if active_log_type
+      "#{active_log_type}."
+    else
+      ""
+    end
+  end
+
+  # Runs a block with the given log type in effect for its duration
+  def with_logging(log_type)
+    old_log_type = @active_log_type
+    @active_log_type = log_type
+    yield
+  ensure
+    @active_log_type = old_log_type
+  end
+
+  # This method can be overridden to provide a plist.
+  # For more examples read Apple's handy manpage:
+  # https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/plist.5.html
+  # <pre>def plist; <<-EOS.undent
+  #  <?xml version="1.0" encoding="UTF-8"?>
+  #  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  #  <plist version="1.0">
+  #  <dict>
+  #    <key>Label</key>
+  #      <string>#{plist_name}</string>
+  #    <key>ProgramArguments</key>
+  #    <array>
+  #      <string>#{opt_bin}/example</string>
+  #      <string>--do-this</string>
+  #    </array>
+  #    <key>RunAtLoad</key>
+  #    <true/>
+  #    <key>KeepAlive</key>
+  #    <true/>
+  #    <key>StandardErrorPath</key>
+  #    <string>/dev/null</string>
+  #    <key>StandardOutPath</key>
+  #    <string>/dev/null</string>
+  #  </plist>
+  #  EOS
+  # end</pre>
+  def plist
+    nil
+  end
+
+  # The generated launchd {.plist} service name.
+  def plist_name
+    "homebrew.mxcl." + name
+  end
+
+  # The generated launchd {.plist} file path.
+  def plist_path
+    prefix + (plist_name + ".plist")
+  end
+
+  # @private
+  def plist_manual
+    self.class.plist_manual
+  end
+
+  # @private
+  def plist_startup
+    self.class.plist_startup
+  end
+
+  # A stable path for this formula, when installed. Contains the formula name
+  # but no version number. Only the active version will be linked here if
+  # multiple versions are installed.
+  #
+  # This is the prefered way to refer a formula in plists or from another
+  # formula, as the path is stable even when the software is updated.
+  # <pre>args << "--with-readline=#{Formula["readline"].opt_prefix}" if build.with? "readline"</pre>
+  def opt_prefix
+    Pathname.new("#{HOMEBREW_PREFIX}/opt/#{name}")
+  end
+
+  def opt_bin
+    opt_prefix/"bin"
+  end
+
+  def opt_include
+    opt_prefix/"include"
+  end
+
+  def opt_lib
+    opt_prefix/"lib"
+  end
+
+  def opt_libexec
+    opt_prefix/"libexec"
+  end
+
+  def opt_sbin
+    opt_prefix/"sbin"
+  end
+
+  def opt_share
+    opt_prefix/"share"
+  end
+
+  def opt_pkgshare
+    opt_prefix/"share"/name
+  end
+
+  def opt_elisp
+    opt_prefix/"share/emacs/site-lisp"/name
+  end
+
+  def opt_frameworks
+    opt_prefix/"Frameworks"
+  end
+
+  # Indicates that this formula supports bottles. (Not necessarily that one
+  # should be used in the current installation run.)
+  # Can be overridden to selectively disable bottles from formulae.
+  # Defaults to true so overridden version does not have to check if bottles
+  # are supported.
+  # Replaced by {.pour_bottle}'s `satisfy` method if it is specified.
+  def pour_bottle?
+    true
+  end
+
+  # @private
+  def pour_bottle_check_unsatisfied_reason
+    self.class.pour_bottle_check_unsatisfied_reason
+  end
+
+  # Can be overridden to run commands on both source and bottle installation.
+  def post_install; end
+
+  # @private
+  def run_post_install
+    @prefix_returns_versioned_prefix = true
+    build = self.build
+    self.build = Tab.for_formula(self)
+
+    old_tmpdir = ENV["TMPDIR"]
+    old_temp = ENV["TEMP"]
+    old_tmp = ENV["TMP"]
+    old_path = ENV["HOMEBREW_PATH"]
+
+    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
+    ENV["HOMEBREW_PATH"] = nil
+
+    ENV.clear_sensitive_environment!
+
+    Pathname.glob("#{bottle_prefix}/{etc,var}/**/*") do |path|
+      path.extend(InstallRenamed)
+      path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
+    end
+
+    with_logging("post_install") do
+      post_install
+    end
+  ensure
+    self.build = build
+    ENV["TMPDIR"] = old_tmpdir
+    ENV["TEMP"] = old_temp
+    ENV["TMP"] = old_tmp
+    ENV["HOMEBREW_PATH"] = old_path
+    @prefix_returns_versioned_prefix = false
+  end
+
+  # Tell the user about any Homebrew-specific caveats or locations regarding
+  # this package. These should not contain setup instructions that would apply
+  # to installation through a different package manager on a different OS.
+  # @return [String]
+  # <pre>def caveats
+  #   <<-EOS.undent
+  #     Are optional. Something the user should know?
+  #   EOS
+  # end</pre>
+  #
+  # <pre>def caveats
+  #   s = <<-EOS.undent
+  #     Print some important notice to the user when `brew info <formula>` is
+  #     called or when brewing a formula.
+  #     This is optional. You can use all the vars like #{version} here.
+  #   EOS
+  #   s += "Some issue only on older systems" if MacOS.version < :mountain_lion
+  #   s
+  # end</pre>
+  def caveats
+    nil
+  end
+
+  # rarely, you don't want your library symlinked into the main prefix
+  # see gettext.rb for an example
+  def keg_only?
+    keg_only_reason && keg_only_reason.valid?
+  end
+
+  # @private
+  def keg_only_reason
+    self.class.keg_only_reason
+  end
+
+  # sometimes the formula cleaner breaks things
+  # skip cleaning paths in a formula with a class method like this:
+  #   skip_clean "bin/foo", "lib/bar"
+  # keep .la files with:
+  #   skip_clean :la
+  # @private
+  def skip_clean?(path)
+    return true if path.extname == ".la" && self.class.skip_clean_paths.include?(:la)
+    to_check = path.relative_path_from(prefix).to_s
+    self.class.skip_clean_paths.include? to_check
+  end
+
+  # Sometimes we accidentally install files outside prefix. After we fix that,
+  # users will get nasty link conflict error. So we create a whitelist here to
+  # allow overwriting certain files. e.g.
+  #   link_overwrite "bin/foo", "lib/bar"
+  #   link_overwrite "share/man/man1/baz-*"
+  # @private
+  def link_overwrite?(path)
+    # Don't overwrite files not created by Homebrew.
+    return false unless path.stat.uid == HOMEBREW_BREW_FILE.stat.uid
+    # Don't overwrite files belong to other keg except when that
+    # keg's formula is deleted.
+    begin
+      keg = Keg.for(path)
+    rescue NotAKegError, Errno::ENOENT
+      # file doesn't belong to any keg.
+    else
+      tab_tap = Tab.for_keg(keg).tap
+      return false if tab_tap.nil? # this keg doesn't below to any core/tap formula, most likely coming from a DIY install.
+      begin
+        Formulary.factory(keg.name)
+      rescue FormulaUnavailableError
+        # formula for this keg is deleted, so defer to whitelist
+      rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
+        return false # this keg belongs to another formula
+      else
+        return false # this keg belongs to another formula
+      end
+    end
+    to_check = path.relative_path_from(HOMEBREW_PREFIX).to_s
+    self.class.link_overwrite_paths.any? do |p|
+      p == to_check ||
+        to_check.start_with?(p.chomp("/") + "/") ||
+        to_check =~ /^#{Regexp.escape(p).gsub('\*', ".*?")}$/
+    end
+  end
+
+  def skip_cxxstdlib_check?
+    false
+  end
+
+  # @private
+  def require_universal_deps?
+    false
+  end
+
+  # @private
+  def patch
+    return if patchlist.empty?
+    ohai "Patching"
+    patchlist.each(&:apply)
+  end
+
+  # yields |self,staging| with current working directory set to the uncompressed tarball
+  # where staging is a Mktemp staging context
+  # @private
+  def brew
+    @prefix_returns_versioned_prefix = true
+    stage do |staging|
+      staging.retain! if ARGV.keep_tmp?
+      prepare_patches
+
+      begin
+        yield self, staging
+      rescue StandardError
+        staging.retain! if ARGV.interactive? || ARGV.debug?
+        raise
+      ensure
+        cp Dir["config.log", "CMakeCache.txt"], logs
+      end
+    end
+  ensure
+    @prefix_returns_versioned_prefix = false
+  end
+
+  # @private
+  def lock
+    @lock = FormulaLock.new(name)
+    @lock.lock
+    return unless oldname
+    return unless (oldname_rack = HOMEBREW_CELLAR/oldname).exist?
+    return unless oldname_rack.resolved_path == rack
+    @oldname_lock = FormulaLock.new(oldname)
+    @oldname_lock.lock
+  end
+
+  # @private
+  def unlock
+    @lock.unlock unless @lock.nil?
+    @oldname_lock.unlock unless @oldname_lock.nil?
+  end
+
+  def migration_needed?
+    return false unless oldname
+    return false if rack.exist?
+
+    old_rack = HOMEBREW_CELLAR/oldname
+    return false unless old_rack.directory?
+    return false if old_rack.subdirs.empty?
+
+    tap == Tab.for_keg(old_rack.subdirs.first).tap
+  end
+
+  # @private
+  def outdated_kegs(options = {})
+    @outdated_kegs ||= Hash.new do |cache, key|
+      raise Migrator::MigrationNeededError, self if migration_needed?
+      cache[key] = _outdated_kegs(key)
+    end
+    @outdated_kegs[options]
+  end
+
+  def _outdated_kegs(options = {})
+    all_kegs = []
+
+    installed_kegs.each do |keg|
+      all_kegs << keg
+      version = keg.version
+      next if version.head?
+
+      tab = Tab.for_keg(keg)
+      next if version_scheme > tab.version_scheme
+      next if version_scheme == tab.version_scheme && pkg_version > version
+
+      # don't consider this keg current if there's a newer formula available
+      next if follow_installed_alias? && new_formula_available?
+
+      return [] # this keg is the current version of the formula, so it's not outdated
+    end
+
+    # Even if this formula hasn't been installed, there may be installations
+    # of other formulae which used to be targets of the alias currently
+    # targetting this formula. These should be counted as outdated versions.
+    all_kegs.concat old_installed_formulae.flat_map(&:installed_kegs)
+
+    head_version = latest_head_version
+    if head_version && !head_version_outdated?(head_version, options)
+      []
+    else
+      all_kegs.sort_by(&:version)
+    end
+  end
+
+  def new_formula_available?
+    installed_alias_target_changed? && !latest_formula.installed?
+  end
+
+  def current_installed_alias_target
+    Formulary.factory(installed_alias_path) if installed_alias_path
+  end
+
+  # Has the target of the alias used to install this formula changed?
+  # Returns false if the formula wasn't installed with an alias.
+  def installed_alias_target_changed?
+    target = current_installed_alias_target
+    target && target.name != name
+  end
+
+  # Is this formula the target of an alias used to install an old formula?
+  def supersedes_an_installed_formula?
+    old_installed_formulae.any?
+  end
+
+  # Has the alias used to install the formula changed, or are different
+  # formulae already installed with this alias?
+  def alias_changed?
+    installed_alias_target_changed? || supersedes_an_installed_formula?
+  end
+
+  # If the alias has changed value, return the new formula.
+  # Otherwise, return self.
+  def latest_formula
+    installed_alias_target_changed? ? current_installed_alias_target : self
+  end
+
+  def old_installed_formulae
+    # If this formula isn't the current target of the alias,
+    # it doesn't make sense to say that other formulae are older versions of it
+    # because we don't know which came first.
+    return [] if alias_path.nil? || installed_alias_target_changed?
+    self.class.installed_with_alias_path(alias_path).reject { |f| f.name == name }
+  end
+
+  # @private
+  def outdated?(options = {})
+    !outdated_kegs(options).empty?
+  rescue Migrator::MigrationNeededError
+    true
+  end
+
+  # @private
+  def pinnable?
+    @pin.pinnable?
+  end
+
+  # @private
+  def pinned?
+    @pin.pinned?
+  end
+
+  # @private
+  def pinned_version
+    @pin.pinned_version
+  end
+
+  # @private
+  def pin
+    @pin.pin
+  end
+
+  # @private
+  def unpin
+    @pin.unpin
+  end
+
+  # @private
+  def ==(other)
+    instance_of?(other.class) &&
+      name == other.name &&
+      active_spec == other.active_spec
+  end
+  alias eql? ==
+
+  # @private
+  def hash
+    name.hash
+  end
+
+  # @private
+  def <=>(other)
+    return unless other.is_a?(Formula)
+    name <=> other.name
+  end
+
+  def to_s
+    name
+  end
+
+  # @private
+  def inspect
+    "#<Formula #{name} (#{active_spec_sym}) #{path}>"
+  end
+
+  # Standard parameters for CMake builds.
+  # Setting CMAKE_FIND_FRAMEWORK to "LAST" tells CMake to search for our
+  # libraries before trying to utilize Frameworks, many of which will be from
+  # 3rd party installs.
+  # Note: there isn't a std_autotools variant because autotools is a lot
+  # less consistent and the standard parameters are more memorable.
+  def std_cmake_args
+    args = %W[
+      -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
+      -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
+      -DCMAKE_INSTALL_PREFIX=#{prefix}
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_FIND_FRAMEWORK=LAST
+      -DCMAKE_VERBOSE_MAKEFILE=ON
+      -Wno-dev
+    ]
+
+    # Avoid false positives for clock_gettime support on 10.11.
+    # CMake cache entries for other weak symbols may be added here as needed.
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0"
+    end
+
+    args
+  end
+
+  # an array of all core {Formula} names
+  # @private
+  def self.core_names
+    CoreTap.instance.formula_names
+  end
+
+  # an array of all core {Formula} files
+  # @private
+  def self.core_files
+    CoreTap.instance.formula_files
+  end
+
+  # an array of all tap {Formula} names
+  # @private
+  def self.tap_names
+    @tap_names ||= Tap.reject(&:core_tap?).flat_map(&:formula_names).sort
+  end
+
+  # an array of all tap {Formula} files
+  # @private
+  def self.tap_files
+    @tap_files ||= Tap.reject(&:core_tap?).flat_map(&:formula_files)
+  end
+
+  # an array of all {Formula} names
+  # @private
+  def self.names
+    @names ||= (core_names + tap_names.map { |name| name.split("/")[-1] }).uniq.sort
+  end
+
+  # an array of all {Formula} files
+  # @private
+  def self.files
+    @files ||= core_files + tap_files
+  end
+
+  # an array of all {Formula} names, which the tap formulae have the fully-qualified name
+  # @private
+  def self.full_names
+    @full_names ||= core_names + tap_names
+  end
+
+  # @private
+  def self.each
+    files.each do |file|
+      begin
+        yield Formulary.factory(file)
+      rescue StandardError => e
+        # Don't let one broken formula break commands. But do complain.
+        onoe "Failed to import: #{file}"
+        puts e
+        next
+      end
+    end
+  end
+
+  # Clear cache of .racks
+  def self.clear_racks_cache
+    @racks = nil
+  end
+
+  # Clear caches of .racks and .installed.
+  def self.clear_installed_formulae_cache
+    clear_racks_cache
+    @installed = nil
+  end
+
+  # An array of all racks currently installed.
+  # @private
+  def self.racks
+    @racks ||= if HOMEBREW_CELLAR.directory?
+      HOMEBREW_CELLAR.subdirs.reject do |rack|
+        rack.symlink? || rack.subdirs.empty?
+      end
+    else
+      []
+    end
+  end
+
+  # An array of all installed {Formula}
+  # @private
+  def self.installed
+    @installed ||= racks.map do |rack|
+      begin
+        Formulary.from_rack(rack)
+      rescue FormulaUnavailableError, TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
+      end
+    end.compact.uniq(&:name)
+  end
+
+  def self.installed_with_alias_path(alias_path)
+    return [] if alias_path.nil?
+    installed.select { |f| f.installed_alias_path == alias_path }
+  end
+
+  # an array of all alias files of core {Formula}
+  # @private
+  def self.core_alias_files
+    CoreTap.instance.alias_files
+  end
+
+  # an array of all core aliases
+  # @private
+  def self.core_aliases
+    CoreTap.instance.aliases
+  end
+
+  # an array of all tap aliases
+  # @private
+  def self.tap_aliases
+    @tap_aliases ||= Tap.reject(&:core_tap?).flat_map(&:aliases).sort
+  end
+
+  # an array of all aliases
+  # @private
+  def self.aliases
+    @aliases ||= (core_aliases + tap_aliases.map { |name| name.split("/")[-1] }).uniq.sort
+  end
+
+  # an array of all aliases, , which the tap formulae have the fully-qualified name
+  # @private
+  def self.alias_full_names
+    @alias_full_names ||= core_aliases + tap_aliases
+  end
+
+  # a table mapping core alias to formula name
+  # @private
+  def self.core_alias_table
+    CoreTap.instance.alias_table
+  end
+
+  # a table mapping core formula name to aliases
+  # @private
+  def self.core_alias_reverse_table
+    CoreTap.instance.alias_reverse_table
+  end
+
+  def self.[](name)
+    Formulary.factory(name)
+  end
+
+  # True if this formula is provided by Homebrew itself
+  # @private
+  def core_formula?
+    tap && tap.core_tap?
+  end
+
+  # True if this formula is provided by external Tap
+  # @private
+  def tap?
+    tap && !tap.core_tap?
+  end
+
+  # @private
+  def print_tap_action(options = {})
+    return unless tap?
+    verb = options[:verb] || "Installing"
+    ohai "#{verb} #{name} from #{tap}"
+  end
+
+  # @private
+  def env
+    self.class.env
+  end
+
+  # @private
+  def conflicts
+    self.class.conflicts
+  end
+
+  # Returns a list of Dependency objects in an installable order, which
+  # means if a depends on b then b will be ordered before a in this list
+  # @private
+  def recursive_dependencies(&block)
+    Dependency.expand(self, &block)
+  end
+
+  # The full set of Requirements for this formula's dependency tree.
+  # @private
+  def recursive_requirements(&block)
+    Requirement.expand(self, &block)
+  end
+
+  # Returns a list of Dependency objects that are required at runtime.
+  # @private
+  def runtime_dependencies
+    runtime_dependencies = recursive_dependencies do |_, dependency|
+      Dependency.prune if dependency.build?
+      Dependency.prune if !dependency.required? && build.without?(dependency)
+    end
+    runtime_requirement_deps = recursive_requirements do |_, requirement|
+      Requirement.prune if requirement.build?
+      Requirement.prune if !requirement.required? && build.without?(requirement)
+    end.map(&:to_dependency).compact
+    runtime_dependencies + runtime_requirement_deps
+  end
+
+  # Returns a list of formulae depended on by this formula that aren't
+  # installed
+  def missing_dependencies(hide: nil)
+    hide ||= []
+    missing_dependencies = recursive_dependencies do |dependent, dep|
+      if dep.build?
+        Dependency.prune
+      elsif dep.optional? || dep.recommended?
+        tab = Tab.for_formula(dependent)
+        Dependency.prune unless tab.with?(dep)
+      end
+    end
+
+    missing_dependencies.map!(&:to_formula)
+    missing_dependencies.select! do |d|
+      hide.include?(d.name) || d.installed_prefixes.empty?
+    end
+    missing_dependencies
+  rescue FormulaUnavailableError
+    []
+  end
+
+  # @private
+  def to_hash
+    hsh = {
+      "name" => name,
+      "full_name" => full_name,
+      "desc" => desc,
+      "homepage" => homepage,
+      "oldname" => oldname,
+      "aliases" => aliases,
+      "versions" => {
+        "stable" => (stable.version.to_s if stable),
+        "bottle" => bottle ? true : false,
+        "devel" => (devel.version.to_s if devel),
+        "head" => (head.version.to_s if head),
+      },
+      "revision" => revision,
+      "version_scheme" => version_scheme,
+      "installed" => [],
+      "linked_keg" => (linked_version.to_s if linked_keg.exist?),
+      "pinned" => pinned?,
+      "outdated" => outdated?,
+      "keg_only" => keg_only?,
+      "dependencies" => deps.map(&:name).uniq,
+      "recommended_dependencies" => deps.select(&:recommended?).map(&:name).uniq,
+      "optional_dependencies" => deps.select(&:optional?).map(&:name).uniq,
+      "build_dependencies" => deps.select(&:build?).map(&:name).uniq,
+      "conflicts_with" => conflicts.map(&:name),
+      "caveats" => caveats,
+    }
+
+    hsh["requirements"] = requirements.map do |req|
+      {
+        "name" => req.name,
+        "default_formula" => req.default_formula,
+        "cask" => req.cask,
+        "download" => req.download,
+      }
+    end
+
+    hsh["options"] = options.map do |opt|
+      { "option" => opt.flag, "description" => opt.description }
+    end
+
+    hsh["bottle"] = {}
+    %w[stable devel].each do |spec_sym|
+      next unless spec = send(spec_sym)
+      next unless spec.bottle_defined?
+      bottle_spec = spec.bottle_specification
+      bottle_info = {
+        "rebuild" => bottle_spec.rebuild,
+        "cellar" => (cellar = bottle_spec.cellar).is_a?(Symbol) ? cellar.inspect : cellar,
+        "prefix" => bottle_spec.prefix,
+        "root_url" => bottle_spec.root_url,
+      }
+      bottle_info["files"] = {}
+      bottle_spec.collector.keys.each do |os|
+        checksum = bottle_spec.collector[os]
+        bottle_info["files"][os] = {
+          "url" => "#{bottle_spec.root_url}/#{Bottle::Filename.create(self, os, bottle_spec.rebuild)}",
+          checksum.hash_type.to_s => checksum.hexdigest,
+        }
+      end
+      hsh["bottle"][spec_sym] = bottle_info
+    end
+
+    installed_kegs.each do |keg|
+      tab = Tab.for_keg keg
+
+      hsh["installed"] << {
+        "version" => keg.version.to_s,
+        "used_options" => tab.used_options.as_flags,
+        "built_as_bottle" => tab.built_as_bottle,
+        "poured_from_bottle" => tab.poured_from_bottle,
+        "runtime_dependencies" => tab.runtime_dependencies,
+        "installed_as_dependency" => tab.installed_as_dependency,
+        "installed_on_request" => tab.installed_on_request,
+      }
+    end
+
+    hsh["installed"] = hsh["installed"].sort_by { |i| Version.create(i["version"]) }
+
+    hsh
+  end
+
+  # @private
+  def fetch
+    active_spec.fetch
+  end
+
+  # @private
+  def verify_download_integrity(fn)
+    active_spec.verify_download_integrity(fn)
+  end
+
+  # @private
+  def run_test
+    @prefix_returns_versioned_prefix = true
+    old_home = ENV["HOME"]
+    old_curl_home = ENV["CURL_HOME"]
+    old_tmpdir = ENV["TMPDIR"]
+    old_temp = ENV["TEMP"]
+    old_tmp = ENV["TMP"]
+    old_term = ENV["TERM"]
+    old_path = ENV["PATH"]
+    old_homebrew_path = ENV["HOMEBREW_PATH"]
+
+    ENV["CURL_HOME"] = old_curl_home || old_home
+    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
+    ENV["TERM"] = "dumb"
+    ENV["PATH"] = PATH.new(old_path).append(HOMEBREW_PREFIX/"bin")
+    ENV["HOMEBREW_PATH"] = nil
+
+    ENV.clear_sensitive_environment!
+
+    mktemp("#{name}-test") do |staging|
+      staging.retain! if ARGV.keep_tmp?
+      @testpath = staging.tmpdir
+      ENV["HOME"] = @testpath
+      setup_home @testpath
+      begin
+        with_logging("test") do
+          test
+        end
+      rescue Exception
+        staging.retain! if ARGV.debug?
+        raise
+      end
+    end
+  ensure
+    @testpath = nil
+    ENV["HOME"] = old_home
+    ENV["CURL_HOME"] = old_curl_home
+    ENV["TMPDIR"] = old_tmpdir
+    ENV["TEMP"] = old_temp
+    ENV["TMP"] = old_tmp
+    ENV["TERM"] = old_term
+    ENV["PATH"] = old_path
+    ENV["HOMEBREW_PATH"] = old_homebrew_path
+    @prefix_returns_versioned_prefix = false
+  end
+
+  # @private
+  def test_defined?
+    false
+  end
+
+  # @private
+  def test
+  end
+
+  # @private
+  def test_fixtures(file)
+    HOMEBREW_LIBRARY_PATH/"test/support/fixtures"/file
+  end
+
+  # This method is overridden in {Formula} subclasses to provide the installation instructions.
+  # The sources (from {.url}) are downloaded, hash-checked and
+  # Homebrew changes into a temporary directory where the
+  # archive was unpacked or repository cloned.
+  # <pre>def install
+  #   system "./configure", "--prefix=#{prefix}"
+  #   system "make", "install"
+  # end</pre>
+  def install
+  end
+
+  protected
+
+  def setup_home(home)
+    # keep Homebrew's site-packages in sys.path when using system Python
+    user_site_packages = home/"Library/Python/2.7/lib/python/site-packages"
+    user_site_packages.mkpath
+    (user_site_packages/"homebrew.pth").write <<-EOS.undent
+      import site; site.addsitedir("#{HOMEBREW_PREFIX}/lib/python2.7/site-packages")
+      import sys, os; sys.path = (os.environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in os.environ else []) + ["#{HOMEBREW_PREFIX}/lib/python2.7/site-packages"] + sys.path
+    EOS
+  end
+
+  public
+
+  # To call out to the system, we use the `system` method and we prefer
+  # you give the args separately as in the line below, otherwise a subshell
+  # has to be opened first.
+  # <pre>system "./bootstrap.sh", "--arg1", "--prefix=#{prefix}"</pre>
+  #
+  # For CMake we have some necessary defaults in {#std_cmake_args}:
+  # <pre>system "cmake", ".", *std_cmake_args</pre>
+  #
+  # If the arguments given to configure (or make or cmake) are depending
+  # on options defined above, we usually make a list first and then
+  # use the `args << if <condition>` to append to:
+  # <pre>args = ["--with-option1", "--with-option2"]
+  #
+  # # Most software still uses `configure` and `make`.
+  # # Check with `./configure --help` what our options are.
+  # system "./configure", "--disable-debug", "--disable-dependency-tracking",
+  #                       "--disable-silent-rules", "--prefix=#{prefix}",
+  #                       *args # our custom arg list (needs `*` to unpack)
+  #
+  # # If there is a "make", "install" available, please use it!
+  # system "make", "install"</pre>
+  def system(cmd, *args)
+    verbose = ARGV.verbose?
+    verbose_using_dots = !ENV["HOMEBREW_VERBOSE_USING_DOTS"].nil?
+
+    # remove "boring" arguments so that the important ones are more likely to
+    # be shown considering that we trim long ohai lines to the terminal width
+    pretty_args = args.dup
+    if cmd == "./configure" && !verbose
+      pretty_args.delete "--disable-dependency-tracking"
+      pretty_args.delete "--disable-debug"
+    end
+    pretty_args.each_index do |i|
+      if pretty_args[i].to_s.start_with? "import setuptools"
+        pretty_args[i] = "import setuptools..."
+      end
+    end
+    ohai "#{cmd} #{pretty_args * " "}".strip
+
+    @exec_count ||= 0
+    @exec_count += 1
+    logfn = format("#{logs}/#{active_log_prefix}%02d.%s", @exec_count, File.basename(cmd).split(" ").first)
+    logs.mkpath
+
+    File.open(logfn, "w") do |log|
+      log.puts Time.now, "", cmd, args, ""
+      log.flush
+
+      if verbose
+        rd, wr = IO.pipe
+        begin
+          pid = fork do
+            rd.close
+            log.close
+            exec_cmd(cmd, args, wr, logfn)
+          end
+          wr.close
+
+          if verbose_using_dots
+            last_dot = Time.at(0)
+            while buf = rd.gets
+              log.puts buf
+              # make sure dots printed with interval of at least 1 min.
+              next unless (Time.now - last_dot) > 60
+              print "."
+              $stdout.flush
+              last_dot = Time.now
+            end
+            puts
+          else
+            while buf = rd.gets
+              log.puts buf
+              puts buf
+            end
+          end
+        ensure
+          rd.close
+        end
+      else
+        pid = fork { exec_cmd(cmd, args, log, logfn) }
+      end
+
+      Process.wait(pid)
+
+      $stdout.flush
+
+      unless $CHILD_STATUS.success?
+        log_lines = ENV["HOMEBREW_FAIL_LOG_LINES"]
+        log_lines ||= "15"
+
+        log.flush
+        if !verbose || verbose_using_dots
+          puts "Last #{log_lines} lines from #{logfn}:"
+          Kernel.system "/usr/bin/tail", "-n", log_lines, logfn
+        end
+        log.puts
+
+        require "system_config"
+        require "build_environment"
+
+        env = ENV.to_hash
+
+        SystemConfig.dump_verbose_config(log)
+        log.puts
+        Homebrew.dump_build_env(env, log)
+
+        raise BuildError.new(self, cmd, args, env)
+      end
+    end
+  end
+
+  # @private
+  def eligible_kegs_for_cleanup
+    eligible_for_cleanup = []
+    if installed?
+      eligible_kegs = if head? && (head_prefix = latest_head_prefix)
+        installed_kegs - [Keg.new(head_prefix)]
+      else
+        installed_kegs.select do |keg|
+          tab = Tab.for_keg(keg)
+          if version_scheme > tab.version_scheme
+            true
+          elsif version_scheme == tab.version_scheme
+            pkg_version > keg.version
+          else
+            false
+          end
+        end
+      end
+
+      unless eligible_kegs.empty?
+        eligible_kegs.each do |keg|
+          if keg.linked?
+            opoo "Skipping (old) #{keg} due to it being linked"
+          elsif pinned? && keg == Keg.new(@pin.path.resolved_path)
+            opoo "Skipping (old) #{keg} due to it being pinned"
+          else
+            eligible_for_cleanup << keg
+          end
+        end
+      end
+    elsif !installed_prefixes.empty? && !pinned?
+      # If the cellar only has one version installed, don't complain
+      # that we can't tell which one to keep. Don't complain at all if the
+      # only installed version is a pinned formula.
+      opoo "Skipping #{full_name}: most recent version #{pkg_version} not installed"
+    end
+    eligible_for_cleanup
+  end
+
+  private
+
+  # Returns the prefix for a given formula version number.
+  # @private
+  def versioned_prefix(v)
+    rack/v
+  end
+
+  def exec_cmd(cmd, args, out, logfn)
+    ENV["HOMEBREW_CC_LOG_PATH"] = logfn
+
+    ENV.remove_cc_etc if cmd.to_s.start_with? "xcodebuild"
+
+    # Turn on argument filtering in the superenv compiler wrapper.
+    # We should probably have a better mechanism for this than adding
+    # special cases to this method.
+    if cmd == "python"
+      setup_py_in_args = %w[setup.py build.py].include?(args.first)
+      setuptools_shim_in_args = args.any? { |a| a.to_s.start_with? "import setuptools" }
+      ENV.refurbish_args if setup_py_in_args || setuptools_shim_in_args
+    end
+
+    $stdout.reopen(out)
+    $stderr.reopen(out)
+    out.close
+    args.collect!(&:to_s)
+    begin
+      exec(cmd, *args)
+    rescue
+      nil
+    end
+    puts "Failed to execute: #{cmd}"
+    exit! 1 # never gets here unless exec threw or failed
+  end
+
+  def stage
+    active_spec.stage do |staging|
+      @source_modified_time = active_spec.source_modified_time
+      @buildpath = Pathname.pwd
+      env_home = buildpath/".brew_home"
+      mkdir_p env_home
+
+      old_home = ENV["HOME"]
+      old_curl_home = ENV["CURL_HOME"]
+      old_path = ENV["HOMEBREW_PATH"]
+
+      unless ARGV.interactive?
+        ENV["HOME"] = env_home
+        ENV["CURL_HOME"] = old_curl_home || old_home
+      end
+      ENV["HOMEBREW_PATH"] = nil
+
+      setup_home env_home
+
+      ENV.clear_sensitive_environment!
+
+      begin
+        yield staging
+      ensure
+        @buildpath = nil
+        unless ARGV.interactive?
+          ENV["HOME"] = old_home
+          ENV["CURL_HOME"] = old_curl_home
+        end
+        ENV["HOMEBREW_PATH"] = old_path
+      end
+    end
+  end
+
+  def prepare_patches
+    active_spec.add_legacy_patches(patches) if respond_to?(:patches)
+
+    patchlist.grep(DATAPatch) { |p| p.path = path }
+
+    patchlist.each do |patch|
+      patch.verify_download_integrity(patch.fetch) if patch.external?
+    end
+  end
+
+  def self.method_added(method)
+    case method
+    when :brew
+      raise "You cannot override Formula#brew in class #{name}"
+    when :test
+      define_method(:test_defined?) { true }
+    when :options
+      instance = allocate
+
+      specs.each do |spec|
+        instance.options.each do |opt, desc|
+          spec.option(opt[/^--(.+)$/, 1], desc)
+        end
+      end
+
+      remove_method(:options)
+    end
+  end
+
+  # The methods below define the formula DSL.
+  class << self
+    include BuildEnvironment::DSL
+
+    # The reason for why this software is not linked (by default) to
+    # {::HOMEBREW_PREFIX}.
+    # @private
+    attr_reader :keg_only_reason
+
+    # @!attribute [w]
+    # A one-line description of the software. Used by users to get an overview
+    # of the software and Homebrew maintainers.
+    # Shows when running `brew info`.
+    #
+    # <pre>desc "Example formula"</pre>
+    attr_rw :desc
+
+    # @!attribute [w] homepage
+    # The homepage for the software. Used by users to get more information
+    # about the software and Homebrew maintainers as a point of contact for
+    # e.g. submitting patches.
+    # Can be opened with running `brew home`.
+    #
+    # <pre>homepage "https://www.example.com"</pre>
+    attr_rw :homepage
+
+    # The `:startup` attribute set by {.plist_options}.
+    # @private
+    attr_reader :plist_startup
+
+    # The `:manual` attribute set by {.plist_options}.
+    # @private
+    attr_reader :plist_manual
+
+    # If `pour_bottle?` returns `false` the user-visible reason to display for
+    # why they cannot use the bottle.
+    # @private
+    attr_accessor :pour_bottle_check_unsatisfied_reason
+
+    # @!attribute [w] revision
+    # Used for creating new Homebrew versions of software without new upstream
+    # versions. For example, if we bump the major version of a library this
+    # {Formula} {.depends_on} then we may need to update the `revision` of this
+    # {Formula} to install a new version linked against the new library version.
+    # `0` if unset.
+    #
+    # <pre>revision 1</pre>
+    attr_rw :revision
+
+    # @!attribute [w] version_scheme
+    # Used for creating new Homebrew versions schemes. For example, if we want
+    # to change version scheme from one to another, then we may need to update
+    # `version_scheme` of this {Formula} to be able to use new version scheme.
+    # E.g. to move from 20151020 scheme to 1.0.0 we need to increment
+    # `version_scheme`. Without this, the prior scheme will always equate to a
+    # higher version.
+    # `0` if unset.
+    #
+    # <pre>version_scheme 1</pre>
+    attr_rw :version_scheme
+
+    # A list of the {.stable}, {.devel} and {.head} {SoftwareSpec}s.
+    # @private
+    def specs
+      @specs ||= [stable, devel, head].freeze
+    end
+
+    # @!attribute [w] url
+    # The URL used to download the source for the {#stable} version of the formula.
+    # We prefer `https` for security and proxy reasons.
+    # If not inferrable, specify the download strategy with `:using => ...`
+    #     `:git`, `:hg`, `:svn`, `:bzr`, `:cvs`,
+    #     `:curl` (normal file download. Will also extract.)
+    #     `:nounzip` (without extracting)
+    #     `:post` (download via an HTTP POST)
+    #     `S3DownloadStrategy` (download from S3 using signed request)
+    #
+    # <pre>url "https://packed.sources.and.we.prefer.https.example.com/archive-1.2.3.tar.bz2"</pre>
+    # <pre>url "https://some.dont.provide.archives.example.com",
+    #     :using => :git,
+    #     :tag => "1.2.3",
+    #     :revision => "db8e4de5b2d6653f66aea53094624468caad15d2"</pre>
+    def url(val, specs = {})
+      stable.url(val, specs)
+    end
+
+    # @!attribute [w] version
+    # The version string for the {#stable} version of the formula.
+    # The version is autodetected from the URL and/or tag so only needs to be
+    # declared if it cannot be autodetected correctly.
+    #
+    # <pre>version "1.2-final"</pre>
+    def version(val = nil)
+      stable.version(val)
+    end
+
+    # @!attribute [w] mirror
+    # Additional URLs for the {#stable} version of the formula.
+    # These are only used if the {.url} fails to download. It's optional and
+    # there can be more than one. Generally we add them when the main {.url}
+    # is unreliable. If {.url} is really unreliable then we may swap the
+    # {.mirror} and {.url}.
+    #
+    # <pre>mirror "https://in.case.the.host.is.down.example.com"
+    # mirror "https://in.case.the.mirror.is.down.example.com</pre>
+    def mirror(val)
+      stable.mirror(val)
+    end
+
+    # @!attribute [w] sha256
+    # @scope class
+    # To verify the {#cached_download}'s integrity and security we verify the
+    # SHA-256 hash matches what we've declared in the {Formula}. To quickly fill
+    # this value you can leave it blank and run `brew fetch --force` and it'll
+    # tell you the currently valid value.
+    #
+    # <pre>sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"</pre>
+    Checksum::TYPES.each do |type|
+      define_method(type) { |val| stable.send(type, val) }
+    end
+
+    # @!attribute [w] bottle
+    # Adds a {.bottle} {SoftwareSpec}.
+    # This provides a pre-built binary package built by the Homebrew maintainers for you.
+    # It will be installed automatically if there is a binary package for your platform
+    # and you haven't passed or previously used any options on this formula.
+    #
+    # If you maintain your own repository, you can add your own bottle links.
+    # http://docs.brew.sh/Bottles.html
+    # You can ignore this block entirely if submitting to Homebrew/Homebrew, It'll be
+    # handled for you by the Brew Test Bot.
+    #
+    # <pre>bottle do
+    #   root_url "https://example.com" # Optional root to calculate bottle URLs
+    #   prefix "/opt/homebrew" # Optional HOMEBREW_PREFIX in which the bottles were built.
+    #   cellar "/opt/homebrew/Cellar" # Optional HOMEBREW_CELLAR in which the bottles were built.
+    #   rebuild 1 # Making the old bottle outdated without bumping the version/revision of the formula.
+    #   sha256 "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865" => :el_capitan
+    #   sha256 "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3" => :yosemite
+    #   sha256 "1121cfccd5913f0a63fec40a6ffd44ea64f9dc135c66634ba001d10bcf4302a2" => :mavericks
+    # end</pre>
+    #
+    # Only formulae where the upstream URL breaks or moves frequently, require compile
+    # or have a reasonable amount of patches/resources should be bottled.
+    # Formulae which do not meet the above requirements should not be bottled.
+    #
+    # Formulae which should not be bottled & can be installed without any compile
+    # required should be tagged with:
+    # <pre>bottle :unneeded</pre>
+    #
+    # Otherwise formulae which do not meet the above requirements and should not
+    # be bottled should be tagged with:
+    # <pre>bottle :disable, "reasons"</pre>
+    def bottle(*args, &block)
+      stable.bottle(*args, &block)
+    end
+
+    # @private
+    def build
+      stable.build
+    end
+
+    # @!attribute [w] stable
+    # Allows adding {.depends_on} and {#patch}es just to the {.stable} {SoftwareSpec}.
+    # This is required instead of using a conditional.
+    # It is preferrable to also pull the {url} and {.sha256} into the block if one is added.
+    #
+    # <pre>stable do
+    #   url "https://example.com/foo-1.0.tar.gz"
+    #   sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"
+    #
+    #   depends_on "libxml2"
+    #   depends_on "libffi"
+    # end</pre>
+    def stable(&block)
+      @stable ||= SoftwareSpec.new
+      return @stable unless block_given?
+      @stable.instance_eval(&block)
+    end
+
+    # @!attribute [w] devel
+    # Adds a {.devel} {SoftwareSpec}.
+    # This can be installed by passing the `--devel` option to allow
+    # installing non-stable (e.g. beta) versions of software.
+    #
+    # <pre>devel do
+    #   url "https://example.com/archive-2.0-beta.tar.gz"
+    #   sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"
+    #
+    #   depends_on "cairo"
+    #   depends_on "pixman"
+    # end</pre>
+    def devel(&block)
+      @devel ||= SoftwareSpec.new
+      return @devel unless block_given?
+      @devel.instance_eval(&block)
+    end
+
+    # @!attribute [w] head
+    # Adds a {.head} {SoftwareSpec}.
+    # This can be installed by passing the `--HEAD` option to allow
+    # installing software directly from a branch of a version-control repository.
+    # If called as a method this provides just the {url} for the {SoftwareSpec}.
+    # If a block is provided you can also add {.depends_on} and {#patch}es just to the {.head} {SoftwareSpec}.
+    # The download strategies (e.g. `:using =>`) are the same as for {url}.
+    # `master` is the default branch and doesn't need stating with a `:branch` parameter.
+    # <pre>head "https://we.prefer.https.over.git.example.com/.git"</pre>
+    # <pre>head "https://example.com/.git", :branch => "name_of_branch", :revision => "abc123"</pre>
+    # or (if autodetect fails):
+    # <pre>head "https://hg.is.awesome.but.git.has.won.example.com/", :using => :hg</pre>
+    def head(val = nil, specs = {}, &block)
+      @head ||= HeadSoftwareSpec.new
+      if block_given?
+        @head.instance_eval(&block)
+      elsif val
+        @head.url(val, specs)
+      else
+        @head
+      end
+    end
+
+    # Additional downloads can be defined as resources and accessed in the
+    # install method. Resources can also be defined inside a stable, devel, or
+    # head block. This mechanism replaces ad-hoc "subformula" classes.
+    # <pre>resource "additional_files" do
+    #   url "https://example.com/additional-stuff.tar.gz"
+    #   sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
+    # end</pre>
+    def resource(name, klass = Resource, &block)
+      specs.each do |spec|
+        spec.resource(name, klass, &block) unless spec.resource_defined?(name)
+      end
+    end
+
+    def go_resource(name, &block)
+      specs.each { |spec| spec.go_resource(name, &block) }
+    end
+
+    # The dependencies for this formula. Use strings for the names of other
+    # formulae. Homebrew provides some :special dependencies for stuff that
+    # requires certain extra handling (often changing some ENV vars or
+    # deciding if to use the system provided version or not.)
+    # <pre># `:build` means this dep is only needed during build.
+    # depends_on "cmake" => :build</pre>
+    # <pre>depends_on "homebrew/dupes/tcl-tk" => :optional</pre>
+    # <pre># `:recommended` dependencies are built by default.
+    # # But a `--without-...` option is generated to opt-out.
+    # depends_on "readline" => :recommended</pre>
+    # <pre># `:optional` dependencies are NOT built by default.
+    # # But a `--with-...` options is generated.
+    # depends_on "glib" => :optional</pre>
+    # <pre># If you need to specify that another formula has to be built with/out
+    # # certain options (note, no `--` needed before the option):
+    # depends_on "zeromq" => "with-pgm"
+    # depends_on "qt" => ["with-qtdbus", "developer"] # Multiple options.</pre>
+    # <pre># Optional and enforce that boost is built with `--with-c++11`.
+    # depends_on "boost" => [:optional, "with-c++11"]</pre>
+    # <pre># If a dependency is only needed in certain cases:
+    # depends_on "sqlite" if MacOS.version == :leopard
+    # depends_on :xcode # If the formula really needs full Xcode.
+    # depends_on :tex # Homebrew does not provide a Tex Distribution.
+    # depends_on :fortran # Checks that `gfortran` is available or `FC` is set.
+    # depends_on :mpi => :cc # Needs MPI with `cc`
+    # depends_on :mpi => [:cc, :cxx, :optional] # Is optional. MPI with `cc` and `cxx`.
+    # depends_on :macos => :lion # Needs at least OS X Lion (10.7).
+    # depends_on :apr # If a formula requires the CLT-provided apr library to exist.
+    # depends_on :arch => :intel # If this formula only builds on Intel architecture.
+    # depends_on :arch => :x86_64 # If this formula only builds on Intel x86 64-bit.
+    # depends_on :arch => :ppc # Only builds on PowerPC?
+    # depends_on :ld64 # Sometimes ld fails on `MacOS.version < :leopard`. Then use this.
+    # depends_on :x11 # X11/XQuartz components. Non-optional X11 deps should go in Homebrew/Homebrew-x11
+    # depends_on :osxfuse # Permits the use of the upstream signed binary or our source package.
+    # depends_on :tuntap # Does the same thing as above. This is vital for Yosemite and above.
+    # depends_on :mysql => :recommended</pre>
+    # <pre># It is possible to only depend on something if
+    # # `build.with?` or `build.without? "another_formula"`:
+    # depends_on :mysql # allows brewed or external mysql to be used
+    # depends_on :postgresql if build.without? "sqlite"
+    # depends_on :hg # Mercurial (external or brewed) is needed</pre>
+    #
+    # <pre># If any Python >= 2.7 < 3.x is okay (either from macOS or brewed):
+    # depends_on :python</pre>
+    # <pre># to depend on Python >= 2.7 but use system Python where possible
+    # depends_on :python if MacOS.version <= :snow_leopard</pre>
+    # <pre># Python 3.x if the `--with-python3` is given to `brew install example`
+    # depends_on :python3 => :optional</pre>
+    def depends_on(dep)
+      specs.each { |spec| spec.depends_on(dep) }
+    end
+
+    # @!attribute [w] option
+    # Options can be used as arguments to `brew install`.
+    # To switch features on/off: `"with-something"` or `"with-otherthing"`.
+    # To use other software: `"with-other-software"` or `"without-foo"`
+    # Note, that for {.depends_on} that are `:optional` or `:recommended`, options
+    # are generated automatically.
+    #
+    # There are also some special options:
+    # - `:universal`: build a universal binary/library (e.g. on newer Intel Macs
+    #   this means a combined x86_64/x86 binary/library).
+    # <pre>option "with-spam", "The description goes here without a dot at the end"</pre>
+    # <pre>option "with-qt", "Text here overwrites the autogenerated one from 'depends_on "qt" => :optional'"</pre>
+    # <pre>option :universal</pre>
+    def option(name, description = "")
+      specs.each { |spec| spec.option(name, description) }
+    end
+
+    # @!attribute [w] deprecated_option
+    # Deprecated options are used to rename options and migrate users who used
+    # them to newer ones. They are mostly used for migrating non-`with` options
+    # (e.g. `enable-debug`) to `with` options (e.g. `with-debug`).
+    # <pre>deprecated_option "enable-debug" => "with-debug"</pre>
+    def deprecated_option(hash)
+      specs.each { |spec| spec.deprecated_option(hash) }
+    end
+
+    # External patches can be declared using resource-style blocks.
+    # <pre>patch do
+    #   url "https://example.com/example_patch.diff"
+    #   sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
+    # end</pre>
+    #
+    # A strip level of `-p1` is assumed. It can be overridden using a symbol
+    # argument:
+    # <pre>patch :p0 do
+    #   url "https://example.com/example_patch.diff"
+    #   sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
+    # end</pre>
+    #
+    # Patches can be declared in stable, devel, and head blocks. This form is
+    # preferred over using conditionals.
+    # <pre>stable do
+    #   patch do
+    #     url "https://example.com/example_patch.diff"
+    #     sha256 "c6bc3f48ce8e797854c4b865f6a8ff969867bbcaebd648ae6fd825683e59fef2"
+    #   end
+    # end</pre>
+    #
+    # Embedded (`__END__`) patches are declared like so:
+    # <pre>patch :DATA
+    # patch :p0, :DATA</pre>
+    #
+    # Patches can also be embedded by passing a string. This makes it possible
+    # to provide multiple embedded patches while making only some of them
+    # conditional.
+    # <pre>patch :p0, "..."</pre>
+    def patch(strip = :p1, src = nil, &block)
+      specs.each { |spec| spec.patch(strip, src, &block) }
+    end
+
+    # Defines launchd plist handling.
+    #
+    # Does your plist need to be loaded at startup?
+    # <pre>plist_options :startup => true</pre>
+    #
+    # Or only when necessary or desired by the user?
+    # <pre>plist_options :manual => "foo"</pre>
+    #
+    # Or perhaps you'd like to give the user a choice? Ooh fancy.
+    # <pre>plist_options :startup => true, :manual => "foo start"</pre>
+    def plist_options(options)
+      @plist_startup = options[:startup]
+      @plist_manual = options[:manual]
+    end
+
+    # @private
+    def conflicts
+      @conflicts ||= []
+    end
+
+    # If this formula conflicts with another one.
+    # <pre>conflicts_with "imagemagick", :because => "because both install 'convert' binaries"</pre>
+    def conflicts_with(*names)
+      opts = names.last.is_a?(Hash) ? names.pop : {}
+      names.each { |name| conflicts << FormulaConflict.new(name, opts[:because]) }
+    end
+
+    def skip_clean(*paths)
+      paths.flatten!
+      # Specifying :all is deprecated and will become an error
+      skip_clean_paths.merge(paths)
+    end
+
+    # @private
+    def skip_clean_paths
+      @skip_clean_paths ||= Set.new
+    end
+
+    # Software that will not be sym-linked into the `brew --prefix` will only
+    # live in its Cellar. Other formulae can depend on it and then brew will
+    # add the necessary includes and libs (etc.) during the brewing of that
+    # other formula. But generally, keg_only formulae are not in your PATH
+    # and not seen by compilers if you build your own software outside of
+    # Homebrew. This way, we don't shadow software provided by macOS.
+    # <pre>keg_only :provided_by_macos</pre>
+    # <pre>keg_only "because I want it so"</pre>
+    def keg_only(reason, explanation = "")
+      @keg_only_reason = KegOnlyReason.new(reason, explanation)
+    end
+
+    # Pass :skip to this method to disable post-install stdlib checking
+    def cxxstdlib_check(check_type)
+      define_method(:skip_cxxstdlib_check?) { true } if check_type == :skip
+    end
+
+    # Marks the {Formula} as failing with a particular compiler so it will fall back to others.
+    # For Apple compilers, this should be in the format:
+    # <pre>fails_with :clang do
+    #   build 600
+    #   cause "multiple configure and compile errors"
+    # end</pre>
+    #
+    # The block may be omitted, and if present the build may be omitted;
+    # if so, then the compiler will be blacklisted for *all* versions.
+    #
+    # `major_version` should be the major release number only, for instance
+    # '4.8' for the GCC 4.8 series (4.8.0, 4.8.1, etc.).
+    # If `version` or the block is omitted, then the compiler will be
+    # blacklisted for all compilers in that series.
+    #
+    # For example, if a bug is only triggered on GCC 4.8.1 but is not
+    # encountered on 4.8.2:
+    #
+    # <pre>fails_with :gcc => '4.8' do
+    #   version '4.8.1'
+    # end</pre>
+    def fails_with(compiler, &block)
+      # odeprecated "fails_with :llvm" if compiler == :llvm
+      specs.each { |spec| spec.fails_with(compiler, &block) }
+    end
+
+    def needs(*standards)
+      specs.each { |spec| spec.needs(*standards) }
+    end
+
+    # Test (is required for new formula and makes us happy).
+    # @return [Boolean]
+    #
+    # The block will create, run in and delete a temporary directory.
+    #
+    # We are fine if the executable does not error out, so we know linking
+    # and building the software was ok.
+    # <pre>system bin/"foobar", "--version"</pre>
+    #
+    # <pre>(testpath/"test.file").write <<-EOS.undent
+    #   writing some test file, if you need to
+    # EOS
+    # assert_equal "OK", shell_output("test_command test.file").strip</pre>
+    #
+    # Need complete control over stdin, stdout?
+    # <pre>require "open3"
+    # Open3.popen3("#{bin}/example", "argument") do |stdin, stdout, _|
+    #   stdin.write("some text")
+    #   stdin.close
+    #   assert_equal "result", stdout.read
+    # end</pre>
+    #
+    # The test will fail if it returns false, or if an exception is raised.
+    # Failed assertions and failed `system` commands will raise exceptions.
+    def test(&block)
+      define_method(:test, &block)
+    end
+
+    # Defines whether the {Formula}'s bottle can be used on the given Homebrew
+    # installation.
+    #
+    # For example, if the bottle requires the Xcode CLT to be installed a
+    # {Formula} would declare:
+    # <pre>pour_bottle? do
+    #   reason "The bottle needs the Xcode CLT to be installed."
+    #   satisfy { MacOS::CLT.installed? }
+    # end</pre>
+    #
+    # If `satisfy` returns `false` then a bottle will not be used and instead
+    # the {Formula} will be built from source and `reason` will be printed.
+    def pour_bottle?(&block)
+      @pour_bottle_check = PourBottleCheck.new(self)
+      @pour_bottle_check.instance_eval(&block)
+    end
+
+    # @private
+    def link_overwrite(*paths)
+      paths.flatten!
+      link_overwrite_paths.merge(paths)
+    end
+
+    # @private
+    def link_overwrite_paths
+      @link_overwrite_paths ||= Set.new
+    end
+  end
+end

--- a/testdata/issue20/load_commands.rb
+++ b/testdata/issue20/load_commands.rb
@@ -1,0 +1,1350 @@
+module MachO
+  # Classes and constants for parsing load commands in Mach-O binaries.
+  module LoadCommands
+    # load commands added after OS X 10.1 need to be bitwise ORed with
+    # LC_REQ_DYLD to be recognized by the dynamic linker (dyld)
+    # @api private
+    LC_REQ_DYLD = 0x80000000
+
+    # association of load commands to symbol representations
+    # @api private
+    LOAD_COMMANDS = {
+      0x1 => :LC_SEGMENT,
+      0x2 => :LC_SYMTAB,
+      0x3 => :LC_SYMSEG,
+      0x4 => :LC_THREAD,
+      0x5 => :LC_UNIXTHREAD,
+      0x6 => :LC_LOADFVMLIB,
+      0x7 => :LC_IDFVMLIB,
+      0x8 => :LC_IDENT,
+      0x9 => :LC_FVMFILE,
+      0xa => :LC_PREPAGE,
+      0xb => :LC_DYSYMTAB,
+      0xc => :LC_LOAD_DYLIB,
+      0xd => :LC_ID_DYLIB,
+      0xe => :LC_LOAD_DYLINKER,
+      0xf => :LC_ID_DYLINKER,
+      0x10 => :LC_PREBOUND_DYLIB,
+      0x11 => :LC_ROUTINES,
+      0x12 => :LC_SUB_FRAMEWORK,
+      0x13 => :LC_SUB_UMBRELLA,
+      0x14 => :LC_SUB_CLIENT,
+      0x15 => :LC_SUB_LIBRARY,
+      0x16 => :LC_TWOLEVEL_HINTS,
+      0x17 => :LC_PREBIND_CKSUM,
+      (0x18 | LC_REQ_DYLD) => :LC_LOAD_WEAK_DYLIB,
+      0x19 => :LC_SEGMENT_64,
+      0x1a => :LC_ROUTINES_64,
+      0x1b => :LC_UUID,
+      (0x1c | LC_REQ_DYLD) => :LC_RPATH,
+      0x1d => :LC_CODE_SIGNATURE,
+      0x1e => :LC_SEGMENT_SPLIT_INFO,
+      (0x1f | LC_REQ_DYLD) => :LC_REEXPORT_DYLIB,
+      0x20 => :LC_LAZY_LOAD_DYLIB,
+      0x21 => :LC_ENCRYPTION_INFO,
+      0x22 => :LC_DYLD_INFO,
+      (0x22 | LC_REQ_DYLD) => :LC_DYLD_INFO_ONLY,
+      (0x23 | LC_REQ_DYLD) => :LC_LOAD_UPWARD_DYLIB,
+      0x24 => :LC_VERSION_MIN_MACOSX,
+      0x25 => :LC_VERSION_MIN_IPHONEOS,
+      0x26 => :LC_FUNCTION_STARTS,
+      0x27 => :LC_DYLD_ENVIRONMENT,
+      (0x28 | LC_REQ_DYLD) => :LC_MAIN,
+      0x29 => :LC_DATA_IN_CODE,
+      0x2a => :LC_SOURCE_VERSION,
+      0x2b => :LC_DYLIB_CODE_SIGN_DRS,
+      0x2c => :LC_ENCRYPTION_INFO_64,
+      0x2d => :LC_LINKER_OPTION,
+      0x2e => :LC_LINKER_OPTIMIZATION_HINT,
+      0x2f => :LC_VERSION_MIN_TVOS,
+      0x30 => :LC_VERSION_MIN_WATCHOS,
+    }.freeze
+
+    # association of symbol representations to load command constants
+    # @api private
+    LOAD_COMMAND_CONSTANTS = LOAD_COMMANDS.invert.freeze
+
+    # load commands responsible for loading dylibs
+    # @api private
+    DYLIB_LOAD_COMMANDS = [
+      :LC_LOAD_DYLIB,
+      :LC_LOAD_WEAK_DYLIB,
+      :LC_REEXPORT_DYLIB,
+      :LC_LAZY_LOAD_DYLIB,
+      :LC_LOAD_UPWARD_DYLIB,
+    ].freeze
+
+    # load commands that can be created manually via {LoadCommand.create}
+    # @api private
+    CREATABLE_LOAD_COMMANDS = DYLIB_LOAD_COMMANDS + [
+      :LC_ID_DYLIB,
+      :LC_RPATH,
+      :LC_LOAD_DYLINKER,
+    ].freeze
+
+    # association of load command symbols to string representations of classes
+    # @api private
+    LC_STRUCTURES = {
+      :LC_SEGMENT => "SegmentCommand",
+      :LC_SYMTAB => "SymtabCommand",
+      # "obsolete"
+      :LC_SYMSEG => "SymsegCommand",
+      # seems obsolete, but not documented as such
+      :LC_THREAD => "ThreadCommand",
+      :LC_UNIXTHREAD => "ThreadCommand",
+      # "obsolete"
+      :LC_LOADFVMLIB => "FvmlibCommand",
+      # "obsolete"
+      :LC_IDFVMLIB => "FvmlibCommand",
+      # "obsolete"
+      :LC_IDENT => "IdentCommand",
+      # "reserved for internal use only"
+      :LC_FVMFILE => "FvmfileCommand",
+      # "reserved for internal use only", no public struct
+      :LC_PREPAGE => "LoadCommand",
+      :LC_DYSYMTAB => "DysymtabCommand",
+      :LC_LOAD_DYLIB => "DylibCommand",
+      :LC_ID_DYLIB => "DylibCommand",
+      :LC_LOAD_DYLINKER => "DylinkerCommand",
+      :LC_ID_DYLINKER => "DylinkerCommand",
+      :LC_PREBOUND_DYLIB => "PreboundDylibCommand",
+      :LC_ROUTINES => "RoutinesCommand",
+      :LC_SUB_FRAMEWORK => "SubFrameworkCommand",
+      :LC_SUB_UMBRELLA => "SubUmbrellaCommand",
+      :LC_SUB_CLIENT => "SubClientCommand",
+      :LC_SUB_LIBRARY => "SubLibraryCommand",
+      :LC_TWOLEVEL_HINTS => "TwolevelHintsCommand",
+      :LC_PREBIND_CKSUM => "PrebindCksumCommand",
+      :LC_LOAD_WEAK_DYLIB => "DylibCommand",
+      :LC_SEGMENT_64 => "SegmentCommand64",
+      :LC_ROUTINES_64 => "RoutinesCommand64",
+      :LC_UUID => "UUIDCommand",
+      :LC_RPATH => "RpathCommand",
+      :LC_CODE_SIGNATURE => "LinkeditDataCommand",
+      :LC_SEGMENT_SPLIT_INFO => "LinkeditDataCommand",
+      :LC_REEXPORT_DYLIB => "DylibCommand",
+      :LC_LAZY_LOAD_DYLIB => "DylibCommand",
+      :LC_ENCRYPTION_INFO => "EncryptionInfoCommand",
+      :LC_DYLD_INFO => "DyldInfoCommand",
+      :LC_DYLD_INFO_ONLY => "DyldInfoCommand",
+      :LC_LOAD_UPWARD_DYLIB => "DylibCommand",
+      :LC_VERSION_MIN_MACOSX => "VersionMinCommand",
+      :LC_VERSION_MIN_IPHONEOS => "VersionMinCommand",
+      :LC_FUNCTION_STARTS => "LinkeditDataCommand",
+      :LC_DYLD_ENVIRONMENT => "DylinkerCommand",
+      :LC_MAIN => "EntryPointCommand",
+      :LC_DATA_IN_CODE => "LinkeditDataCommand",
+      :LC_SOURCE_VERSION => "SourceVersionCommand",
+      :LC_DYLIB_CODE_SIGN_DRS => "LinkeditDataCommand",
+      :LC_ENCRYPTION_INFO_64 => "EncryptionInfoCommand64",
+      :LC_LINKER_OPTION => "LinkerOptionCommand",
+      :LC_LINKER_OPTIMIZATION_HINT => "LinkeditDataCommand",
+      :LC_VERSION_MIN_TVOS => "VersionMinCommand",
+      :LC_VERSION_MIN_WATCHOS => "VersionMinCommand",
+    }.freeze
+
+    # association of segment name symbols to names
+    # @api private
+    SEGMENT_NAMES = {
+      :SEG_PAGEZERO => "__PAGEZERO",
+      :SEG_TEXT => "__TEXT",
+      :SEG_DATA => "__DATA",
+      :SEG_OBJC => "__OBJC",
+      :SEG_ICON => "__ICON",
+      :SEG_LINKEDIT => "__LINKEDIT",
+      :SEG_UNIXSTACK => "__UNIXSTACK",
+      :SEG_IMPORT => "__IMPORT",
+    }.freeze
+
+    # association of segment flag symbols to values
+    # @api private
+    SEGMENT_FLAGS = {
+      :SG_HIGHVM => 0x1,
+      :SG_FVMLIB => 0x2,
+      :SG_NORELOC => 0x4,
+      :SG_PROTECTED_VERSION_1 => 0x8,
+    }.freeze
+
+    # Mach-O load command structure
+    # This is the most generic load command - only cmd ID and size are
+    # represented, and no actual data. Used when a more specific class
+    # isn't available/implemented.
+    class LoadCommand < MachOStructure
+      # @return [MachO::MachOView] the raw view associated with the load command
+      attr_reader :view
+
+      # @return [Fixnum] the load command's identifying number
+      attr_reader :cmd
+
+      # @return [Fixnum] the size of the load command, in bytes
+      attr_reader :cmdsize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+
+      # Instantiates a new LoadCommand given a view into its origin Mach-O
+      # @param view [MachO::MachOView] the load command's raw view
+      # @return [LoadCommand] the new load command
+      # @api private
+      def self.new_from_bin(view)
+        bin = view.raw_data.slice(view.offset, bytesize)
+        format = Utils.specialize_format(self::FORMAT, view.endianness)
+
+        new(view, *bin.unpack(format))
+      end
+
+      # Creates a new (viewless) command corresponding to the symbol provided
+      # @param cmd_sym [Symbol] the symbol of the load command being created
+      # @param args [Array] the arguments for the load command being created
+      def self.create(cmd_sym, *args)
+        raise LoadCommandNotCreatableError, cmd_sym unless CREATABLE_LOAD_COMMANDS.include?(cmd_sym)
+
+        klass = LoadCommands.const_get LC_STRUCTURES[cmd_sym]
+        cmd = LOAD_COMMAND_CONSTANTS[cmd_sym]
+
+        # cmd will be filled in, view and cmdsize will be left unpopulated
+        klass_arity = klass.instance_method(:initialize).arity - 3
+
+        raise LoadCommandCreationArityError.new(cmd_sym, klass_arity, args.size) if klass_arity != args.size
+
+        klass.new(nil, cmd, nil, *args)
+      end
+
+      # @param view [MachO::MachOView] the load command's raw view
+      # @param cmd [Fixnum] the load command's identifying number
+      # @param cmdsize [Fixnum] the size of the load command in bytes
+      # @api private
+      def initialize(view, cmd, cmdsize)
+        @view = view
+        @cmd = cmd
+        @cmdsize = cmdsize
+      end
+
+      # @return [Boolean] whether the load command can be serialized
+      def serializable?
+        CREATABLE_LOAD_COMMANDS.include?(LOAD_COMMANDS[cmd])
+      end
+
+      # @param context [SerializationContext] the context
+      #  to serialize into
+      # @return [String, nil] the serialized fields of the load command, or nil
+      #  if the load command can't be serialized
+      # @api private
+      def serialize(context)
+        raise LoadCommandNotSerializableError, LOAD_COMMANDS[cmd] unless serializable?
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        [cmd, SIZEOF].pack(format)
+      end
+
+      # @return [Fixnum] the load command's offset in the source file
+      # @deprecated use {#view} instead
+      def offset
+        view.offset
+      end
+
+      # @return [Symbol] a symbol representation of the load command's
+      #  identifying number
+      def type
+        LOAD_COMMANDS[cmd]
+      end
+
+      alias to_sym type
+
+      # @return [String] a string representation of the load command's
+      #  identifying number
+      def to_s
+        type.to_s
+      end
+
+      # Represents a Load Command string. A rough analogue to the lc_str
+      # struct used internally by OS X. This class allows ruby-macho to
+      # pretend that strings stored in LCs are immediately available without
+      # explicit operations on the raw Mach-O data.
+      class LCStr
+        # @param lc [LoadCommand] the load command
+        # @param lc_str [Fixnum, String] the offset to the beginning of the
+        #  string, or the string itself if not being initialized with a view.
+        # @raise [MachO::LCStrMalformedError] if the string is malformed
+        # @todo devise a solution such that the `lc_str` parameter is not
+        #  interpreted differently depending on `lc.view`. The current behavior
+        #  is a hack to allow viewless load command creation.
+        # @api private
+        def initialize(lc, lc_str)
+          view = lc.view
+
+          if view
+            lc_str_abs = view.offset + lc_str
+            lc_end = view.offset + lc.cmdsize - 1
+            raw_string = view.raw_data.slice(lc_str_abs..lc_end)
+            @string, null_byte, _padding = raw_string.partition("\x00")
+            raise LCStrMalformedError, lc if null_byte.empty?
+            @string_offset = lc_str
+          else
+            @string = lc_str
+            @string_offset = 0
+          end
+        end
+
+        # @return [String] a string representation of the LCStr
+        def to_s
+          @string
+        end
+
+        # @return [Fixnum] the offset to the beginning of the string in the
+        #  load command
+        def to_i
+          @string_offset
+        end
+      end
+
+      # Represents the contextual information needed by a load command to
+      # serialize itself correctly into a binary string.
+      class SerializationContext
+        # @return [Symbol] the endianness of the serialized load command
+        attr_reader :endianness
+
+        # @return [Fixnum] the constant alignment value used to pad the
+        #  serialized load command
+        attr_reader :alignment
+
+        # @param macho [MachO::MachOFile] the file to contextualize
+        # @return [SerializationContext] the
+        #  resulting context
+        def self.context_for(macho)
+          new(macho.endianness, macho.alignment)
+        end
+
+        # @param endianness [Symbol] the endianness of the context
+        # @param alignment [Fixnum] the alignment of the context
+        # @api private
+        def initialize(endianness, alignment)
+          @endianness = endianness
+          @alignment = alignment
+        end
+      end
+    end
+
+    # A load command containing a single 128-bit unique random number
+    # identifying an object produced by static link editor. Corresponds to
+    # LC_UUID.
+    class UUIDCommand < LoadCommand
+      # @return [Array<Fixnum>] the UUID
+      attr_reader :uuid
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, uuid)
+        super(view, cmd, cmdsize)
+        @uuid = uuid.unpack("C16") # re-unpack for the actual UUID array
+      end
+
+      # @return [String] a string representation of the UUID
+      def uuid_string
+        hexes = uuid.map { |e| "%02x" % e }
+        segs = [
+          hexes[0..3].join, hexes[4..5].join, hexes[6..7].join,
+          hexes[8..9].join, hexes[10..15].join
+        ]
+
+        segs.join("-")
+      end
+    end
+
+    # A load command indicating that part of this file is to be mapped into
+    # the task's address space. Corresponds to LC_SEGMENT.
+    class SegmentCommand < LoadCommand
+      # @return [String] the name of the segment
+      attr_reader :segname
+
+      # @return [Fixnum] the memory address of the segment
+      attr_reader :vmaddr
+
+      # @return [Fixnum] the memory size of the segment
+      attr_reader :vmsize
+
+      # @return [Fixnum] the file offset of the segment
+      attr_reader :fileoff
+
+      # @return [Fixnum] the amount to map from the file
+      attr_reader :filesize
+
+      # @return [Fixnum] the maximum VM protection
+      attr_reader :maxprot
+
+      # @return [Fixnum] the initial VM protection
+      attr_reader :initprot
+
+      # @return [Fixnum] the number of sections in the segment
+      attr_reader :nsects
+
+      # @return [Fixnum] any flags associated with the segment
+      attr_reader :flags
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16L=4l=2L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 56
+
+      # @api private
+      def initialize(view, cmd, cmdsize, segname, vmaddr, vmsize, fileoff,
+                     filesize, maxprot, initprot, nsects, flags)
+        super(view, cmd, cmdsize)
+        @segname = segname.delete("\x00")
+        @vmaddr = vmaddr
+        @vmsize = vmsize
+        @fileoff = fileoff
+        @filesize = filesize
+        @maxprot = maxprot
+        @initprot = initprot
+        @nsects = nsects
+        @flags = flags
+      end
+
+      # All sections referenced within this segment.
+      # @return [Array<MachO::Sections::Section>] if the Mach-O is 32-bit
+      # @return [Array<MachO::Sections::Section64>] if the Mach-O is 64-bit
+      def sections
+        klass = case self
+        when SegmentCommand64
+          MachO::Sections::Section64
+        when SegmentCommand
+          MachO::Sections::Section
+        end
+
+        offset = view.offset + self.class.bytesize
+        length = nsects * klass.bytesize
+
+        bins = view.raw_data[offset, length]
+        bins.unpack("a#{klass.bytesize}" * nsects).map do |bin|
+          klass.new_from_bin(view.endianness, bin)
+        end
+      end
+
+      # @example
+      #  puts "this segment relocated in/to it" if sect.flag?(:SG_NORELOC)
+      # @param flag [Symbol] a segment flag symbol
+      # @return [Boolean] true if `flag` is present in the segment's flag field
+      def flag?(flag)
+        flag = SEGMENT_FLAGS[flag]
+        return false if flag.nil?
+        flags & flag == flag
+      end
+    end
+
+    # A load command indicating that part of this file is to be mapped into
+    # the task's address space. Corresponds to LC_SEGMENT_64.
+    class SegmentCommand64 < SegmentCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2a16Q=4l=2L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 72
+    end
+
+    # A load command representing some aspect of shared libraries, depending
+    # on filetype. Corresponds to LC_ID_DYLIB, LC_LOAD_DYLIB,
+    # LC_LOAD_WEAK_DYLIB, and LC_REEXPORT_DYLIB.
+    class DylibCommand < LoadCommand
+      # @return [LCStr] the library's path
+      #  name as an LCStr
+      attr_reader :name
+
+      # @return [Fixnum] the library's build time stamp
+      attr_reader :timestamp
+
+      # @return [Fixnum] the library's current version number
+      attr_reader :current_version
+
+      # @return [Fixnum] the library's compatibility version number
+      attr_reader :compatibility_version
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, name, timestamp, current_version,
+                     compatibility_version)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @timestamp = timestamp
+        @current_version = current_version
+        @compatibility_version = compatibility_version
+      end
+
+      # @param context [SerializationContext]
+      #  the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF,
+                                                            context.alignment,
+                                                            :name => name.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:name], timestamp, current_version,
+         compatibility_version].pack(format) + string_payload
+      end
+    end
+
+    # A load command representing some aspect of the dynamic linker, depending
+    # on filetype. Corresponds to LC_ID_DYLINKER, LC_LOAD_DYLINKER, and
+    # LC_DYLD_ENVIRONMENT.
+    class DylinkerCommand < LoadCommand
+      # @return [LCStr] the dynamic linker's
+      #  path name as an LCStr
+      attr_reader :name
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, name)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+      end
+
+      # @param context [SerializationContext]
+      #  the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF,
+                                                            context.alignment,
+                                                            :name => name.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:name]].pack(format) + string_payload
+      end
+    end
+
+    # A load command used to indicate dynamic libraries used in prebinding.
+    # Corresponds to LC_PREBOUND_DYLIB.
+    class PreboundDylibCommand < LoadCommand
+      # @return [LCStr] the library's path
+      #  name as an LCStr
+      attr_reader :name
+
+      # @return [Fixnum] the number of modules in the library
+      attr_reader :nmodules
+
+      # @return [Fixnum] a bit vector of linked modules
+      attr_reader :linked_modules
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      # @api private
+      def initialize(view, cmd, cmdsize, name, nmodules, linked_modules)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @nmodules = nmodules
+        @linked_modules = linked_modules
+      end
+    end
+
+    # A load command used to represent threads.
+    # @note cctools-870 and onwards have all fields of thread_command commented
+    # out except the common ones (cmd, cmdsize)
+    class ThreadCommand < LoadCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+    end
+
+    # A load command containing the address of the dynamic shared library
+    # initialization routine and an index into the module table for the module
+    # that defines the routine. Corresponds to LC_ROUTINES.
+    class RoutinesCommand < LoadCommand
+      # @return [Fixnum] the address of the initialization routine
+      attr_reader :init_address
+
+      # @return [Fixnum] the index into the module table that the init routine
+      #  is defined in
+      attr_reader :init_module
+
+      # @return [void]
+      attr_reader :reserved1
+
+      # @return [void]
+      attr_reader :reserved2
+
+      # @return [void]
+      attr_reader :reserved3
+
+      # @return [void]
+      attr_reader :reserved4
+
+      # @return [void]
+      attr_reader :reserved5
+
+      # @return [void]
+      attr_reader :reserved6
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=10".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 40
+
+      # @api private
+      def initialize(view, cmd, cmdsize, init_address, init_module, reserved1,
+                     reserved2, reserved3, reserved4, reserved5, reserved6)
+        super(view, cmd, cmdsize)
+        @init_address = init_address
+        @init_module = init_module
+        @reserved1 = reserved1
+        @reserved2 = reserved2
+        @reserved3 = reserved3
+        @reserved4 = reserved4
+        @reserved5 = reserved5
+        @reserved6 = reserved6
+      end
+    end
+
+    # A load command containing the address of the dynamic shared library
+    # initialization routine and an index into the module table for the module
+    # that defines the routine. Corresponds to LC_ROUTINES_64.
+    class RoutinesCommand64 < RoutinesCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=8".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 72
+    end
+
+    # A load command signifying membership of a subframework containing the name
+    # of an umbrella framework. Corresponds to LC_SUB_FRAMEWORK.
+    class SubFrameworkCommand < LoadCommand
+      # @return [LCStr] the umbrella framework name as an LCStr
+      attr_reader :umbrella
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, umbrella)
+        super(view, cmd, cmdsize)
+        @umbrella = LCStr.new(self, umbrella)
+      end
+    end
+
+    # A load command signifying membership of a subumbrella containing the name
+    # of an umbrella framework. Corresponds to LC_SUB_UMBRELLA.
+    class SubUmbrellaCommand < LoadCommand
+      # @return [LCStr] the subumbrella framework name as an LCStr
+      attr_reader :sub_umbrella
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_umbrella)
+        super(view, cmd, cmdsize)
+        @sub_umbrella = LCStr.new(self, sub_umbrella)
+      end
+    end
+
+    # A load command signifying a sublibrary of a shared library. Corresponds
+    # to LC_SUB_LIBRARY.
+    class SubLibraryCommand < LoadCommand
+      # @return [LCStr] the sublibrary name as an LCStr
+      attr_reader :sub_library
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_library)
+        super(view, cmd, cmdsize)
+        @sub_library = LCStr.new(self, sub_library)
+      end
+    end
+
+    # A load command signifying a shared library that is a subframework of
+    # an umbrella framework. Corresponds to LC_SUB_CLIENT.
+    class SubClientCommand < LoadCommand
+      # @return [LCStr] the subclient name as an LCStr
+      attr_reader :sub_client
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, sub_client)
+        super(view, cmd, cmdsize)
+        @sub_client = LCStr.new(self, sub_client)
+      end
+    end
+
+    # A load command containing the offsets and sizes of the link-edit 4.3BSD
+    # "stab" style symbol table information. Corresponds to LC_SYMTAB.
+    class SymtabCommand < LoadCommand
+      # @return [Fixnum] the symbol table's offset
+      attr_reader :symoff
+
+      # @return [Fixnum] the number of symbol table entries
+      attr_reader :nsyms
+
+      # @return the string table's offset
+      attr_reader :stroff
+
+      # @return the string table size in bytes
+      attr_reader :strsize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, symoff, nsyms, stroff, strsize)
+        super(view, cmd, cmdsize)
+        @symoff = symoff
+        @nsyms = nsyms
+        @stroff = stroff
+        @strsize = strsize
+      end
+    end
+
+    # A load command containing symbolic information needed to support data
+    # structures used by the dynamic link editor. Corresponds to LC_DYSYMTAB.
+    class DysymtabCommand < LoadCommand
+      # @return [Fixnum] the index to local symbols
+      attr_reader :ilocalsym
+
+      # @return [Fixnum] the number of local symbols
+      attr_reader :nlocalsym
+
+      # @return [Fixnum] the index to externally defined symbols
+      attr_reader :iextdefsym
+
+      # @return [Fixnum] the number of externally defined symbols
+      attr_reader :nextdefsym
+
+      # @return [Fixnum] the index to undefined symbols
+      attr_reader :iundefsym
+
+      # @return [Fixnum] the number of undefined symbols
+      attr_reader :nundefsym
+
+      # @return [Fixnum] the file offset to the table of contents
+      attr_reader :tocoff
+
+      # @return [Fixnum] the number of entries in the table of contents
+      attr_reader :ntoc
+
+      # @return [Fixnum] the file offset to the module table
+      attr_reader :modtaboff
+
+      # @return [Fixnum] the number of entries in the module table
+      attr_reader :nmodtab
+
+      # @return [Fixnum] the file offset to the referenced symbol table
+      attr_reader :extrefsymoff
+
+      # @return [Fixnum] the number of entries in the referenced symbol table
+      attr_reader :nextrefsyms
+
+      # @return [Fixnum] the file offset to the indirect symbol table
+      attr_reader :indirectsymoff
+
+      # @return [Fixnum] the number of entries in the indirect symbol table
+      attr_reader :nindirectsyms
+
+      # @return [Fixnum] the file offset to the external relocation entries
+      attr_reader :extreloff
+
+      # @return [Fixnum] the number of external relocation entries
+      attr_reader :nextrel
+
+      # @return [Fixnum] the file offset to the local relocation entries
+      attr_reader :locreloff
+
+      # @return [Fixnum] the number of local relocation entries
+      attr_reader :nlocrel
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=20".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 80
+
+      # ugh
+      # @api private
+      def initialize(view, cmd, cmdsize, ilocalsym, nlocalsym, iextdefsym,
+                     nextdefsym, iundefsym, nundefsym, tocoff, ntoc, modtaboff,
+                     nmodtab, extrefsymoff, nextrefsyms, indirectsymoff,
+                     nindirectsyms, extreloff, nextrel, locreloff, nlocrel)
+        super(view, cmd, cmdsize)
+        @ilocalsym = ilocalsym
+        @nlocalsym = nlocalsym
+        @iextdefsym = iextdefsym
+        @nextdefsym = nextdefsym
+        @iundefsym = iundefsym
+        @nundefsym = nundefsym
+        @tocoff = tocoff
+        @ntoc = ntoc
+        @modtaboff = modtaboff
+        @nmodtab = nmodtab
+        @extrefsymoff = extrefsymoff
+        @nextrefsyms = nextrefsyms
+        @indirectsymoff = indirectsymoff
+        @nindirectsyms = nindirectsyms
+        @extreloff = extreloff
+        @nextrel = nextrel
+        @locreloff = locreloff
+        @nlocrel = nlocrel
+      end
+    end
+
+    # A load command containing the offset and number of hints in the two-level
+    # namespace lookup hints table. Corresponds to LC_TWOLEVEL_HINTS.
+    class TwolevelHintsCommand < LoadCommand
+      # @return [Fixnum] the offset to the hint table
+      attr_reader :htoffset
+
+      # @return [Fixnum] the number of hints in the hint table
+      attr_reader :nhints
+
+      # @return [TwolevelHintsTable]
+      #  the hint table
+      attr_reader :table
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, htoffset, nhints)
+        super(view, cmd, cmdsize)
+        @htoffset = htoffset
+        @nhints = nhints
+        @table = TwolevelHintsTable.new(view, htoffset, nhints)
+      end
+
+      # A representation of the two-level namespace lookup hints table exposed
+      # by a {TwolevelHintsCommand} (`LC_TWOLEVEL_HINTS`).
+      class TwolevelHintsTable
+        # @return [Array<TwolevelHint>] all hints in the table
+        attr_reader :hints
+
+        # @param view [MachO::MachOView] the view into the current Mach-O
+        # @param htoffset [Fixnum] the offset of the hints table
+        # @param nhints [Fixnum] the number of two-level hints in the table
+        # @api private
+        def initialize(view, htoffset, nhints)
+          format = Utils.specialize_format("L=#{nhints}", view.endianness)
+          raw_table = view.raw_data[htoffset, nhints * 4]
+          blobs = raw_table.unpack(format)
+
+          @hints = blobs.map { |b| TwolevelHint.new(b) }
+        end
+
+        # An individual two-level namespace lookup hint.
+        class TwolevelHint
+          # @return [Fixnum] the index into the sub-images
+          attr_reader :isub_image
+
+          # @return [Fixnum] the index into the table of contents
+          attr_reader :itoc
+
+          # @param blob [Fixnum] the 32-bit number containing the lookup hint
+          # @api private
+          def initialize(blob)
+            @isub_image = blob >> 24
+            @itoc = blob & 0x00FFFFFF
+          end
+        end
+      end
+    end
+
+    # A load command containing the value of the original checksum for prebound
+    # files, or zero. Corresponds to LC_PREBIND_CKSUM.
+    class PrebindCksumCommand < LoadCommand
+      # @return [Fixnum] the checksum or 0
+      attr_reader :cksum
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cksum)
+        super(view, cmd, cmdsize)
+        @cksum = cksum
+      end
+    end
+
+    # A load command representing an rpath, which specifies a path that should
+    # be added to the current run path used to find @rpath prefixed dylibs.
+    # Corresponds to LC_RPATH.
+    class RpathCommand < LoadCommand
+      # @return [LCStr] the path to add to the run path as an LCStr
+      attr_reader :path
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, path)
+        super(view, cmd, cmdsize)
+        @path = LCStr.new(self, path)
+      end
+
+      # @param context [SerializationContext] the context
+      # @return [String] the serialized fields of the load command
+      # @api private
+      def serialize(context)
+        format = Utils.specialize_format(FORMAT, context.endianness)
+        string_payload, string_offsets = Utils.pack_strings(SIZEOF,
+                                                            context.alignment,
+                                                            :path => path.to_s)
+        cmdsize = SIZEOF + string_payload.bytesize
+        [cmd, cmdsize, string_offsets[:path]].pack(format) + string_payload
+      end
+    end
+
+    # A load command representing the offsets and sizes of a blob of data in
+    # the __LINKEDIT segment. Corresponds to LC_CODE_SIGNATURE,
+    # LC_SEGMENT_SPLIT_INFO, LC_FUNCTION_STARTS, LC_DATA_IN_CODE,
+    # LC_DYLIB_CODE_SIGN_DRS, and LC_LINKER_OPTIMIZATION_HINT.
+    class LinkeditDataCommand < LoadCommand
+      # @return [Fixnum] offset to the data in the __LINKEDIT segment
+      attr_reader :dataoff
+
+      # @return [Fixnum] size of the data in the __LINKEDIT segment
+      attr_reader :datasize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, dataoff, datasize)
+        super(view, cmd, cmdsize)
+        @dataoff = dataoff
+        @datasize = datasize
+      end
+    end
+
+    # A load command representing the offset to and size of an encrypted
+    # segment. Corresponds to LC_ENCRYPTION_INFO.
+    class EncryptionInfoCommand < LoadCommand
+      # @return [Fixnum] the offset to the encrypted segment
+      attr_reader :cryptoff
+
+      # @return [Fixnum] the size of the encrypted segment
+      attr_reader :cryptsize
+
+      # @return [Fixnum] the encryption system, or 0 if not encrypted yet
+      attr_reader :cryptid
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid)
+        super(view, cmd, cmdsize)
+        @cryptoff = cryptoff
+        @cryptsize = cryptsize
+        @cryptid = cryptid
+      end
+    end
+
+    # A load command representing the offset to and size of an encrypted
+    # segment. Corresponds to LC_ENCRYPTION_INFO_64.
+    class EncryptionInfoCommand64 < LoadCommand
+      # @return [Fixnum] the offset to the encrypted segment
+      attr_reader :cryptoff
+
+      # @return [Fixnum] the size of the encrypted segment
+      attr_reader :cryptsize
+
+      # @return [Fixnum] the encryption system, or 0 if not encrypted yet
+      attr_reader :cryptid
+
+      # @return [Fixnum] 64-bit padding value
+      attr_reader :pad
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=6".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, cryptoff, cryptsize, cryptid, pad)
+        super(view, cmd, cmdsize)
+        @cryptoff = cryptoff
+        @cryptsize = cryptsize
+        @cryptid = cryptid
+        @pad = pad
+      end
+    end
+
+    # A load command containing the minimum OS version on which the binary
+    # was built to run. Corresponds to LC_VERSION_MIN_MACOSX and
+    # LC_VERSION_MIN_IPHONEOS.
+    class VersionMinCommand < LoadCommand
+      # @return [Fixnum] the version X.Y.Z packed as x16.y8.z8
+      attr_reader :version
+
+      # @return [Fixnum] the SDK version X.Y.Z packed as x16.y8.z8
+      attr_reader :sdk
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, version, sdk)
+        super(view, cmd, cmdsize)
+        @version = version
+        @sdk = sdk
+      end
+
+      # A string representation of the binary's minimum OS version.
+      # @return [String] a string representing the minimum OS version.
+      def version_string
+        binary = "%032b" % version
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+
+      # A string representation of the binary's SDK version.
+      # @return [String] a string representing the SDK version.
+      def sdk_string
+        binary = "%032b" % sdk
+        segs = [
+          binary[0..15], binary[16..23], binary[24..31]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+    end
+
+    # A load command containing the file offsets and sizes of the new
+    # compressed form of the information dyld needs to load the image.
+    # Corresponds to LC_DYLD_INFO and LC_DYLD_INFO_ONLY.
+    class DyldInfoCommand < LoadCommand
+      # @return [Fixnum] the file offset to the rebase information
+      attr_reader :rebase_off
+
+      # @return [Fixnum] the size of the rebase information
+      attr_reader :rebase_size
+
+      # @return [Fixnum] the file offset to the binding information
+      attr_reader :bind_off
+
+      # @return [Fixnum] the size of the binding information
+      attr_reader :bind_size
+
+      # @return [Fixnum] the file offset to the weak binding information
+      attr_reader :weak_bind_off
+
+      # @return [Fixnum] the size of the weak binding information
+      attr_reader :weak_bind_size
+
+      # @return [Fixnum] the file offset to the lazy binding information
+      attr_reader :lazy_bind_off
+
+      # @return [Fixnum] the size of the lazy binding information
+      attr_reader :lazy_bind_size
+
+      # @return [Fixnum] the file offset to the export information
+      attr_reader :export_off
+
+      # @return [Fixnum] the size of the export information
+      attr_reader :export_size
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=12".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 48
+
+      # @api private
+      def initialize(view, cmd, cmdsize, rebase_off, rebase_size, bind_off,
+                     bind_size, weak_bind_off, weak_bind_size, lazy_bind_off,
+                     lazy_bind_size, export_off, export_size)
+        super(view, cmd, cmdsize)
+        @rebase_off = rebase_off
+        @rebase_size = rebase_size
+        @bind_off = bind_off
+        @bind_size = bind_size
+        @weak_bind_off = weak_bind_off
+        @weak_bind_size = weak_bind_size
+        @lazy_bind_off = lazy_bind_off
+        @lazy_bind_size = lazy_bind_size
+        @export_off = export_off
+        @export_size = export_size
+      end
+    end
+
+    # A load command containing linker options embedded in object files.
+    # Corresponds to LC_LINKER_OPTION.
+    class LinkerOptionCommand < LoadCommand
+      # @return [Fixnum] the number of strings
+      attr_reader :count
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=3".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 12
+
+      # @api private
+      def initialize(view, cmd, cmdsize, count)
+        super(view, cmd, cmdsize)
+        @count = count
+      end
+    end
+
+    # A load command specifying the offset of main(). Corresponds to LC_MAIN.
+    class EntryPointCommand < LoadCommand
+      # @return [Fixnum] the file (__TEXT) offset of main()
+      attr_reader :entryoff
+
+      # @return [Fixnum] if not 0, the initial stack size.
+      attr_reader :stacksize
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 24
+
+      # @api private
+      def initialize(view, cmd, cmdsize, entryoff, stacksize)
+        super(view, cmd, cmdsize)
+        @entryoff = entryoff
+        @stacksize = stacksize
+      end
+    end
+
+    # A load command specifying the version of the sources used to build the
+    # binary. Corresponds to LC_SOURCE_VERSION.
+    class SourceVersionCommand < LoadCommand
+      # @return [Fixnum] the version packed as a24.b10.c10.d10.e10
+      attr_reader :version
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2Q=1".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, version)
+        super(view, cmd, cmdsize)
+        @version = version
+      end
+
+      # A string representation of the sources used to build the binary.
+      # @return [String] a string representation of the version
+      def version_string
+        binary = "%064b" % version
+        segs = [
+          binary[0..23], binary[24..33], binary[34..43], binary[44..53],
+          binary[54..63]
+        ].map { |s| s.to_i(2) }
+
+        segs.join(".")
+      end
+    end
+
+    # An obsolete load command containing the offset and size of the (GNU style)
+    # symbol table information. Corresponds to LC_SYMSEG.
+    class SymsegCommand < LoadCommand
+      # @return [Fixnum] the offset to the symbol segment
+      attr_reader :offset
+
+      # @return [Fixnum] the size of the symbol segment in bytes
+      attr_reader :size
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      # @api private
+      def initialize(view, cmd, cmdsize, offset, size)
+        super(view, cmd, cmdsize)
+        @offset = offset
+        @size = size
+      end
+    end
+
+    # An obsolete load command containing a free format string table. Each
+    # string is null-terminated and the command is zero-padded to a multiple of
+    # 4. Corresponds to LC_IDENT.
+    class IdentCommand < LoadCommand
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=2".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 8
+    end
+
+    # An obsolete load command containing the path to a file to be loaded into
+    # memory. Corresponds to LC_FVMFILE.
+    class FvmfileCommand < LoadCommand
+      # @return [LCStr] the pathname of the file being loaded
+      attr_reader :name
+
+      # @return [Fixnum] the virtual address being loaded at
+      attr_reader :header_addr
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=4".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 16
+
+      def initialize(view, cmd, cmdsize, name, header_addr)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @header_addr = header_addr
+      end
+    end
+
+    # An obsolete load command containing the path to a library to be loaded
+    # into memory. Corresponds to LC_LOADFVMLIB and LC_IDFVMLIB.
+    class FvmlibCommand < LoadCommand
+      # @return [LCStr] the library's target pathname
+      attr_reader :name
+
+      # @return [Fixnum] the library's minor version number
+      attr_reader :minor_version
+
+      # @return [Fixnum] the library's header address
+      attr_reader :header_addr
+
+      # @see MachOStructure::FORMAT
+      # @api private
+      FORMAT = "L=5".freeze
+
+      # @see MachOStructure::SIZEOF
+      # @api private
+      SIZEOF = 20
+
+      def initialize(view, cmd, cmdsize, name, minor_version, header_addr)
+        super(view, cmd, cmdsize)
+        @name = LCStr.new(self, name)
+        @minor_version = minor_version
+        @header_addr = header_addr
+      end
+    end
+  end
+end

--- a/testdata/issue20/parser.rs
+++ b/testdata/issue20/parser.rs
@@ -1,0 +1,625 @@
+use super::syntax_definition::*;
+use super::scope::*;
+use onig::{self, Region};
+use std::usize;
+use std::collections::{HashMap, HashSet};
+use std::i32;
+use std::hash::BuildHasherDefault;
+use fnv::FnvHasher;
+
+/// Keeps the current parser state (the internal syntax interpreter stack) between lines of parsing.
+/// If you are parsing an entire file you create one of these at the start and use it
+/// all the way to the end.
+///
+/// # Caching
+///
+/// One reason this is exposed is that since it implements `Clone` you can actually cache
+/// these (probably along with a `HighlightState`) and only re-start parsing from the point of a change.
+/// See the docs for `HighlightState` for more in-depth discussion of caching.
+///
+/// This state doesn't keep track of the current scope stack and parsing only returns changes to this stack
+/// so if you want to construct scope stacks you'll need to keep track of that as well.
+/// Note that `HighlightState` contains exactly this as a public field that you can use.
+///
+/// **Note:** Caching is for advanced users who have tons of time to maximize performance or want to do so eventually.
+/// It is not recommended that you try caching the first time you implement highlighting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseState {
+    stack: Vec<StateLevel>,
+    first_line: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StateLevel {
+    context: ContextPtr,
+    prototype: Option<ContextPtr>,
+    captures: Option<(Region, String)>,
+}
+
+#[derive(Debug)]
+struct RegexMatch {
+    regions: Region,
+    context: ContextPtr,
+    pat_index: usize,
+}
+
+/// maps the pattern to the start index, which is -1 if not found.
+type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefault<FnvHasher>>;
+type MatchedPatterns = HashSet<*const MatchPattern, BuildHasherDefault<FnvHasher>>;
+
+impl ParseState {
+    /// Create a state from a syntax, keeps its own reference counted
+    /// pointer to the main context of the syntax.
+    pub fn new(syntax: &SyntaxDefinition) -> ParseState {
+        let start_state = StateLevel {
+            // __start is a special context we add in yaml_load.rs
+            context: syntax.contexts["__start"].clone(),
+            prototype: None,
+            captures: None,
+        };
+        ParseState {
+            stack: vec![start_state],
+            first_line: true,
+        }
+    }
+
+    /// Parses a single line of the file. Because of the way regex engines work you unfortunately
+    /// have to pass in a single line contigous in memory. This can be bad for really long lines.
+    /// Sublime Text avoids this by just not highlighting lines that are too long (thousands of characters).
+    ///
+    /// For efficiency reasons this returns only the changes to the current scope at each point in the line.
+    /// You can use `ScopeStack#apply` on each operation in succession to get the stack for a given point.
+    /// Look at the code in `highlighter.rs` for an example of doing this for highlighting purposes.
+    ///
+    /// The vector is in order both by index to apply at (the `usize`) and also by order to apply them at a
+    /// given index (e.g popping old scopes before pusing new scopes).
+    pub fn parse_line(&mut self, line: &str) -> Vec<(usize, ScopeStackOp)> {
+        assert!(self.stack.len() > 0,
+                "Somehow main context was popped from the stack");
+        let mut match_start = 0;
+        let mut prev_match_start = 0;
+        let mut res = Vec::new();
+
+        if self.first_line {
+            let cur_level = &self.stack[self.stack.len() - 1];
+            let context = cur_level.context.borrow();
+            if !context.meta_content_scope.is_empty() {
+                res.push((0, ScopeStackOp::Push(context.meta_content_scope[0])));
+            }
+            self.first_line = false;
+        }
+
+        let mut regions = Region::with_capacity(8);
+        let fnv = BuildHasherDefault::<FnvHasher>::default();
+        let mut search_cache: SearchCache = HashMap::with_capacity_and_hasher(128, fnv);
+        let fnv2 = BuildHasherDefault::<FnvHasher>::default();
+        // Fixes issue https://github.com/trishume/syntect/issues/25
+        let mut matched: MatchedPatterns = HashSet::with_capacity_and_hasher(4, fnv2);
+
+        while self.parse_next_token(line,
+                                    &mut match_start,
+                                    &mut search_cache,
+                                    &mut matched,
+                                    &mut regions,
+                                    &mut res) {
+            // We only care about not repeatedly matching things at the same location
+            if match_start != prev_match_start {
+                matched.clear();
+            }
+            prev_match_start = match_start;
+        }
+
+        res
+    }
+
+    fn parse_next_token(&mut self,
+                        line: &str,
+                        start: &mut usize,
+                        search_cache: &mut SearchCache,
+                        matched: &mut MatchedPatterns,
+                        regions: &mut Region,
+                        ops: &mut Vec<(usize, ScopeStackOp)>)
+                        -> bool {
+        let cur_match = {
+            let cur_level = &self.stack[self.stack.len() - 1];
+            let mut min_start = usize::MAX;
+            let mut cur_match: Option<RegexMatch> = None;
+            let prototype: Option<ContextPtr> = {
+                let ctx_ref = cur_level.context.borrow();
+                ctx_ref.prototype.clone()
+            };
+            let context_chain = self.stack
+                .iter().rev() // iterate the stack in top-down order to apply the prototypes
+                .filter_map(|lvl| lvl.prototype.as_ref().cloned())
+                .chain(prototype.into_iter())
+                .chain(Some(cur_level.context.clone()).into_iter());
+            // println!("{:#?}", cur_level);
+            // println!("token at {} on {}", start, line.trim_right());
+            for ctx in context_chain {
+                for (pat_context_ptr, pat_index) in context_iter(ctx) {
+                    let mut pat_context = pat_context_ptr.borrow_mut();
+                    let mut match_pat = pat_context.match_at_mut(pat_index);
+                    // println!("{} - {:?} - {:?}", match_pat.regex_str, match_pat.has_captures, cur_level.captures.is_some());
+                    let match_ptr = match_pat as *const MatchPattern;
+
+                    // Avoid matching the same pattern twice in the same place, causing an infinite loop
+                    if matched.contains(&match_ptr) {
+                        continue;
+                    }
+
+                    if let Some(maybe_region) =
+                           search_cache.get(&match_ptr) {
+                        let mut valid_entry = true;
+                        if let Some(ref region) = *maybe_region {
+                            let match_start = region.pos(0).unwrap().0;
+                            if match_start < *start {
+                                valid_entry = false;
+                            } else if match_start < min_start {
+                                // print!("match {} at {} on {}", match_pat.regex_str, match_start, line);
+                                min_start = match_start;
+                                cur_match = Some(RegexMatch {
+                                    regions: region.clone(),
+                                    context: pat_context_ptr.clone(),
+                                    pat_index: pat_index,
+                                });
+                            }
+                        }
+                        if valid_entry {
+                            continue;
+                        }
+                    }
+
+                    match_pat.ensure_compiled_if_possible();
+                    let refs_regex = if match_pat.has_captures && cur_level.captures.is_some() {
+                        let &(ref region, ref s) = cur_level.captures.as_ref().unwrap();
+                        Some(match_pat.compile_with_refs(region, s))
+                    } else {
+                        None
+                    };
+                    let regex = if let Some(ref rgx) = refs_regex {
+                        rgx
+                    } else {
+                        match_pat.regex.as_ref().unwrap()
+                    };
+                    let matched = regex.search_with_options(line,
+                                                            *start,
+                                                            line.len(),
+                                                            onig::SEARCH_OPTION_NONE,
+                                                            Some(regions));
+                    if let Some(match_start) = matched {
+                        let match_end = regions.pos(0).unwrap().1;
+                        // this is necessary to avoid infinite looping on dumb patterns
+                        let does_something = match match_pat.operation {
+                            MatchOperation::None => match_start != match_end,
+                            _ => true,
+                        };
+                        if refs_regex.is_none() && does_something {
+                            search_cache.insert(match_pat, Some(regions.clone()));
+                        }
+                        if match_start < min_start && does_something {
+                            // print!("catch {} at {} on {}", match_pat.regex_str, match_start, line);
+                            min_start = match_start;
+                            cur_match = Some(RegexMatch {
+                                regions: regions.clone(),
+                                context: pat_context_ptr.clone(),
+                                pat_index: pat_index,
+                            });
+                        }
+                    } else if refs_regex.is_none() {
+                        search_cache.insert(match_pat, None);
+                    }
+                }
+            }
+            cur_match
+        };
+
+        if let Some(reg_match) = cur_match {
+            let (_, match_end) = reg_match.regions.pos(0).unwrap();
+            *start = match_end;
+            let level_context = self.stack[self.stack.len() - 1].context.clone();
+            self.exec_pattern(line, reg_match, level_context, matched, ops);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the stack was changed
+    fn exec_pattern(&mut self,
+                    line: &str,
+                    reg_match: RegexMatch,
+                    level_context_ptr: ContextPtr,
+                    matched: &mut MatchedPatterns,
+                    ops: &mut Vec<(usize, ScopeStackOp)>)
+                    -> bool {
+        let (match_start, match_end) = reg_match.regions.pos(0).unwrap();
+        let context = reg_match.context.borrow();
+        let pat = context.match_at(reg_match.pat_index);
+        let level_context = level_context_ptr.borrow();
+        // println!("running pattern {:?} on '{}' at {}", pat.regex_str, line, match_start);
+
+        // We only worry about keeping track to avoid infinite loops on pushes and sets
+        // So that we fix #25 but don't break like #28
+        match pat.operation {
+            MatchOperation::Push(_) |
+            MatchOperation::Set(_) => {
+                matched.insert(pat as *const MatchPattern);
+            },
+            MatchOperation::Pop | MatchOperation:: None => ()
+        };
+
+        self.push_meta_ops(true, match_start, &*level_context, &pat.operation, ops);
+        for s in &pat.scope {
+            // println!("pushing {:?} at {}", s, match_start);
+            ops.push((match_start, ScopeStackOp::Push(*s)));
+        }
+        if let Some(ref capture_map) = pat.captures {
+            // captures could appear in an arbitrary order, have to produce ops in right order
+            // ex: ((bob)|(hi))* could match hibob in wrong order, and outer has to push first
+            // we don't have to handle a capture matching multiple times, Sublime doesn't
+            let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
+            for &(cap_index, ref scopes) in capture_map.iter() {
+                if let Some((cap_start, cap_end)) = reg_match.regions.pos(cap_index) {
+                    // marking up empty captures causes pops to be sorted wrong
+                    if cap_start == cap_end {
+                        continue;
+                    }
+                    // println!("capture {:?} at {:?}-{:?}", scopes[0], cap_start, cap_end);
+                    for scope in scopes.iter() {
+                        map.push(((cap_start, -((cap_end - cap_start) as i32)),
+                                  ScopeStackOp::Push(*scope)));
+                    }
+                    map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
+                }
+            }
+            map.sort_by(|a, b| a.0.cmp(&b.0));
+            for ((index, _), op) in map.into_iter() {
+                ops.push((index, op));
+            }
+        }
+        if !pat.scope.is_empty() {
+            // println!("popping at {}", match_end);
+            ops.push((match_end, ScopeStackOp::Pop(pat.scope.len())));
+        }
+        self.push_meta_ops(false, match_end, &*level_context, &pat.operation, ops);
+
+        self.perform_op(line, &reg_match.regions, pat)
+    }
+
+    fn push_meta_ops(&self,
+                     initial: bool,
+                     index: usize,
+                     cur_context: &Context,
+                     match_op: &MatchOperation,
+                     ops: &mut Vec<(usize, ScopeStackOp)>) {
+        // println!("metas ops for {:?}, initial: {}",
+        //          match_op,
+        //          initial);
+        // println!("{:?}", cur_context.meta_scope);
+        match *match_op {
+            MatchOperation::Pop => {
+                let v = if initial {
+                    &cur_context.meta_content_scope
+                } else {
+                    &cur_context.meta_scope
+                };
+                if !v.is_empty() {
+                    ops.push((index, ScopeStackOp::Pop(v.len())));
+                }
+
+                // cleared scopes are restored after the scopes from match pattern that invoked the pop are applied
+                if !initial && cur_context.clear_scopes != None {
+                    ops.push((index, ScopeStackOp::Restore));
+                }
+            },
+            // for some reason the ST3 behaviour of set is convoluted and is inconsistent with the docs and other ops
+            // - the meta_content_scope of the current context is applied to the matched thing, unlike pop
+            // - the clear_scopes are applied after the matched token, unlike push
+            // - the interaction with meta scopes means that the token has the meta scopes of both the current scope and the new scope.
+            MatchOperation::Push(ref context_refs) |
+            MatchOperation::Set(ref context_refs) => {
+                let is_set = match *match_op {
+                    MatchOperation::Set(_) => true,
+                    _ => false
+                };
+                // a match pattern that "set"s keeps the meta_content_scope and meta_scope from the previous context
+                if initial {
+                    // add each context's meta scope
+                    for r in context_refs.iter() {
+                        let ctx_ptr = r.resolve();
+                        let ctx = ctx_ptr.borrow();
+
+                        if !is_set {
+                            if let Some(clear_amount) = ctx.clear_scopes {
+                                ops.push((index, ScopeStackOp::Clear(clear_amount)));
+                            }
+                        }
+
+                        for scope in ctx.meta_scope.iter() {
+                            ops.push((index, ScopeStackOp::Push(*scope)));
+                        }
+                    }
+                } else {
+                    let repush = (is_set && (!cur_context.meta_scope.is_empty() || !cur_context.meta_content_scope.is_empty())) || context_refs.iter().any(|r| {
+                        let ctx_ptr = r.resolve();
+                        let ctx = ctx_ptr.borrow();
+
+                        !ctx.meta_content_scope.is_empty() || (ctx.clear_scopes.is_some() && is_set)
+                    });
+                    if repush {
+                        // remove previously pushed meta scopes, so that meta content scopes will be applied in the correct order
+                        let mut num_to_pop : usize = context_refs.iter().map(|r| {
+                            let ctx_ptr = r.resolve();
+                            let ctx = ctx_ptr.borrow();
+                            ctx.meta_scope.len()
+                        }).sum();
+
+                        // also pop off the original context's meta scopes
+                        if is_set {
+                            num_to_pop += cur_context.meta_content_scope.len() + cur_context.meta_scope.len();
+                        }
+
+                        // do all the popping as one operation
+                        if num_to_pop > 0 {
+                            ops.push((index, ScopeStackOp::Pop(num_to_pop)));
+                        }
+
+                        // now we push meta scope and meta context scope for each context pushed
+                        for r in context_refs {
+                            let ctx_ptr = r.resolve();
+                            let ctx = ctx_ptr.borrow();
+
+                            // for some reason, contrary to my reading of the docs, set does this after the token
+                            if is_set {
+                                if let Some(clear_amount) = ctx.clear_scopes {
+                                    ops.push((index, ScopeStackOp::Clear(clear_amount)));
+                                }
+                            }
+
+                            for scope in ctx.meta_scope.iter() {
+                                ops.push((index, ScopeStackOp::Push(*scope)));
+                            }
+                            for scope in ctx.meta_content_scope.iter() {
+                                ops.push((index, ScopeStackOp::Push(*scope)));
+                            }
+                        }
+                    }
+                }
+            },
+            MatchOperation::None => (),
+        }
+    }
+
+    /// Returns true if the stack was changed
+    fn perform_op(&mut self, line: &str, regions: &Region, pat: &MatchPattern) -> bool {
+        let ctx_refs = match pat.operation {
+            MatchOperation::Push(ref ctx_refs) => ctx_refs,
+            MatchOperation::Set(ref ctx_refs) => {
+                self.stack.pop();
+                ctx_refs
+            }
+            MatchOperation::Pop => {
+                self.stack.pop();
+                return true;
+            }
+            MatchOperation::None => return false,
+        };
+        for (i, r) in ctx_refs.iter().enumerate() {
+            let proto = if i == 0 {
+                pat.with_prototype.clone()
+            } else {
+                None
+            };
+            let ctx_ptr = r.resolve();
+            let captures = {
+                let ctx = ctx_ptr.borrow();
+                if ctx.uses_backrefs {
+                    Some((regions.clone(), line.to_owned()))
+                } else {
+                    None
+                }
+            };
+            self.stack.push(StateLevel {
+                context: ctx_ptr,
+                prototype: proto,
+                captures: captures,
+            });
+        }
+        true
+    }
+}
+
+#[cfg(feature = "yaml-load")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parsing::{SyntaxSet, Scope, ScopeStack};
+    use util::debug_print_ops;
+
+    #[test]
+    fn can_parse() {
+        use parsing::ScopeStackOp::{Push, Pop, Clear, Restore};
+        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let mut state = {
+            let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
+            ParseState::new(syntax)
+        };
+        let mut state2 = {
+            let syntax = ps.find_syntax_by_name("HTML (Rails)").unwrap();
+            ParseState::new(syntax)
+        };
+        let mut state3 = {
+            let syntax = ps.find_syntax_by_name("C").unwrap();
+            ParseState::new(syntax)
+        };
+
+        let line = "module Bob::Wow::Troll::Five; 5; end";
+        let ops = state.parse_line(line);
+        debug_print_ops(line, &ops);
+
+        let test_ops = vec![
+            (0, Push(Scope::new("source.ruby.rails").unwrap())),
+            (0, Push(Scope::new("meta.module.ruby").unwrap())),
+            (0, Push(Scope::new("keyword.control.module.ruby").unwrap())),
+            (6, Pop(2)),
+            (6, Push(Scope::new("meta.module.ruby").unwrap())),
+            (7, Pop(1)),
+            (7, Push(Scope::new("meta.module.ruby").unwrap())),
+            (7, Push(Scope::new("entity.name.module.ruby").unwrap())),
+            (7, Push(Scope::new("support.other.namespace.ruby").unwrap())),
+            (10, Pop(1)),
+            (10, Push(Scope::new("punctuation.accessor.ruby").unwrap())),
+        ];
+        assert_eq!(&ops[0..test_ops.len()], &test_ops[..]);
+
+        let line2 = "def lol(wow = 5)";
+        let ops2 = state.parse_line(line2);
+        debug_print_ops(line2, &ops2);
+        let test_ops2 = vec![
+            (0, Push(Scope::new("meta.function.ruby").unwrap())),
+            (0, Push(Scope::new("keyword.control.def.ruby").unwrap())),
+            (3, Pop(2)),
+            (3, Push(Scope::new("meta.function.ruby").unwrap())),
+            (4, Push(Scope::new("entity.name.function.ruby").unwrap())),
+            (7, Pop(1))
+        ];
+        assert_eq!(&ops2[0..test_ops2.len()], &test_ops2[..]);
+
+        let line3 = "<script>var lol = '<% def wow(";
+        let ops3 = state2.parse_line(line3);
+        debug_print_ops(line3, &ops3);
+        let mut test_stack = ScopeStack::new();
+        test_stack.push(Scope::new("text.html.ruby").unwrap());
+        test_stack.push(Scope::new("text.html.basic").unwrap());
+        test_stack.push(Scope::new("source.js.embedded.html").unwrap());
+        test_stack.push(Scope::new("string.quoted.single.js").unwrap());
+        test_stack.push(Scope::new("source.ruby.rails.embedded.html").unwrap());
+        test_stack.push(Scope::new("meta.function.parameters.ruby").unwrap());
+        let mut test_stack2 = ScopeStack::new();
+        for &(_, ref op) in ops3.iter() {
+            test_stack2.apply(op);
+        }
+        assert_eq!(test_stack2, test_stack);
+
+        // for testing backrefs
+        let line4 = "lol = <<-SQL\nwow\nSQL";
+        let ops4 = state.parse_line(line4);
+        debug_print_ops(line4, &ops4);
+        let test_ops4 = vec![
+            (4, Push(Scope::new("keyword.operator.assignment.ruby").unwrap())),
+            (5, Pop(1)),
+            (6, Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())),
+            (6, Push(Scope::new("punctuation.definition.string.begin.ruby").unwrap())),
+            (12, Pop(1)),
+            (12, Pop(1)),
+            (12, Push(Scope::new("string.unquoted.embedded.sql.ruby").unwrap())),
+            (12, Push(Scope::new("text.sql.embedded.ruby").unwrap())),
+            (12, Clear(ClearAmount::TopN(2))),
+            (12, Restore),
+            (17, Pop(1)),
+            (17, Push(Scope::new("punctuation.definition.string.end.ruby").unwrap())),
+            (20, Pop(1)),
+            (20, Pop(1)),
+        ];
+        assert_eq!(ops4, test_ops4);
+
+        // test fix for issue #25
+        let line5 = "struct{estruct";
+        let ops5 = state3.parse_line(line5);
+        assert_eq!(ops5.len(), 10);
+
+        // assert!(false);
+    }
+
+    fn expect_scope_stacks(line: &str, expect: &[&str]) {
+        // check that each expected scope stack appears at least once while parsing the given test line
+
+        //let syntax = SyntaxSet::load_syntax_file("testdata/parser_tests.sublime-syntax", true).unwrap();
+        use std::fs::File;
+        use std::io::Read;
+        let mut f = File::open("testdata/parser_tests.sublime-syntax").unwrap();
+        let mut s = String::new();
+        f.read_to_string(&mut s).unwrap();
+
+        let syntax = SyntaxDefinition::load_from_str(&s, true).unwrap();
+
+        let mut state = ParseState::new(&syntax);
+
+        let mut ss = SyntaxSet::new();
+        ss.add_syntax(syntax);
+        ss.link_syntaxes();
+
+        let mut stack = ScopeStack::new();
+        let ops = state.parse_line(line);
+        debug_print_ops(line, &ops);
+
+        let mut criteria_met = Vec::new();
+        for &(_, ref op) in ops.iter() {
+            stack.apply(op);
+            let stack_str = format!("{:?}", stack);
+            println!("{}", stack_str);
+            for expectation in expect.iter() {
+                if stack_str.contains(expectation) {
+                    criteria_met.push(expectation);
+                }
+            }
+        }
+        if let Some(missing) = expect.iter().filter(|e| !criteria_met.contains(&e)).next() {
+            panic!("expected scope stack '{}' missing", missing);
+        }
+    }
+
+    #[test]
+    fn can_parse_non_nested_clear_scopes() {
+        let line = "'hello #simple_cleared_scopes_test world test \\n '\n";
+        let expect = [
+            "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pushes-clear-scopes.example>",
+            "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
+            "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
+        ];
+        expect_scope_stacks(&line, &expect);
+    }
+
+    #[test]
+    fn can_parse_non_nested_too_many_clear_scopes() {
+        let line = "'hello #too_many_cleared_scopes_test world test \\n '\n";
+        let expect = [
+            "<example.meta-scope.after-clear-scopes.example>, <example.pushes-clear-scopes.example>",
+            "<example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
+            "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
+        ];
+        expect_scope_stacks(&line, &expect);
+    }
+
+    #[test]
+    fn can_parse_nested_clear_scopes() {
+        let line = "'hello #nested_clear_scopes_test world foo bar test \\n '\n";
+        let expect = [
+            "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pushes-clear-scopes.example>",
+            "<source.test>, <example.meta-scope.cleared-previous-meta-scope.example>, <foo>",
+            "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
+            "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
+        ];
+        expect_scope_stacks(&line, &expect);
+    }
+
+    #[test]
+    fn can_parse_infinite_loop() {
+        let line = "#infinite_loop_test 123\n";
+        let expect = [
+            "<source.test>, <constant.numeric.test>",
+        ];
+        expect_scope_stacks(&line, &expect);
+    }
+
+    #[test]
+    fn can_parse_infinite_seeming_loop() {
+        let line = "#infinite_seeming_loop_test hello\n";
+        let expect = [
+            "<source.test>, <keyword.test>",
+            "<source.test>, <test>, <string.unquoted.test>",
+            "<source.test>, <test>, <keyword.control.test>",
+        ];
+        expect_scope_stacks(&line, &expect);
+    }
+}


### PR DESCRIPTION
See #20.

This PR adds a struct `SyntaxSetPool` which pools `SyntaxSet`s for parallel usage with the minimum amount of initialization of said `SyntaxSet`s. By default, it will only initialize as many `SyntaxSet`s as the running machine has CPUs, though this can be specified as well.

Examples of the usage of `SyntaxSetPool` can be found in `examples/parsyncat.rs`, which highlights multiple source files in parallel and prints the results to `stdout`, and `benches/parallel_parsing.rs`.

## Issues

`SyntaxDefinition`'s preexisting `Clone` implementation, which was merely incorrect before (due to `Weak` pointers in the resulting clone), can now cause memory unsafety due to their containing `SyntaxSet` being ferried across thread boundaries. Since this implementation was already incorrect, ideally this `Clone` implementation would be fixed or removed before merging this PR. Alternatively, there might be a way to hide it from library users.