### PR TITLE
Switch benchmarks to criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [dev-dependencies]
+criterion = "0.2"
 rayon = "1.0.0"
 regex = "0.2"
 getopts = "0.2"
@@ -59,3 +60,15 @@ default = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create"]
 
 # [profile.release]
 # debug = true
+
+[[bench]]
+name = "highlighting"
+harness = false
+
+[[bench]]
+name = "loading"
+harness = false
+
+[[bench]]
+name = "parsing"
+harness = false

--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -21,13 +21,23 @@ fn do_highlight(s: &str, syntax: &SyntaxDefinition, theme: &Theme) -> usize {
     count
 }
 
-fn highlight_file(b: &mut Bencher, path_s: &str) {
+fn highlight_file(b: &mut Bencher, file: &str) {
+    let path = match file {
+        "highlight_test.erb" => "testdata/highlight_test.erb",
+        "InspiredGitHub.tmTheme" => "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
+        "Ruby.sublime-syntax" => "testdata/Packages/Ruby/Ruby.sublime-syntax",
+        "jquery.js" => "testdata/jquery.js",
+        "parser.rs" => "testdata/parser.rs",
+        "scope.rs" => "src/parsing/scope.rs",
+        _ => panic!("Unknown test file {}", file),
+    };
+
     // don't load from dump so we don't count lazy regex compilation time
     let ps = SyntaxSet::load_defaults_nonewlines();
     let ts = ThemeSet::load_defaults();
 
-    let syntax = ps.find_syntax_for_file(path_s).unwrap().unwrap();
-    let mut f = File::open(path_s).unwrap();
+    let syntax = ps.find_syntax_for_file(path).unwrap().unwrap();
+    let mut f = File::open(path).unwrap();
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
@@ -52,17 +62,17 @@ fn highlighting_benchmark(c: &mut Criterion) {
         "highlight",
         |b, s| highlight_file(b, s),
         vec![
-            "testdata/highlight_test.erb",
-            "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
-            "testdata/Packages/Ruby/Ruby.sublime-syntax",
-            "testdata/jquery.js",
-            "testdata/parser.rs",
-            "src/parsing/scope.rs",
-        ]
+            "highlight_test.erb",
+            "InspiredGitHub.tmTheme",
+            "Ruby.sublime-syntax",
+            "jquery.js",
+            "parser.rs",
+            "scope.rs",
+        ],
     );
 }
 
-criterion_group!{
+criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
     targets = highlighting_benchmark

--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -1,8 +1,8 @@
-#![feature(test)]
-
-extern crate test;
+#[macro_use]
+extern crate criterion;
 extern crate syntect;
-use test::Bencher;
+
+use criterion::{Bencher, Criterion};
 
 use syntect::parsing::{SyntaxSet, SyntaxDefinition, ScopeStack};
 use syntect::highlighting::{ThemeSet, Theme};
@@ -11,12 +11,14 @@ use std::str::FromStr;
 use std::fs::File;
 use std::io::Read;
 
-fn do_highlight(s: &str, syntax: &SyntaxDefinition, theme: &Theme) {
+fn do_highlight(s: &str, syntax: &SyntaxDefinition, theme: &Theme) -> usize {
     let mut h = HighlightLines::new(syntax, theme);
+    let mut count = 0;
     for line in s.lines() {
         let regions = h.highlight(line);
-        test::black_box(&regions);
+        count += regions.len();
     }
+    count
 }
 
 fn highlight_file(b: &mut Bencher, path_s: &str) {
@@ -29,49 +31,40 @@ fn highlight_file(b: &mut Bencher, path_s: &str) {
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
-    do_highlight(&s, syntax, &ts.themes["base16-ocean.dark"]);
     b.iter(|| {
-        do_highlight(&s, syntax, &ts.themes["base16-ocean.dark"]);
+        do_highlight(&s, syntax, &ts.themes["base16-ocean.dark"])
     });
 }
 
-#[bench]
-fn bench_highlighting_nesting(b: &mut Bencher) {
-    highlight_file(b, "testdata/highlight_test.erb");
-}
 
-#[bench]
-fn bench_highlighting_xml(b: &mut Bencher) {
-    highlight_file(b, "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme");
-}
-
-#[bench]
-fn bench_highlighting_yaml(b: &mut Bencher) {
-    highlight_file(b, "testdata/Packages/Ruby/Ruby.sublime-syntax");
-}
-
-#[bench]
-fn bench_highlighting_jquery(b: &mut Bencher) {
-    highlight_file(b, "testdata/jquery.js");
-}
-
-#[bench]
-fn bench_highlighting_rustc(b: &mut Bencher) {
-    highlight_file(b, "testdata/parser.rs");
-}
-
-#[bench]
-fn bench_highlighting_scope(b: &mut Bencher) {
-    highlight_file(b, "src/parsing/scope.rs");
-}
-
-#[bench]
-fn bench_stack_matching(b: &mut Bencher) {
+fn stack_matching(b: &mut Bencher) {
     let s = "source.js meta.group.js meta.group.js meta.block.js meta.function-call.method.js meta.group.js meta.object-literal.js meta.block.js meta.function-call.method.js meta.group.js variable.other.readwrite.js";
     let stack = ScopeStack::from_str(s).unwrap();
     let selector = ScopeStack::from_str("source meta.function-call.method").unwrap();
     b.iter(|| {
-        let res = selector.does_match(stack.as_slice());
-        test::black_box(res);
+        selector.does_match(stack.as_slice())
     });
 }
+
+fn highlighting_benchmark(c: &mut Criterion) {
+    c.bench_function("stack_matching", stack_matching);
+    c.bench_function_over_inputs(
+        "highlight",
+        |b, s| highlight_file(b, s),
+        vec![
+            "testdata/highlight_test.erb",
+            "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
+            "testdata/Packages/Ruby/Ruby.sublime-syntax",
+            "testdata/jquery.js",
+            "testdata/parser.rs",
+            "src/parsing/scope.rs",
+        ]
+    );
+}
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = highlighting_benchmark
+}
+criterion_main!(benches);

--- a/benches/loading.rs
+++ b/benches/loading.rs
@@ -50,7 +50,7 @@ fn loading_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(100);
+    config = Criterion::default().sample_size(50);
     targets = loading_benchmark
 }
 criterion_main!(benches);

--- a/benches/loading.rs
+++ b/benches/loading.rs
@@ -1,45 +1,37 @@
-#![feature(test)]
-
-extern crate test;
+#[macro_use]
+extern crate criterion;
 extern crate syntect;
-use test::Bencher;
 
+use criterion::{Bencher, Criterion};
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::ThemeSet;
 
-#[bench]
+
 fn bench_load_internal_dump(b: &mut Bencher) {
     b.iter(|| {
-        let ps = SyntaxSet::load_defaults_newlines();
-        test::black_box(&ps);
+        SyntaxSet::load_defaults_newlines()
     });
 }
 
-#[bench]
 fn bench_load_internal_themes(b: &mut Bencher) {
     b.iter(|| {
-        let ts = ThemeSet::load_defaults();
-        test::black_box(&ts);
+        ThemeSet::load_defaults()
     });
 }
 
-#[bench]
 fn bench_load_theme(b: &mut Bencher) {
     b.iter(|| {
-        let theme = ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme");
-        test::black_box(&theme);
+        ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme")
     });
 }
 
-#[bench]
 fn bench_load_syntaxes(b: &mut Bencher) {
     b.iter(|| {
         let mut ps = SyntaxSet::new();
-        ps.load_syntaxes("testdata/Packages", false).unwrap();
+        ps.load_syntaxes("testdata/Packages", false).unwrap()
     });
 }
 
-#[bench]
 fn bench_link_syntaxes(b: &mut Bencher) {
     let mut ps = SyntaxSet::new();
     ps.load_syntaxes("testdata/Packages", false).unwrap();
@@ -47,3 +39,18 @@ fn bench_link_syntaxes(b: &mut Bencher) {
         ps.link_syntaxes();
     });
 }
+
+fn loading_benchmark(c: &mut Criterion) {
+    c.bench_function("load_internal_dump", bench_load_internal_dump);
+    c.bench_function("load_internal_themes", bench_load_internal_themes);
+    c.bench_function("load_theme", bench_load_theme);
+    c.bench_function("load_syntaxes", bench_load_syntaxes);
+    c.bench_function("link_syntaxes", bench_link_syntaxes);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(100);
+    targets = loading_benchmark
+}
+criterion_main!(benches);

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -17,12 +17,22 @@ fn do_parse(s: &str, syntax: &SyntaxDefinition) -> usize {
     count
 }
 
-fn parse_file(b: &mut Bencher, path_s: &str) {
+fn parse_file(b: &mut Bencher, file: &str) {
+    let path = match file {
+        "highlight_test.erb" => "testdata/highlight_test.erb",
+        "InspiredGitHub.tmTheme" => "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
+        "Ruby.sublime-syntax" => "testdata/Packages/Ruby/Ruby.sublime-syntax",
+        "jquery.js" => "testdata/jquery.js",
+        "parser.rs" => "testdata/parser.rs",
+        "scope.rs" => "src/parsing/scope.rs",
+        _ => panic!("Unknown test file {}", file),
+    };
+
     // don't load from dump so we don't count lazy regex compilation time
     let ps = SyntaxSet::load_defaults_nonewlines();
 
-    let syntax = ps.find_syntax_for_file(path_s).unwrap().unwrap();
-    let mut f = File::open(path_s).unwrap();
+    let syntax = ps.find_syntax_for_file(path).unwrap().unwrap();
+    let mut f = File::open(path).unwrap();
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
@@ -34,12 +44,12 @@ fn parsing_benchmark(c: &mut Criterion) {
         "parse",
         |b, s| parse_file(b, s),
         vec![
-            "testdata/highlight_test.erb",
-            "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
-            "testdata/Packages/Ruby/Ruby.sublime-syntax",
-            "testdata/jquery.js",
-            "testdata/parser.rs",
-            "src/parsing/scope.rs",
+            "highlight_test.erb",
+            "InspiredGitHub.tmTheme",
+            "Ruby.sublime-syntax",
+            "jquery.js",
+            "parser.rs",
+            "scope.rs",
         ],
     );
 }


### PR DESCRIPTION
Advantages over the previous system:

* Allows running on stable Rust
* Compares benchmarks between runs using statistics

See https://github.com/japaric/criterion.rs for more.