### PR TITLE
Add pure Rust versions of dump loading and creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,6 @@ script:
   # default features are required for examples to build - so remove them from sight.
   # Doc-tests may also use default features
   - rm -Rf examples && cargo test --lib --no-default-features
+  # Test the build configuration that Xi uses
+  - cargo test --lib --no-default-features --features "assets dump-load-rs"
 after_success: curl https://raw.githubusercontent.com/trishume/syntect/master/scripts/travis-doc-upload.sh | sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ regex-syntax = { version = "^0.4", optional = true }
 lazy_static = "^0.2"
 bitflags = "^0.8"
 plist = "0.2"
-bincode = "0.8"
-flate2 = "^0.2"
+bincode = { version = "0.8", optional = true }
+flate2 = { version = "^0.2", optional = true }
+libflate = { version = "0.1.8", optional = true }
 fnv = { version = "^1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
@@ -33,12 +34,28 @@ regex = "0.2.1"
 getopts = "0.2"
 
 [features]
+
+# If you enable two dump loading features or two creation features the build
+# will fail, choose one of each. If you are using both creation and loading,
+# your binary will be smaller if you choose the same one for each.
+
+# Pure Rust dump loading, slower than regular `dump-load`
+dump-load-rs = ["libflate", "bincode"]
+# Dump loading using flate2, which depends on the miniz C library.
+dump-load = ["flate2", "bincode"]
+# Dump creation using flate2, which depends on the miniz C library.
+dump-create = ["flate2", "bincode"]
+# Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
+dump-create-rs = ["libflate", "bincode"]
+
 static-onig = ["onig/static-libonig"]
 parsing = ["onig", "regex-syntax", "fnv"]
+# The `assets` feature enables inclusion of the default theme and syntax packages.
+# For `assets` to do anything, it requires one of `dump-load-rs` or `dump-load` to be set.
 assets = []
 html = ["parsing", "assets"]
-yaml-load = ["yaml-rust"]
-default = ["parsing", "assets", "html", "yaml-load"]
+yaml-load = ["yaml-rust", "parsing"]
+default = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create"]
 
 # [profile.release]
 # debug = true

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Tristan Hume
+Copyright (c) 2017 Tristan Hume, Keith Hall, Google Inc and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -174,7 +174,7 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
     }
 }
 
-#[cfg(feature = "assets")]
+#[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -271,13 +271,13 @@ impl<'a> Highlighter<'a> {
     }
 }
 
-#[cfg(feature = "assets")]
+#[cfg(all(feature = "assets", feature = "parsing", any(feature = "dump-load", feature = "dump-load-rs")))]
 #[cfg(test)]
 mod tests {
     use super::*;
     use highlighting::{ThemeSet, Style, Color, FontStyle};
     use parsing::{ SyntaxSet, ScopeStack, ParseState};
-    
+
     #[test]
     fn can_parse() {
         let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,14 @@ extern crate regex_syntax;
 #[macro_use]
 extern crate lazy_static;
 extern crate plist;
+#[cfg(any(feature = "dump-load-rs", feature = "dump-load", feature = "dump-create"))]
 extern crate bincode;
 #[macro_use]
 extern crate bitflags;
+#[cfg(any(feature = "dump-load", feature = "dump-create"))]
 extern crate flate2;
+#[cfg(any(feature = "dump-load-rs", feature = "dump-create-rs"))]
+extern crate libflate;
 #[cfg(feature = "parsing")]
 extern crate fnv;
 extern crate serde;
@@ -37,6 +41,7 @@ extern crate serde_json;
 pub mod highlighting;
 pub mod parsing;
 pub mod util;
+#[cfg(any(feature = "dump-load-rs", feature = "dump-load", feature = "dump-create", feature = "dump-create-rs"))]
 pub mod dumps;
 #[cfg(feature = "parsing")]
 pub mod easy;


### PR DESCRIPTION
Splits out the existing functionality into dump-load and dump-create
features and adds dump-load-rs and dump-create-rs features which use
the libflate crate but are respectively slower and worse at compressing.

Also updates the LICENSE.txt file to comply with Google's preferences
and updates .travis.yml to build the configuration used by Xi.

cc @Byron since you don't use default features so you'll probably have to add the dump features when upgrading.