### PR TITLE
Find syntax by filename as well as file extension

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -437,6 +437,7 @@ mod tests {
                    "Go");
         assert_eq!(&ps.find_syntax_for_file(".bashrc").unwrap().unwrap().name,
                    "Bourne Again Shell (bash)");
+        assert_eq!(&ps.find_syntax_for_file("Rakefile").unwrap().unwrap().name, "Ruby");
         assert!(&ps.find_syntax_by_first_line("derp derp hi lol").is_none());
         assert_eq!(&ps.find_syntax_by_path("Packages/Rust/Rust.sublime-syntax").unwrap().name,
                    "Rust");

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -188,7 +188,7 @@ impl SyntaxSet {
     }
 
     /// Convenience method that tries to find the syntax for a file path,
-    /// first by extension and then by first line of the file if that doesn't work.
+    /// first by extension/name and then by first line of the file if that doesn't work.
     /// May IO Error because it sometimes tries to read the first line of the file.
     ///
     /// # Examples
@@ -207,7 +207,9 @@ impl SyntaxSet {
                                                 -> io::Result<Option<&SyntaxDefinition>> {
         let path: &Path = path_obj.as_ref();
         let extension = path.extension().and_then(|x| x.to_str()).unwrap_or("");
-        let ext_syntax = self.find_syntax_by_extension(extension);
+        let ext_syntax = self.find_syntax_by_extension(extension)
+                             .or_else(|| self.find_syntax_by_extension(
+                                     path.file_name().and_then(|n| n.to_str()).unwrap_or("")));
         let line_syntax = if ext_syntax.is_none() {
             let mut line = String::new();
             let f = File::open(path)?;

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -435,6 +435,8 @@ mod tests {
                        .unwrap()
                        .name,
                    "Go");
+        assert_eq!(&ps.find_syntax_for_file(".bashrc").unwrap().unwrap().name,
+                   "Bourne Again Shell (bash)");
         assert!(&ps.find_syntax_by_first_line("derp derp hi lol").is_none());
         assert_eq!(&ps.find_syntax_by_path("Packages/Rust/Rust.sublime-syntax").unwrap().name,
                    "Rust");


### PR DESCRIPTION
Some sublime-syntax files include explicit filenames in their list of supported "extensions", like `.bashrc` or `.gitignore`. This PR adds a feature to find the right syntax definition for these files.

Note: I'm not sure if this is the right place to introduce this feature.