### PR TITLE
Upgrade bitflags to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ onig = { version = "^1.2", optional = true }
 walkdir = "^1.0"
 regex-syntax = { version = "^0.4", optional = true }
 lazy_static = "^0.2"
-bitflags = "^0.8"
+bitflags = "1.0"
 plist = "0.2"
 bincode = { version = "0.8", optional = true }
 flate2 = { version = "^0.2", optional = true }

--- a/examples/synhtml.rs
+++ b/examples/synhtml.rs
@@ -2,7 +2,7 @@
 //! Basically just wraps a body around `highlighted_snippet_for_file`
 extern crate syntect;
 use syntect::parsing::SyntaxSet;
-use syntect::highlighting::{ThemeSet, self};
+use syntect::highlighting::{Color, ThemeSet};
 use syntect::html::highlighted_snippet_for_file;
 
 fn main() {
@@ -22,7 +22,7 @@ fn main() {
         }";
     println!("<head><title>{}</title><style>{}</style></head>", &args[1], style);
     let theme = &ts.themes["base16-ocean.dark"];
-    let c = theme.settings.background.unwrap_or(highlighting::WHITE);
+    let c = theme.settings.background.unwrap_or(Color::WHITE);
     println!("<body style=\"background-color:#{:02x}{:02x}{:02x};\">\n", c.r, c.g, c.b);
     let html = highlighted_snippet_for_file(&args[1], &ss, theme).unwrap();
     println!("{}", html);

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -8,7 +8,7 @@ use std::iter::Iterator;
 use parsing::{Scope, ScopeStack, BasicScopeStackOp, ScopeStackOp, MatchPower, ATOM_LEN_BITS};
 use super::selector::ScopeSelector;
 use super::theme::Theme;
-use super::style::{Style, StyleModifier, FontStyle, BLACK, WHITE};
+use super::style::{Color, FontStyle, Style, StyleModifier};
 
 /// Basically a wrapper around a `Theme` preparing it to be used for highlighting.
 /// This is part of the API to preserve the possibility of caching
@@ -173,8 +173,8 @@ impl<'a> Highlighter<'a> {
     /// Basically what plain text gets highlighted as.
     pub fn get_default(&self) -> Style {
         Style {
-            foreground: self.theme.settings.foreground.unwrap_or(BLACK),
-            background: self.theme.settings.background.unwrap_or(WHITE),
+            foreground: self.theme.settings.foreground.unwrap_or(Color::BLACK),
+            background: self.theme.settings.background.unwrap_or(Color::WHITE),
             font_style: FontStyle::empty(),
         }
     }

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -23,23 +23,6 @@ pub struct StyleModifier {
     pub font_style: Option<FontStyle>,
 }
 
-
-/// Pre-defined convenience colour
-pub const BLACK: Color = Color {
-    r: 0x00,
-    g: 0x00,
-    b: 0x00,
-    a: 0xFF,
-};
-
-/// Pre-defined convenience colour
-pub const WHITE: Color = Color {
-    r: 0xFF,
-    g: 0xFF,
-    b: 0xFF,
-    a: 0xFF,
-};
-
 /// RGBA colour, these numbers come directly from the theme so
 /// for now you might have to do your own colour space conversion if you are outputting
 /// a different colour space from the theme. This can be a problem because some Sublime
@@ -57,16 +40,35 @@ pub struct Color {
 }
 
 bitflags! {
-/// This can be a combination of `FONT_STYLE_BOLD`, `FONT_STYLE_UNDERLINE` and `FONT_STYLE_ITALIC`
+    /// This can be a combination of `BOLD`, `UNDERLINE` and `ITALIC`
     #[derive(Serialize, Deserialize)]
-    pub flags FontStyle: u8 {
-/// A bitfield constant FontStyle
-        const FONT_STYLE_BOLD = 1,
-/// A bitfield constant FontStyle
-        const FONT_STYLE_UNDERLINE = 2,
-/// A bitfield constant FontStyle
-        const FONT_STYLE_ITALIC = 4,
+    pub struct FontStyle: u8 {
+        /// Bold font style
+        const BOLD = 1;
+        /// Underline font style
+        const UNDERLINE = 2;
+        /// Italic font style
+        const ITALIC = 4;
     }
+}
+
+
+impl Color {
+    /// Black color (`#000000`)
+    pub const BLACK: Color = Color {
+        r: 0x00,
+        g: 0x00,
+        b: 0x00,
+        a: 0xFF,
+    };
+
+    /// White color (`#FFFFFF`)
+    pub const WHITE: Color = Color {
+        r: 0xFF,
+        g: 0xFF,
+        b: 0xFF,
+        a: 0xFF,
+    };
 }
 
 impl Style {

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -23,6 +23,12 @@ pub struct StyleModifier {
     pub font_style: Option<FontStyle>,
 }
 
+#[deprecated(since = "1.8.0", note = "use Color::BLACK instead")]
+pub const BLACK: Color = Color::BLACK;
+
+#[deprecated(since = "1.8.0", note = "use Color::WHITE instead")]
+pub const WHITE: Color = Color::WHITE;
+
 /// RGBA colour, these numbers come directly from the theme so
 /// for now you might have to do your own colour space conversion if you are outputting
 /// a different colour space from the theme. This can be a problem because some Sublime
@@ -38,6 +44,13 @@ pub struct Color {
     /// Alpha component
     pub a: u8,
 }
+
+#[deprecated(since = "1.8.0", note = "use FontStyle::BOLD instead")]
+pub const FONT_STYLE_BOLD: FontStyle = FontStyle::BOLD;
+#[deprecated(since = "1.8.0", note = "use FontStyle::UNDERLINE instead")]
+pub const FONT_STYLE_UNDERLINE: FontStyle = FontStyle::UNDERLINE;
+#[deprecated(since = "1.8.0", note = "use FontStyle::ITALIC instead")]
+pub const FONT_STYLE_ITALIC: FontStyle = FontStyle::ITALIC;
 
 bitflags! {
     /// This can be a combination of `BOLD`, `UNDERLINE` and `ITALIC`

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -205,9 +205,9 @@ impl FromStr for FontStyle {
         let mut font_style = FontStyle::empty();
         for i in s.split_whitespace() {
             font_style.insert(match i {
-                "bold" => FONT_STYLE_BOLD,
-                "underline" => FONT_STYLE_UNDERLINE,
-                "italic" => FONT_STYLE_ITALIC,
+                "bold" => FontStyle::BOLD,
+                "underline" => FontStyle::UNDERLINE,
+                "italic" => FontStyle::ITALIC,
                 "normal" |
                 "regular" => FontStyle::empty(),
                 s => return Err(IncorrectFontStyle(s.to_owned())),

--- a/src/html.rs
+++ b/src/html.rs
@@ -2,7 +2,7 @@
 use std::fmt::Write;
 use parsing::{ScopeStackOp, BasicScopeStackOp, Scope, ScopeStack, SyntaxDefinition, SyntaxSet, SCOPE_REPO};
 use easy::{HighlightLines, HighlightFile};
-use highlighting::{self, Style, Theme, Color};
+use highlighting::{Color, FontStyle, Style, Theme};
 use escape::Escape;
 use std::io::{self, BufRead};
 use std::path::Path;
@@ -41,7 +41,7 @@ fn scope_to_classes(s: &mut String, scope: Scope, style: ClassStyle) {
 pub fn highlighted_snippet_for_string(s: &str, syntax: &SyntaxDefinition, theme: &Theme) -> String {
     let mut output = String::new();
     let mut highlighter = HighlightLines::new(syntax, theme);
-    let c = theme.settings.background.unwrap_or(highlighting::WHITE);
+    let c = theme.settings.background.unwrap_or(Color::WHITE);
     write!(output,
            "<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
            c.r,
@@ -72,7 +72,7 @@ pub fn highlighted_snippet_for_file<P: AsRef<Path>>(path: P,
     // TODO reduce code duplication with highlighted_snippet_for_string
     let mut output = String::new();
     let mut highlighter = HighlightFile::new(path, ss, theme)?;
-    let c = theme.settings.background.unwrap_or(highlighting::WHITE);
+    let c = theme.settings.background.unwrap_or(Color::WHITE);
     write!(output,
            "<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
            c.r,
@@ -183,13 +183,13 @@ pub fn styles_to_coloured_html(v: &[(Style, &str)], bg: IncludeBackground) -> St
             write_css_color(&mut s, style.background);
             write!(s, ";").unwrap();
         }
-        if style.font_style.contains(highlighting::FONT_STYLE_UNDERLINE) {
+        if style.font_style.contains(FontStyle::UNDERLINE) {
             write!(s, "text-decoration:underline;").unwrap();
         }
-        if style.font_style.contains(highlighting::FONT_STYLE_BOLD) {
+        if style.font_style.contains(FontStyle::BOLD) {
             write!(s, "font-weight:bold;").unwrap();
         }
-        if style.font_style.contains(highlighting::FONT_STYLE_ITALIC) {
+        if style.font_style.contains(FontStyle::ITALIC) {
             write!(s, "font-style:italic;").unwrap();
         }
         write!(s, "color:").unwrap();
@@ -209,7 +209,7 @@ pub fn styles_to_coloured_html(v: &[(Style, &str)], bg: IncludeBackground) -> St
 /// You're responsible for creating the string `</pre>` to close this, I'm not gonna provide a
 /// helper for that :-)
 pub fn start_coloured_html_snippet(t: &Theme) -> String {
-    let c = t.settings.background.unwrap_or(highlighting::WHITE);
+    let c = t.settings.background.unwrap_or(Color::WHITE);
     format!("<pre style=\"background-color:#{:02x}{:02x}{:02x}\">\n",
             c.r,
             c.g,


### PR DESCRIPTION
bitflags 1.0 requires Rust 1.20 which stabilized associated constants.
This change also makes the black and white Colors consts.

How do you feel about requiring Rust 1.20? If you want to support stable and stable-1, we can wait with this.