### PR TITLE
Check regular expressions for compile errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@ impl fmt::Display for LoadingError {
         match *self {
             WalkDir(ref error) => error.fmt(f),
             Io(ref error) => error.fmt(f),
+            #[cfg(feature = "yaml-load")]
+            ParseSyntax(ref error) => error.fmt(f),
             _ => write!(f, "{}", self.description()),
         }
     }
@@ -125,7 +127,7 @@ impl Error for LoadingError {
             WalkDir(ref error) => error.description(),
             Io(ref error) => error.description(),
             #[cfg(feature = "yaml-load")]
-            ParseSyntax(_) => "Invalid syntax file",
+            ParseSyntax(ref error) => error.description(),
             ParseTheme(_) => "Invalid syntax theme",
             ReadSettings(_) => "Invalid syntax theme settings",
             BadPath => "Invalid path",

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -482,6 +482,10 @@ fn rewrite_regex(regex: String) -> String {
         return regex;
     }
 
+    // A special fix to rewrite a pattern from the `Rd` syntax that the RegexRewriter can not
+    // handle properly.
+    let regex = regex.replace("(?:\\n)?", "(?:$|)");
+
     let rewriter = RegexRewriter {
         bytes: regex.as_bytes(),
         index: 0,
@@ -870,7 +874,7 @@ mod tests {
         // In order to properly understand nesting, we'd have to have a full parser, so ignore it.
         assert_eq!(&rewrite(r"[[a]&&[\n]]"), r"[[a]&&[\n]]");
 
-        assert_eq!(&rewrite(r"ab(?:\n)?"), r"ab(?:$)?");
+        assert_eq!(&rewrite(r"ab(?:\n)?"), r"ab(?:$|)");
         assert_eq!(&rewrite(r"(?<!\n)ab"), r"(?<!$)ab");
         assert_eq!(&rewrite(r"(?<=\n)ab"), r"(?<=$)ab");
     }

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -290,11 +290,8 @@ impl SyntaxDefinition {
     }
 
     fn try_compile_regex(regex_str: &str) -> Result<(), ParseSyntaxError> {
-        // Replace backreferences with a dummy placeholder value
-        let mut regex_str = String::from(regex_str);
-        for i in 0..10 {
-            regex_str = regex_str.replace(&format!("\\{}", i), "placeholder");
-        }
+        // Replace backreferences with a placeholder value that will also appear in errors
+        let regex_str = substitute_backrefs_in_regex(regex_str, |i| Some(format!("<placeholder_{}>", i)));
 
         let result = Regex::with_options(&regex_str,
                                          RegexOptions::REGEX_OPTION_CAPTURE_GROUP,

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -3,7 +3,7 @@ use super::syntax_definition::*;
 use yaml_rust::{YamlLoader, Yaml, ScanError};
 use yaml_rust::yaml::Hash;
 use std::collections::HashMap;
-use onig::{self, Regex, Captures};
+use onig::{self, Regex, Captures, RegexOptions, Syntax};
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::error::Error;
@@ -296,7 +296,10 @@ impl SyntaxDefinition {
             regex_str = regex_str.replace(&format!("\\{}", i), "placeholder");
         }
 
-        match Regex::new(&regex_str) {
+        let result = Regex::with_options(&regex_str,
+                                         RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
+                                         Syntax::default());
+        match result {
             Err(onig_error) => {
                 Err(ParseSyntaxError::RegexCompileError(regex_str, onig_error))
             },
@@ -777,7 +780,7 @@ mod tests {
         assert!(def.is_err());
         match def.unwrap_err() {
             ParseSyntaxError::RegexCompileError(ref regex, _) => assert_eq!("[a", regex),
-            _ => assert!(false, "Got unexpedted ParseSyntaxError"),
+            _ => assert!(false, "Got unexpected ParseSyntaxError"),
         }
     }
 


### PR DESCRIPTION
This PR implements a basic version of regex syntax checking as proposed in #98 by @robinst. This would hopefully allow us to catch a lot of possible errors at `SyntaxSet`-generation time (and prevent `panic!`s at syntax-highlighting time).

I have also implemented `Error` for `ParseSyntaxError` (which includes `RegexCompileError`). This allows user code to display nice error messages when loading syntax sets. For example, I get the following error when I try to load [`CMake.sublime-syntax`](https://github.com/zyxar/Sublime-CMakeLists):

```
Error while compiling regex '(?=\b@?[A-Z_][A-Z0-9_]*(?=[^\w-<>=\$]))':
unmatched range specifier in char-class
```
(this has already been addressed upstream: https://github.com/zyxar/Sublime-CMakeLists/pull/32)

Note that the tests currently do not pass due to #164 (I believe this is a good thing!), so #164 should be fixed before merging this. All tests pass if `Rd (R Documentation).sublime-syntax` is removed.

---

The backreference "rewriting" is very immature (and maybe even "unsafe"?). I ended up using this simple search-and-replace after trying two other approaches first:

- Simply ignore regex compile errors with code `-208` (`onig_sys::ONIGERR_INVALID_BACKREF`).
  However, using this approach, we wouldn't catch other syntax errors in these regexes.

- Use `onig`s `SyntaxBehavior` to disable backreference checking (because I thought that
  SYNTAX_BEHAVIOR_STRICT_CHECK_BACKREF might help - it did not).
