### PR TITLE
Syntest reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
     fi
   - cargo test
   - make assets
+  - make syntest
   - rm -Rf examples
   - cargo doc
   # default features are required for examples to build - so remove them from sight.

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,25 @@ info:
 	$(info - OTHER TARGETS -------------------------------------------------------)
 	$(info themes      | generate default theme pack)
 	$(info packs       | generate default syntax pack)
-	
-	
+	$(info syntest     | run syntax test summary)
+
+
 $(SUBMODULES):
 	git submodule update --init --recursive
 
 assets: packs themes
 
 packs: $(SUBMODULES)
-	cargo run --example gendata -- synpack testdata/Packages assets/default_newlines.packdump assets/default_nonewlines.packdump 
-	
+	cargo run --example gendata -- synpack testdata/Packages assets/default_newlines.packdump assets/default_nonewlines.packdump
+
 themes: $(SUBMODULES)
 	cargo run --example gendata -- themepack testdata assets/default.themedump
-	
+
+syntest: $(SUBMODULES)
+	@echo Tip: Run make update-known-failures to update the known failures file.
+	cargo run --release --example syntest -- testdata/Packages testdata/Packages --summary | diff -U 1000000 testdata/known_syntest_failures.txt -
+	@echo No new failures!
+
+update-known-failures: $(SUBMODULES)
+	cargo run --release --example syntest -- testdata/Packages testdata/Packages --summary | tee testdata/known_syntest_failures.txt
+

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,0 +1,6 @@
+loading syntax definitions from testdata/Packages
+FAILED testdata/Packages/ASP/syntax_test_asp.asp: 162
+FAILED testdata/Packages/C#/tests/syntax_test_Strings.cs: 38
+FAILED testdata/Packages/LaTeX/syntax_test_latex.tex: 1
+FAILED testdata/Packages/Makefile/syntax_test_makefile.mak: 7
+exiting with code 1


### PR DESCRIPTION
This adds syntax tests to CI and makes it easier to check for regressions locally using them!

I was about to spend some time debugging syntax test regressions in #166 but then I realized I still hadn't gotten around to making regressions be caught automatically and be easy to digest.

I switched `syntest` to use `getopts` since `syncat` was already using it, and then added a `--summary` option which only prints failures and failure counts. I then added a `make syntest` command to diff against known issues and fail if there's a difference, and a `make update-known-failures` to easily update the counts on submodule bump PRs and things, or when we fix some.

I don't print the total number of assertions in summaries so that adding new succeeding tests doesn't cause CI failures.

cc @sharkdp 