### PR TITLE
Use `?` instead of `try!` for error handling

### DIFF
--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -138,7 +138,7 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool) -> Result<Synt
     // parse the syntax test header in the first line of the file
     let header_line = line.clone();
     let search_result = SYNTAX_TEST_HEADER_PATTERN.captures(&header_line);
-    let captures = try!(search_result.ok_or(SyntaxTestHeaderError::MalformedHeader));
+    let captures = search_result.ok_or(SyntaxTestHeaderError::MalformedHeader)?;
 
     let testtoken_start = captures.name("testtoken_start").unwrap().as_str();
     let testtoken_end = captures.name("testtoken_end").map_or(None, |c|Some(c.as_str()));
@@ -146,7 +146,7 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool) -> Result<Synt
 
     // find the relevant syntax definition to parse the file with - case is important!
     println!("The test file references syntax definition file: {}", syntax_file);
-    let syntax = try!(ss.find_syntax_by_path(syntax_file).ok_or(SyntaxTestHeaderError::SyntaxDefinitionNotFound));
+    let syntax = ss.find_syntax_by_path(syntax_file).ok_or(SyntaxTestHeaderError::SyntaxDefinitionNotFound)?;
 
     // iterate over the lines of the file, testing them
     let mut state = ParseState::new(syntax);

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -64,7 +64,7 @@ pub fn dump_binary<T: Serialize>(o: &T) -> Vec<u8> {
 /// compressed with the `flate2` crate.
 #[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
 pub fn dump_to_file<T: Serialize, P: AsRef<Path>>(o: &T, path: P) -> Result<()> {
-    let out = BufWriter::new(try!(File::create(path).map_err(ErrorKind::IoError)));
+    let out = BufWriter::new(File::create(path).map_err(ErrorKind::IoError)?);
     dump_to_writer(o, out)
 }
 
@@ -76,7 +76,7 @@ pub fn from_reader<T: DeserializeOwned, R: Read>(input: R) -> Result<T> {
 
 #[cfg(feature = "dump-load-rs")]
 pub fn from_reader<T: DeserializeOwned, R: Read>(input: R) -> Result<T> {
-    let mut decoder: Decoder<R> = try!(Decoder::new(input));
+    let mut decoder: Decoder<R> = Decoder::new(input)?;
     deserialize_from(&mut decoder, Infinite)
 }
 
@@ -90,7 +90,7 @@ pub fn from_binary<T: DeserializeOwned>(v: &[u8]) -> T {
 /// Returns a fully loaded syntax set from a binary dump file.
 #[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
 pub fn from_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
-    let f = try!(File::open(path).map_err(ErrorKind::IoError));
+    let f = File::open(path).map_err(ErrorKind::IoError)?;
     let reader = BufReader::new(f);
     from_reader(reader)
 }

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -105,8 +105,8 @@ impl<'a> HighlightFile<'a> {
                                theme: &'a Theme)
                                -> io::Result<HighlightFile<'a>> {
         let path: &Path = path_obj.as_ref();
-        let f = try!(File::open(path));
-        let syntax = try!(ss.find_syntax_for_file(path))
+        let f = File::open(path)?;
+        let syntax = ss.find_syntax_for_file(path)?
             .unwrap_or_else(|| ss.find_syntax_plain_text());
 
         Ok(HighlightFile {

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -29,7 +29,7 @@ impl<'a> fmt::Display for Escape<'a> {
         for (i, ch) in s.bytes().enumerate() {
             match ch as char {
                 '<' | '>' | '&' | '\'' | '"' => {
-                    try!(fmt.write_str(&pile_o_bits[last..i]));
+                    fmt.write_str(&pile_o_bits[last..i])?;
                     let s = match ch as char {
                         '>' => "&gt;",
                         '<' => "&lt;",
@@ -38,7 +38,7 @@ impl<'a> fmt::Display for Escape<'a> {
                         '"' => "&quot;",
                         _ => unreachable!(),
                     };
-                    try!(fmt.write_str(s));
+                    fmt.write_str(s)?;
                     last = i + 1;
                 }
                 _ => {}
@@ -46,7 +46,7 @@ impl<'a> fmt::Display for Escape<'a> {
         }
 
         if last < s.len() {
-            try!(fmt.write_str(&pile_o_bits[last..]));
+            fmt.write_str(&pile_o_bits[last..])?;
         }
         Ok(())
     }

--- a/src/highlighting/selector.rs
+++ b/src/highlighting/selector.rs
@@ -57,11 +57,11 @@ impl FromStr for ScopeSelector {
             if i == 0 {
                 path_str = selector;
             } else {
-                excludes.push(try!(ScopeStack::from_str(selector)));
+                excludes.push(ScopeStack::from_str(selector)?);
             }
         }
         Ok(ScopeSelector {
-            path: try!(ScopeStack::from_str(path_str)),
+            path: ScopeStack::from_str(path_str)?,
             excludes: excludes,
         })
     }
@@ -95,7 +95,7 @@ impl FromStr for ScopeSelectors {
     fn from_str(s: &str) -> Result<ScopeSelectors, ParseScopeError> {
         let mut selectors = Vec::new();
         for selector in s.split(&[',', '|'][..]) {
-            selectors.push(try!(ScopeSelector::from_str(selector)))
+            selectors.push(ScopeSelector::from_str(selector)?)
         }
         Ok(ScopeSelectors { selectors: selectors })
     }

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -192,7 +192,7 @@ impl ParseSettings for UnderlineOption {
 
     fn parse_settings(settings: Settings) -> Result<UnderlineOption, Self::Error> {
         match settings {
-            Settings::String(value) => Ok(try!(UnderlineOption::from_str(&value))),
+            Settings::String(value) => UnderlineOption::from_str(&value),
             _ => Err(IncorrectUnderlineOption),
         }
     }
@@ -222,7 +222,7 @@ impl ParseSettings for FontStyle {
 
     fn parse_settings(settings: Settings) -> Result<FontStyle, Self::Error> {
         match settings {
-            Settings::String(value) => Ok(try!(FontStyle::from_str(&value))),
+            Settings::String(value) => FontStyle::from_str(&value),
             c => Err(IncorrectFontStyle(c.to_string())),
         }
     }
@@ -238,7 +238,7 @@ impl FromStr for Color {
         }
         let mut d = Vec::new();
         for char in chars {
-            d.push(try!(char.to_digit(16).ok_or(IncorrectColor)) as u8);
+            d.push(char.to_digit(16).ok_or(IncorrectColor)? as u8);
         }
         Ok(match d.len() {
             3 => {
@@ -275,7 +275,7 @@ impl ParseSettings for Color {
 
     fn parse_settings(settings: Settings) -> Result<Color, Self::Error> {
         match settings {
-            Settings::String(value) => Ok(try!(Color::from_str(&value))),
+            Settings::String(value) => Color::from_str(&value),
             _ => Err(IncorrectColor),
         }
     }
@@ -290,17 +290,17 @@ impl ParseSettings for StyleModifier {
             _ => return Err(ColorShemeScopeIsNotObject),
         };
         let font_style = match obj.remove("fontStyle") {
-            Some(Settings::String(value)) => Some(try!(FontStyle::from_str(&value))),
+            Some(Settings::String(value)) => Some(FontStyle::from_str(&value)?),
             None => None,
             Some(c) => return Err(IncorrectFontStyle(c.to_string())),
         };
         let foreground = match obj.remove("foreground") {
-            Some(Settings::String(value)) => Some(try!(Color::from_str(&value))),
+            Some(Settings::String(value)) => Some(Color::from_str(&value)?),
             None => None,
             _ => return Err(IncorrectColor),
         };
         let background = match obj.remove("background") {
-            Some(Settings::String(value)) => Some(try!(Color::from_str(&value))),
+            Some(Settings::String(value)) => Some(Color::from_str(&value)?),
             None => None,
             _ => return Err(IncorrectColor),
         };
@@ -322,11 +322,11 @@ impl ParseSettings for ThemeItem {
             _ => return Err(ColorShemeScopeIsNotObject),
         };
         let scope = match obj.remove("scope") {
-            Some(Settings::String(value)) => try!(ScopeSelectors::from_str(&value)),
+            Some(Settings::String(value)) => ScopeSelectors::from_str(&value)?,
             _ => return Err(ScopeSelectorIsNotString(format!("{:?}", obj))),
         };
         let style = match obj.remove("settings") {
-            Some(settings) => try!(StyleModifier::parse_settings(settings)),
+            Some(settings) => StyleModifier::parse_settings(settings)?,
             None => return Err(IncorrectSettings),
         };
         Ok(ThemeItem {
@@ -438,7 +438,7 @@ impl ParseSettings for Theme {
         let settings = match iter.next() {
             Some(Settings::Object(mut obj)) => {
                 match obj.remove("settings") {
-                    Some(settings) => try!(ThemeSettings::parse_settings(settings)),
+                    Some(settings) => ThemeSettings::parse_settings(settings)?,
                     None => return Err(UndefinedSettings),
                 }
             }

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -18,7 +18,7 @@ impl ThemeSet {
     pub fn discover_theme_paths<P: AsRef<Path>>(folder: P) -> Result<Vec<PathBuf>, LoadingError> {
         let mut themes = Vec::new();
         for entry in WalkDir::new(folder) {
-            let entry = try!(entry.map_err(LoadingError::WalkDir));
+            let entry = entry.map_err(LoadingError::WalkDir)?;
             if entry.path().extension().map_or(false, |e| e == "tmTheme") {
                 themes.push(entry.path().to_owned());
             }
@@ -28,24 +28,24 @@ impl ThemeSet {
 
     /// Loads a theme given a path to a .tmTheme file
     pub fn get_theme<P: AsRef<Path>>(path: P) -> Result<Theme, LoadingError> {
-        let file = try!(File::open(path));
+        let file = File::open(path)?;
         let mut file = BufReader::new(file);
         Self::load_from_reader(&mut file)
     }
 
     /// Loads a theme given a readable stream
     pub fn load_from_reader<R: BufRead + Seek>(r: &mut R) -> Result<Theme, LoadingError> {
-        Ok(try!(Theme::parse_settings(try!(read_plist(r)))))
+        Ok(Theme::parse_settings(read_plist(r)?)?)
     }
 
     /// Loads all the themes in a folder
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<ThemeSet, LoadingError> {
-        let paths = try!(Self::discover_theme_paths(folder));
+        let paths = Self::discover_theme_paths(folder)?;
         let mut map = BTreeMap::new();
         for p in &paths {
-            let theme = try!(Self::get_theme(p));
+            let theme = Self::get_theme(p)?;
             let basename =
-                try!(p.file_stem().and_then(|x| x.to_str()).ok_or(LoadingError::BadPath));
+                p.file_stem().and_then(|x| x.to_str()).ok_or(LoadingError::BadPath)?;
             map.insert(basename.to_owned(), theme);
         }
         Ok(ThemeSet { themes: map })

--- a/src/html.rs
+++ b/src/html.rs
@@ -71,7 +71,7 @@ pub fn highlighted_snippet_for_file<P: AsRef<Path>>(path: P,
                                                     -> io::Result<String> {
     // TODO reduce code duplication with highlighted_snippet_for_string
     let mut output = String::new();
-    let mut highlighter = try!(HighlightFile::new(path, ss, theme));
+    let mut highlighter = HighlightFile::new(path, ss, theme)?;
     let c = theme.settings.background.unwrap_or(highlighting::WHITE);
     write!(output,
            "<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
@@ -80,7 +80,7 @@ pub fn highlighted_snippet_for_file<P: AsRef<Path>>(path: P,
            c.b)
         .unwrap();
     for maybe_line in highlighter.reader.lines() {
-        let line = try!(maybe_line);
+        let line = maybe_line?;
         let regions = highlighter.highlight_lines.highlight(&line);
         let html = styles_to_coloured_html(&regions[..], IncludeBackground::IfDifferent(c));
         output.push_str(&html);

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -500,7 +500,7 @@ impl FromStr for ScopeStack {
     fn from_str(s: &str) -> Result<ScopeStack, ParseScopeError> {
         let mut scopes = Vec::new();
         for name in s.split_whitespace() {
-            scopes.push(try!(Scope::from_str(name)))
+            scopes.push(Scope::from_str(name)?)
         }
         Ok(ScopeStack::from_vec(scopes))
     }
@@ -509,7 +509,7 @@ impl FromStr for ScopeStack {
 impl fmt::Display for ScopeStack {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for s in &self.scopes {
-            try!(write!(f, "{} ", s));
+            write!(f, "{} ", s)?;
         }
         Ok(())
     }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -39,11 +39,11 @@ pub struct SyntaxSet {
 fn load_syntax_file(p: &Path,
                     lines_include_newline: bool)
                     -> Result<SyntaxDefinition, LoadingError> {
-    let mut f = try!(File::open(p));
+    let mut f = File::open(p)?;
     let mut s = String::new();
-    try!(f.read_to_string(&mut s));
+    f.read_to_string(&mut s)?;
 
-    Ok(try!(SyntaxDefinition::load_from_str(&s, lines_include_newline)))
+    Ok(SyntaxDefinition::load_from_str(&s, lines_include_newline)?)
 }
 
 impl Default for SyntaxSet {
@@ -69,7 +69,7 @@ impl SyntaxSet {
     #[cfg(feature = "yaml-load")]
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<SyntaxSet, LoadingError> {
         let mut ps = Self::new();
-        try!(ps.load_syntaxes(folder, false));
+        ps.load_syntaxes(folder, false)?;
         ps.link_syntaxes();
         Ok(ps)
     }
@@ -93,10 +93,10 @@ impl SyntaxSet {
                                          -> Result<(), LoadingError> {
         self.is_linked = false;
         for entry in WalkDir::new(folder).sort_by(|a, b| a.cmp(b)) {
-            let entry = try!(entry.map_err(LoadingError::WalkDir));
+            let entry = entry.map_err(LoadingError::WalkDir)?;
             if entry.path().extension().map_or(false, |e| e == "sublime-syntax") {
                 // println!("{}", entry.path().display());
-                let syntax = try!(load_syntax_file(entry.path(), lines_include_newline));
+                let syntax = load_syntax_file(entry.path(), lines_include_newline)?;
                 if let Some(path_str) = entry.path().to_str() {
                     self.path_syntaxes.push((path_str.to_string(), self.syntaxes.len()));
                 }
@@ -207,9 +207,9 @@ impl SyntaxSet {
         let ext_syntax = self.find_syntax_by_extension(extension);
         let line_syntax = if ext_syntax.is_none() {
             let mut line = String::new();
-            let f = try!(File::open(path));
+            let f = File::open(path)?;
             let mut line_reader = BufReader::new(&f);
-            try!(line_reader.read_line(&mut line));
+            line_reader.read_line(&mut line)?;
             self.find_syntax_by_first_line(&line)
         } else {
             None


### PR DESCRIPTION
`?` has been stable since [Rust 1.13](https://blog.rust-lang.org/2016/11/10/Rust-1.13.html).