### PR TITLE
Stop matching as soon as we found the best possible match

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -358,6 +358,12 @@ impl ParseState {
                             from_with_prototype: from_with_proto,
                             would_loop: pop_would_loop,
                         });
+
+                        if match_start == start && !pop_would_loop {
+                            // We're not gonna find a better match after this,
+                            // so as an optimization we can stop matching now.
+                            return best_match;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
See https://github.com/trishume/syntect/pull/146#discussion_r183708858

I added some timing to syntest and this is why syntest changes so dramatically:

![chart](https://user-images.githubusercontent.com/16778/39396943-83b751d6-4b3a-11e8-8dcb-ec26ad99c8bc.png)

The rules for Makefiles must be written in a way where this change eliminates a lot of matching. But even disregarding that, there's some nice improvements:

![chart-without-makefile](https://user-images.githubusercontent.com/16778/39396967-def2a8fc-4b3a-11e8-9793-e004fe32fa18.png)
