### PR TITLE
trim dots from the right of the scope (selector)

### DIFF
--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -136,7 +136,7 @@ impl ScopeRepository {
         if s.is_empty() {
             return Ok(Scope { a: 0, b: 0 });
         }
-        let parts: Vec<usize> = s.split('.').map(|a| self.atom_to_index(a)).collect();
+        let parts: Vec<usize> = s.trim_right_matches('.').split('.').map(|a| self.atom_to_index(a)).collect();
         if parts.len() > 8 {
             return Err(ParseScopeError::TooManyAtoms);
         }
@@ -540,6 +540,8 @@ mod tests {
         assert_eq!(repo.to_string(s2), "source.php.wow");
         assert!(repo.build("source.php").unwrap() != repo.build("source.perl").unwrap());
         assert!(repo.build("source.php").unwrap() != repo.build("source.php.wagon").unwrap());
+        assert_eq!(repo.build("comment.line.").unwrap(),
+                   repo.build("comment.line").unwrap());
     }
     #[test]
     fn global_repo_works() {

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -2,5 +2,5 @@ loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/ASP/syntax_test_asp.asp: 162
 FAILED testdata/Packages/C#/tests/syntax_test_Strings.cs: 38
 FAILED testdata/Packages/LaTeX/syntax_test_latex.tex: 1
-FAILED testdata/Packages/Makefile/syntax_test_makefile.mak: 7
+FAILED testdata/Packages/Makefile/syntax_test_makefile.mak: 6
 exiting with code 1


### PR DESCRIPTION
This PR tweaks the way scopes and scope selectors are created from strings, to more closely match how Sublime Text does it. Specifically, Sublime ignores trailing `.` characters.

In Sublime:

    sublime.score_selector('comment.line.cs', 'comment.line...')

returns 16. The same as with no trailing dots.

[This difference was causing a `syntest` failure](https://travis-ci.org/trishume/syntect/jobs/384849350#L676) that doesn't occur in Sublime for Makefile -
 https://github.com/sublimehq/Packages/blob/22c230deb432ee09b22de0b962ee94567e08b866/Makefile/syntax_test_makefile.mak#L251