### PR TITLE
Bump onig to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.3.5", optional = true }
-onig = { version = "^1.2", optional = true }
+onig = { version = "^2.0", optional = true }
 walkdir = "^1.0"
 regex-syntax = { version = "^0.4", optional = true }
 lazy_static = "^0.2"
@@ -49,7 +49,6 @@ dump-create = ["flate2", "bincode"]
 # Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
 dump-create-rs = ["libflate", "bincode"]
 
-static-onig = ["onig/static-libonig"]
 parsing = ["onig", "regex-syntax", "fnv"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
 # For `assets` to do anything, it requires one of `dump-load-rs` or `dump-load` to be set.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.3.5", optional = true }
-onig = { version = "^2.0", optional = true }
-walkdir = "^1.0"
-regex-syntax = { version = "^0.4", optional = true }
-lazy_static = "^0.2"
+onig = { version = "2.0", optional = true }
+walkdir = "1.0"
+regex-syntax = { version = "0.4", optional = true }
+lazy_static = "0.2"
 bitflags = "1.0"
 plist = "0.2"
 bincode = { version = "0.8", optional = true }
-flate2 = { version = "^0.2", optional = true }
+flate2 = { version = "0.2", optional = true }
 libflate = { version = "0.1.8", optional = true }
-fnv = { version = "^1.0", optional = true }
+fnv = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,6 +1,6 @@
 use super::syntax_definition::*;
 use super::scope::*;
-use onig::{self, Region};
+use onig::{SearchOptions, Region};
 use std::usize;
 use std::collections::{HashMap, HashSet};
 use std::i32;
@@ -222,7 +222,7 @@ impl ParseState {
                     let matched = regex.search_with_options(line,
                                                             *start,
                                                             line.len(),
-                                                            onig::SEARCH_OPTION_NONE,
+                                                            SearchOptions::SEARCH_OPTION_NONE,
                                                             Some(regions));
                     if let Some(match_start) = matched {
                         let match_end = regions.pos(0).unwrap().1;

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -5,7 +5,7 @@
 //! into this data structure?
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
-use onig::{self, Regex, Region, Syntax};
+use onig::{Regex, RegexOptions, Region, Syntax};
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 use super::scope::*;
@@ -225,7 +225,7 @@ impl MatchPattern {
     pub fn compile_with_refs(&self, region: &Region, s: &str) -> Regex {
         // TODO don't panic on invalid regex
         Regex::with_options(&self.regex_with_substitutes(region, s),
-                            onig::REGEX_OPTION_CAPTURE_GROUP,
+                            RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
                             Syntax::default())
             .unwrap()
     }
@@ -233,7 +233,7 @@ impl MatchPattern {
     fn compile_regex(&mut self) {
         // TODO don't panic on invalid regex
         let compiled = Regex::with_options(&self.regex_str,
-                                           onig::REGEX_OPTION_CAPTURE_GROUP,
+                                           RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
                                            Syntax::default())
             .unwrap();
         self.regex = Some(compiled);
@@ -287,7 +287,7 @@ mod tests {
     use super::*;
     #[test]
     fn can_compile_refs() {
-        use onig::{self, Regex, Region};
+        use onig::{SearchOptions, Regex, Region};
         let pat = MatchPattern {
             has_captures: true,
             regex_str: String::from(r"lol \\ \2 \1 '\9' \wz"),
@@ -300,7 +300,7 @@ mod tests {
         let r = Regex::new(r"(\\\[\]\(\))(b)(c)(d)(e)").unwrap();
         let mut region = Region::new();
         let s = r"\[]()bcde";
-        assert!(r.match_with_options(s, 0, onig::SEARCH_OPTION_NONE, Some(&mut region)).is_some());
+        assert!(r.match_with_options(s, 0, SearchOptions::SEARCH_OPTION_NONE, Some(&mut region)).is_some());
 
         let regex_res = pat.regex_with_substitutes(&region, s);
         assert_eq!(regex_res, r"lol \\ b \\\[\]\(\) '' \wz");


### PR DESCRIPTION
The bump is needed so that I can get my documentation failure fix https://github.com/rust-onig/rust-onig/pull/61 . The minimum required Rust version is still 1.20 so no major bump is needed. I'd really love a minor or patch version bump though!