### PR TITLE
Make syntax set dumps deterministic

### DIFF
--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -156,7 +156,22 @@ mod tests {
         println!("{:?}", bin.len());
         let ps2: SyntaxSet = from_binary(&bin[..]);
         assert_eq!(ps.syntaxes().len(), ps2.syntaxes().len());
+    }
 
+    #[cfg(all(feature = "yaml-load", any(feature = "dump-create", feature = "dump-create-rs"), any(feature = "dump-load", feature = "dump-load-rs")))]
+    #[test]
+    fn dump_is_deterministic() {
+        use super::*;
+        use parsing::SyntaxSet;
+
+        let mut ps1 = SyntaxSet::new();
+        ps1.load_syntaxes("testdata/Packages", false).unwrap();
+        let bin1 = dump_binary(&ps1);
+
+        let mut ps2 = SyntaxSet::new();
+        ps2.load_syntaxes("testdata/Packages", false).unwrap();
+        let bin2 = dump_binary(&ps2);
+        assert_eq!(bin1, bin2);
     }
 
     #[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -92,7 +92,7 @@ impl SyntaxSet {
                                          lines_include_newline: bool)
                                          -> Result<(), LoadingError> {
         self.is_linked = false;
-        for entry in WalkDir::new(folder) {
+        for entry in WalkDir::new(folder).sort_by(|a, b| a.cmp(b)) {
             let entry = try!(entry.map_err(LoadingError::WalkDir));
             if entry.path().extension().map_or(false, |e| e == "sublime-syntax") {
                 // println!("{}", entry.path().display());


### PR DESCRIPTION
Because the HashMaps used in SyntaxDefinition have non-deterministic
ordering, loading and dumping a syntax set resulted in different binary
data each time.

Having a deterministic result is nice for some things such as making a
change to a source .sublime-syntax file and seeing if it changes the
resulting dump or not. Or checking that regenerating the dump with some
modifications in the code does not alter the output.