### PR TITLE
Replace libflate with rust_backend feature of flate2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ lazy_static = "1.0"
 bitflags = "1.0"
 plist = "0.2"
 bincode = { version = "1.0", optional = true }
-flate2 = { version = "1.0", optional = true }
-libflate = { version = "0.1.8", optional = true }
+flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
@@ -42,13 +41,13 @@ pretty_assertions = "0.5.0"
 # your binary will be smaller if you choose the same one for each.
 
 # Pure Rust dump loading, slower than regular `dump-load`
-dump-load-rs = ["libflate", "bincode"]
+dump-load-rs = ["flate2/rust_backend", "bincode"]
 # Dump loading using flate2, which depends on the miniz C library.
-dump-load = ["flate2", "bincode"]
+dump-load = ["flate2/default", "bincode"]
 # Dump creation using flate2, which depends on the miniz C library.
-dump-create = ["flate2", "bincode"]
+dump-create = ["flate2/default", "bincode"]
 # Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
-dump-create-rs = ["libflate", "bincode"]
+dump-create-rs = ["flate2/rust_backend", "bincode"]
 
 parsing = ["onig", "regex-syntax", "fnv"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -24,31 +24,19 @@ use highlighting::ThemeSet;
 use std::path::Path;
 #[cfg(feature = "dump-create")]
 use flate2::write::ZlibEncoder;
-#[cfg(feature = "dump-load")]
+#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
 use flate2::read::ZlibDecoder;
-#[cfg(feature = "dump-create")]
+#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
 use flate2::Compression;
 #[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
 use serde::Serialize;
 #[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
 use serde::de::DeserializeOwned;
-#[cfg(feature = "dump-load-rs")]
-use libflate::zlib::Decoder;
-#[cfg(feature = "dump-create-rs")]
-use libflate::zlib::Encoder;
 
-#[cfg(feature = "dump-create")]
+#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
 pub fn dump_to_writer<T: Serialize, W: Write>(to_dump: &T, output: W) -> Result<()> {
     let mut encoder = ZlibEncoder::new(output, Compression::best());
     serialize_into(&mut encoder, to_dump)
-}
-
-#[cfg(feature = "dump-create-rs")]
-pub fn dump_to_writer<T: Serialize, W: Write>(to_dump: &T, output: W) -> Result<()> {
-    let mut encoder = Encoder::new(output)?;
-    serialize_into(&mut encoder, to_dump)?;
-    encoder.finish().into_result()?;
-    Ok(())
 }
 
 /// Dumps an object to a binary array in the same format as `dump_to_file`
@@ -68,15 +56,9 @@ pub fn dump_to_file<T: Serialize, P: AsRef<Path>>(o: &T, path: P) -> Result<()> 
     dump_to_writer(o, out)
 }
 
-#[cfg(feature = "dump-load")]
+#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
 pub fn from_reader<T: DeserializeOwned, R: Read>(input: R) -> Result<T> {
     let mut decoder = ZlibDecoder::new(input);
-    deserialize_from(&mut decoder)
-}
-
-#[cfg(feature = "dump-load-rs")]
-pub fn from_reader<T: DeserializeOwned, R: Read>(input: R) -> Result<T> {
-    let mut decoder: Decoder<R> = Decoder::new(input)?;
     deserialize_from(&mut decoder)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,8 @@ extern crate plist;
 extern crate bincode;
 #[macro_use]
 extern crate bitflags;
-#[cfg(any(feature = "dump-load", feature = "dump-create"))]
+#[cfg(any(feature = "dump-load", feature = "dump-create", feature = "dump-load-rs", feature = "dump-create-rs"))]
 extern crate flate2;
-#[cfg(any(feature = "dump-load-rs", feature = "dump-create-rs"))]
-extern crate libflate;
 #[cfg(feature = "parsing")]
 extern crate fnv;
 extern crate serde;


### PR DESCRIPTION
flate2 already has an [pure Rust backend](https://github.com/alexcrichton/flate2-rs/pull/128).