### PR TITLE
Remove unused import that caused the warning

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -14,10 +14,6 @@ use std::ops::DerefMut;
 use std::mem;
 use std::rc::Rc;
 
-// TODO this is unused in nightly but used in stable, remove eventually
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
-
 use std::sync::Mutex;
 use onig::Regex;
 


### PR DESCRIPTION
Fix this warning.

```
warning: use of deprecated item 'std::ascii::AsciiExt': use inherent methods instead
  --> src/parsing/syntax_set.rs:19:5
   |
19 | use std::ascii::AsciiExt;
   |     ^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default
```

My understanding is that comment was referring to the stable toolchain. I tested it with the stable rustup toolchain and it compiles fine, so I assume it's safe to remove.