### PR TITLE
keep with_prototype when switching contexts with `set`

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1298,6 +1298,9 @@ contexts:
     - match: e
       scope: e
       pop: true
+    - match: f
+      scope: f
+      set: [next1, next2]
   next3:
     - match: d
       scope: d
@@ -1314,9 +1317,9 @@ contexts:
             ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
         );
         expect_scope_stacks_with_syntax(
-            "5cedcea",
+            "5cfcecbedcdea",
             &[
-                "<5>", "<cwith>", "<e>", "<d>", "<cwithout>", "<a>"
+                "<5>", "<cwith>", "<f>", "<e>", "<b>", "<d>", "<cwithout>", "<a>"
             ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
         );
     }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -608,14 +608,17 @@ impl ParseState {
             MatchOperation::None => return false,
         };
         for (i, r) in ctx_refs.iter().enumerate() {
-            // if a with_prototype was specified, and multiple contexts were pushed,
-            // then the with_prototype applies only to the last context pushed, i.e.
-            // top most on the stack after all the contexts are pushed - this is also
-            // referred to as the "target" of the push by sublimehq - see
-            // https://forum.sublimetext.com/t/dev-build-3111/19240/17 for more info
             let proto = if i == 0 && pat.with_prototype.is_none() {
+                // a `with_prototype` stays active when the context is `set`
+                // until the context layer in the stack (where the `with_prototype`
+                // was initially applied) is popped off.
                 old_proto.clone()
             } else if i == ctx_refs.len() - 1 {
+                // if a with_prototype was specified, and multiple contexts were pushed,
+                // then the with_prototype applies only to the last context pushed, i.e.
+                // top most on the stack after all the contexts are pushed - this is also
+                // referred to as the "target" of the push by sublimehq - see
+                // https://forum.sublimetext.com/t/dev-build-3111/19240/17 for more info
                 pat.with_prototype.clone()
             } else {
                 None

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -608,18 +608,16 @@ impl ParseState {
             MatchOperation::None => return false,
         };
         for (i, r) in ctx_refs.iter().enumerate() {
-            let proto = if i == ctx_refs.len() - 1 && pat.with_prototype.is_none() {
+            let proto = if i == ctx_refs.len() - 1 {
                 // a `with_prototype` stays active when the context is `set`
                 // until the context layer in the stack (where the `with_prototype`
                 // was initially applied) is popped off.
-                old_proto.clone()
-            } else if i == ctx_refs.len() - 1 {
                 // if a with_prototype was specified, and multiple contexts were pushed,
                 // then the with_prototype applies only to the last context pushed, i.e.
                 // top most on the stack after all the contexts are pushed - this is also
                 // referred to as the "target" of the push by sublimehq - see
                 // https://forum.sublimetext.com/t/dev-build-3111/19240/17 for more info
-                pat.with_prototype.clone()
+                pat.with_prototype.clone().or(old_proto.clone())
             } else {
                 None
             };

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -608,7 +608,7 @@ impl ParseState {
             MatchOperation::None => return false,
         };
         for (i, r) in ctx_refs.iter().enumerate() {
-            let proto = if i == 0 && pat.with_prototype.is_none() {
+            let proto = if i == ctx_refs.len() - 1 && pat.with_prototype.is_none() {
                 // a `with_prototype` stays active when the context is `set`
                 // until the context layer in the stack (where the `with_prototype`
                 // was initially applied) is popped off.
@@ -1283,6 +1283,10 @@ contexts:
           scope: '4'
     - match: '5'
       scope: '5'
+      set: [next3, next2]
+      with_prototype:
+        - match: c
+          scope: cwith
   next1:
     - match: b
       scope: b
@@ -1299,14 +1303,21 @@ contexts:
       scope: d
     - match: (?=e)
       pop: true
+    - match: c
+      scope: cwithout
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
         expect_scope_stacks_with_syntax(
             "a1b2c3d4e5",
             &[
                 "<a>", "<1>", "<b>", "<2>", "<c>", "<3>", "<d>", "<4>", "<e>", "<5>"
-            ], syntax
+            ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
+        );
+        expect_scope_stacks_with_syntax(
+            "5cedcea",
+            &[
+                "<5>", "<cwith>", "<e>", "<d>", "<cwithout>", "<a>"
+            ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -617,7 +617,7 @@ impl ParseState {
                 // top most on the stack after all the contexts are pushed - this is also
                 // referred to as the "target" of the push by sublimehq - see
                 // https://forum.sublimetext.com/t/dev-build-3111/19240/17 for more info
-                pat.with_prototype.clone().or(old_proto.clone())
+                pat.with_prototype.clone().or_else(|| old_proto.clone())
             } else {
                 None
             };


### PR DESCRIPTION
This implements @robinst's fix from https://github.com/trishume/syntect/pull/166#issuecomment-392753346 with a minimal test case, to keep the `with_prototype` context active when a context is `set` - only when a `pop` occurs at that layer should the `with_prototype` be removed.