### PR TITLE
Bump to v2.0.0 with cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["syntax", "highlighting", "highlighter", "colouring", "parsing"]
 categories = ["parser-implementations", "parsing", "text-processing"]
 readme = "Readme.md"
 license = "MIT"
-version = "1.8.2" # remember to update html_root_url
+version = "2.0.0" # remember to update html_root_url
 authors = ["Tristan Hume <tristan@thume.ca>"]
 exclude = [
     "testdata/*",

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -23,12 +23,6 @@ pub struct StyleModifier {
     pub font_style: Option<FontStyle>,
 }
 
-#[deprecated(since = "1.8.0", note = "use Color::BLACK instead")]
-pub const BLACK: Color = Color::BLACK;
-
-#[deprecated(since = "1.8.0", note = "use Color::WHITE instead")]
-pub const WHITE: Color = Color::WHITE;
-
 /// RGBA colour, these numbers come directly from the theme so
 /// for now you might have to do your own colour space conversion if you are outputting
 /// a different colour space from the theme. This can be a problem because some Sublime
@@ -44,13 +38,6 @@ pub struct Color {
     /// Alpha component
     pub a: u8,
 }
-
-#[deprecated(since = "1.8.0", note = "use FontStyle::BOLD instead")]
-pub const FONT_STYLE_BOLD: FontStyle = FontStyle::BOLD;
-#[deprecated(since = "1.8.0", note = "use FontStyle::UNDERLINE instead")]
-pub const FONT_STYLE_UNDERLINE: FontStyle = FontStyle::UNDERLINE;
-#[deprecated(since = "1.8.0", note = "use FontStyle::ITALIC instead")]
-pub const FONT_STYLE_ITALIC: FontStyle = FontStyle::ITALIC;
 
 bitflags! {
     /// This can be a combination of `BOLD`, `UNDERLINE` and `ITALIC`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! Some docs have example code but a good place to look is the `syncat` example as well as the source code
 //! for the `easy` module in `easy.rs` as that shows how to plug the various parts together for common use cases.
 
-#![doc(html_root_url = "https://docs.rs/syntect/1.8.2")]
+#![doc(html_root_url = "https://docs.rs/syntect/2.0.0")]
 
 #[cfg(feature = "yaml-load")]
 extern crate yaml_rust;

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -13,7 +13,11 @@ use std::fs::File;
 use std::ops::DerefMut;
 use std::mem;
 use std::rc::Rc;
+
+// TODO this is unused in nightly but used in stable, remove eventually
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
+
 use std::sync::Mutex;
 use onig::Regex;
 

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -65,6 +65,8 @@ __main:
 impl SyntaxDefinition {
     /// In case you want to create your own SyntaxDefinition's in memory from strings.
     /// Generally you should use a `SyntaxSet`
+    ///
+    /// `fallback_name` is an optional name to use when the YAML doesn't provide a `name` key.
     pub fn load_from_str(s: &str,
                          lines_include_newline: bool,
                          fallback_name: Option<&str>)


### PR DESCRIPTION
Breaking changes:
- The `static-onig` feature was removed, static linking is now the default
- Font styles and color constants now use associated consts because of bitflags upgrade
- SyntaxDefinition::load_from_str now has an extra parameter

Other notable changes:
- Support for new `embed` syntax #124
- Updates to many dependencies
- Updated dumps
- More compact HTML output

As well as bumping the version this commit does some cleaning up for the breaking changes.

Thanks to @Keats @keith-hall and @est31 for your significant contributions to this release!