### PR TITLE
Implement Error for LoadingError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,11 +112,7 @@ impl fmt::Display for LoadingError {
         match *self {
             WalkDir(ref error) => error.fmt(f),
             Io(ref error) => error.fmt(f),
-            #[cfg(feature = "yaml-load")]
-            ParseSyntax(_) => write!(f, "Invalid syntax file"),
-            ParseTheme(_) => write!(f, "Invalid syntax theme"),
-            ReadSettings(_) => write!(f, "Invalid syntax theme settings"),
-            BadPath => write!(f, "Invalid path"),
+            _ => write!(f, "{}", self.description()),
         }
     }
 }


### PR DESCRIPTION
Implements `std::error::Error` for `LoadingError`.

This is a first step towards #94. Things could definitely be improved by also implementing `Error` for the other syntect-specific errors.