### PR TITLE
Allow syntest to work with pack dumps generated on Windows

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -101,7 +101,7 @@ impl SyntaxSet {
             if entry.path().extension().map_or(false, |e| e == "sublime-syntax") {
                 let syntax = load_syntax_file(entry.path(), lines_include_newline)?;
                 if let Some(path_str) = entry.path().to_str() {
-                    self.path_syntaxes.push((path_str.to_string(), self.syntaxes.len()));
+                    self.path_syntaxes.push((path_str.replace("\\", "/").to_string(), self.syntaxes.len()));
                 }
                 self.syntaxes.push(syntax);
             }


### PR DESCRIPTION
Sublime Text internally deals with Unix style paths, which is why syntax tests point to the syntax definition using `Packages/PackageName/SyntaxName.sublime-syntax`. Unfortunately, that currently fails in `syntect` with pack dumps generated on Windows, because it stores the paths in Windows format and thus can't find them when it comes time to look it up using Unix path separators. This PR fixes that by converting `\` to `/` when storing the path the syntax was loaded from. I'm not sure if this is the best solution, so feel free to suggest problems with it and/or something better. :)