### PR TITLE
Recover from catastrophic backtracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
-onig = { version = "3.0", optional = true }
+onig = { version = "3.2.1", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "1.0"


### PR DESCRIPTION
Oniguruma 6.8.0 [enabled USE_TRY_IN_MATCH_LIMIT by default](https://github.com/kkos/oniguruma/blob/v6.8.0/HISTORY#L14), with a limit
of 10_000_000. That means after that number of failed matches, it will
stop trying to match and return an error instead.

We can gracefully handle that error by using the onig crate's new
`search_with_param` method which returns a Result instead of panicking.

I tried this on the file from #64 and the parse time goes from 10
seconds to 200 ms.