### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.3.5", optional = true }
-onig = { version = "2.0", optional = true }
-walkdir = "1.0"
+onig = { version = "3.0", optional = true }
+walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "0.2"
 bitflags = "1.0"
 plist = "0.2"
-bincode = { version = "0.8", optional = true }
+bincode = { version = "0.9", optional = true }
 flate2 = { version = "0.2", optional = true }
 libflate = { version = "0.1.8", optional = true }
 fnv = { version = "1.0", optional = true }
@@ -30,7 +30,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
-rayon = "0.8.0"
+rayon = "0.9.0"
 regex = "0.2.1"
 getopts = "0.2"
 

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -15,7 +15,7 @@ use syntect::easy::{ScopeRegionIterator};
 use std::path::Path;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
-use walkdir::{DirEntry, WalkDir, WalkDirIterator};
+use walkdir::{DirEntry, WalkDir};
 use std::str::FromStr;
 
 #[derive(Debug)]

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 use std::cmp::{min, max};
-use walkdir::{DirEntry, WalkDir, WalkDirIterator};
+use walkdir::{DirEntry, WalkDir};
 use std::str::FromStr;
 use regex::Regex;
 

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -92,7 +92,7 @@ impl SyntaxSet {
                                          lines_include_newline: bool)
                                          -> Result<(), LoadingError> {
         self.is_linked = false;
-        for entry in WalkDir::new(folder).sort_by(|a, b| a.cmp(b)) {
+        for entry in WalkDir::new(folder).sort_by(|a, b| a.file_name().cmp(b.file_name())) {
             let entry = entry.map_err(LoadingError::WalkDir)?;
             if entry.path().extension().map_or(false, |e| e == "sublime-syntax") {
                 // println!("{}", entry.path().display());


### PR DESCRIPTION
Most importantly, it updates the onig dependency to 3.0 [so that it links onig statically per default](https://github.com/rust-onig/rust-onig/issues/65).

I've tested using `cargo +1.20.0 test --no-default-features --features "dump-create-rs dump-load-rs parsing assets html yaml-load"` and `cargo +1.20.0 test`.

cc @epage