### PR TITLE
ignore prototype context when escaping embedded contexts

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1229,6 +1229,34 @@ contexts:
         expect_scope_stacks(&line, &expect, syntax);
     }
 
+    #[test]
+    fn can_parse_prototype_with_embed() {
+        let syntax = r#"
+name: Javadoc
+scope: text.html.javadoc
+contexts:
+  prototype:
+    - match: \*
+      scope: punctuation.definition.comment.javadoc
+
+  main:
+    - meta_include_prototype: false
+    - match: /\*\*
+      scope: comment.block.documentation.javadoc punctuation.definition.comment.begin.javadoc
+      embed: contents
+      embed_scope: comment.block.documentation.javadoc text.html.javadoc
+      escape: \*/
+      escape_captures:
+        0: comment.block.documentation.javadoc punctuation.definition.comment.end.javadoc
+
+  contents:
+    - match: ''
+"#;
+
+        let syntax = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        expect_scope_stacks_with_syntax("/** * */", &["<comment.block.documentation.javadoc>, <punctuation.definition.comment.begin.javadoc>", "<comment.block.documentation.javadoc>, <text.html.javadoc>, <punctuation.definition.comment.javadoc>", "<comment.block.documentation.javadoc>, <punctuation.definition.comment.end.javadoc>"], syntax);
+    }
+
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {
         println!("Parsing with newlines");
         let line_with_newline = format!("{}\n", line_without_newline);

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -350,8 +350,11 @@ impl SyntaxDefinition {
         } else if let Ok(y) = get_key(map, "embed", Some) {
             // Same as push so we translate it to what it would be
             let mut embed_escape_context_yaml = vec!();
+            let mut commands = Hash::new();
+            commands.insert(Yaml::String("meta_include_prototype".to_string()), Yaml::Boolean(false));
+            embed_escape_context_yaml.push(Yaml::Hash(commands));
             if let Ok(s) = get_key(map, "embed_scope", Some) {
-                let mut commands = Hash::new();
+                commands = Hash::new();
                 commands.insert(Yaml::String("meta_content_scope".to_string()), s.clone());
                 embed_escape_context_yaml.push(Yaml::Hash(commands));
             }
@@ -718,7 +721,7 @@ mod tests {
               captures:
                 1: meta.tag.style.begin.html punctuation.definition.tag.end.html
               push:
-                - [{ meta_content_scope: 'source.css.embedded.html'}, { match: '(?i)(?=</style)', pop: true }]
+                - [{ meta_include_prototype: false }, { meta_content_scope: 'source.css.embedded.html' }, { match: '(?i)(?=</style)', pop: true }]
                 - scope:source.css
               with_prototype:
                 - match: (?=(?i)(?=</style))


### PR DESCRIPTION
this fixes the bug found at https://github.com/trishume/syntect/issues/160#issuecomment-393832122, whereby the `prototype` context was being applied in the context that is `escape`-ing `embed`ded contexts, and causing it to not pop out as expected.