### PR TITLE
Fix warnings on nightly

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -138,7 +138,7 @@ impl ParseState {
             for ctx in context_chain {
                 for (pat_context_ptr, pat_index) in context_iter(ctx) {
                     let mut pat_context = pat_context_ptr.borrow_mut();
-                    let mut match_pat = pat_context.match_at_mut(pat_index);
+                    let match_pat = pat_context.match_at_mut(pat_index);
                     // println!("{} - {:?} - {:?}", match_pat.regex_str, match_pat.has_captures, cur_level.captures.is_some());
                     let match_ptr = match_pat as *const MatchPattern;
 

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -268,8 +268,8 @@ impl SyntaxSet {
             context.meta_include_prototype = false;
             for pattern in &mut context.patterns {
                 match *pattern {
-                    /// Apparently inline blocks also don't include the prototype when within the prototype.
-                    /// This is really weird, but necessary to run the YAML syntax.
+                    // Apparently inline blocks also don't include the prototype when within the prototype.
+                    // This is really weird, but necessary to run the YAML syntax.
                     Pattern::Match(ref mut match_pat) => {
                         let maybe_context_refs = match match_pat.operation {
                             MatchOperation::Push(ref context_refs) |


### PR DESCRIPTION
"doc comment not used by rustdoc" and "variable does not need to be
mutable".