### PR TITLE
WIP: support for .tmPreferences features (indentation, comment toggling etc)

### DIFF
--- a/examples/indent_toy.rs
+++ b/examples/indent_toy.rs
@@ -1,0 +1,49 @@
+extern crate syntect;
+extern crate getopts;
+
+use getopts::Options;
+use syntect::easy::IndentFile;
+use syntect::parsing::SyntaxSet;
+
+fn main() -> Result<(), std::io::Error> {
+
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut opts = Options::new();
+    opts.optflag("t", "tabs", "reindent using tabs");
+    opts.optopt("s", "spaces", "reindent using spaces", "NUM_SPACES");
+    opts.reqopt("p", "extra-syntaxes", "SYNTAX_FOLDER", "Additional folder to search for .sublime-syntax files in.");
+
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => { m }
+        Err(f) => { panic!(f.to_string()) }
+    };
+
+    if matches.opt_present("tabs") && matches.opt_present("spaces") {
+        panic!("tabs or spaces? (not both)");
+    }
+
+    let tab_text = if matches.opt_present("tabs") {
+        "\t"
+    } else {
+        let num_spaces = matches.opt_str("spaces")
+        .map(|s| s.parse::<usize>().expect("spaces argument must be an integer"))
+        .unwrap_or(4);
+        &"                                            "[..num_spaces]
+    };
+
+    let mut syntax_set = SyntaxSet::new();
+    syntax_set.load_syntaxes(matches.opt_str("extra-syntaxes").unwrap(), false);
+
+    for src in &matches.free[..] {
+        if matches.free.len() > 1 {
+            println!("==> {} <==", src);
+        }
+
+        let mut indenter = IndentFile::new(src, &syntax_set, tab_text)?;
+        for line in indenter {
+            println!("{}", line);
+        }
+    }
+    Ok(())
+}

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -3,7 +3,7 @@
 //! settings like selection colour, `ThemeSet` for loading themes,
 //! as well as things starting with `Highlight` for how to highlight text.
 mod selector;
-mod settings;
+pub mod settings;
 mod style;
 mod theme;
 mod highlighter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ mod escape;
 use std::io::Error as IoError;
 use std::error::Error;
 use std::fmt;
+
+use serde_json::Error as JsonError;
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 use parsing::ParseSyntaxError;
 use highlighting::{ParseThemeError, SettingsError};
@@ -71,6 +73,7 @@ pub enum LoadingError {
     /// a syntax file was invalid in some way
     #[cfg(feature = "yaml-load")]
     ParseSyntax(ParseSyntaxError),
+    ParseJson(JsonError),
     /// a theme file was invalid in some way
     ParseTheme(ParseThemeError),
     /// a theme's Plist syntax was invalid in some way
@@ -97,6 +100,13 @@ impl From<ParseThemeError> for LoadingError {
         LoadingError::ParseTheme(error)
     }
 }
+
+impl From<JsonError> for LoadingError {
+    fn from(src: JsonError) -> LoadingError {
+        LoadingError::ParseJson(src)
+    }
+}
+
 
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 impl From<ParseSyntaxError> for LoadingError {
@@ -128,6 +138,7 @@ impl Error for LoadingError {
             Io(ref error) => error.description(),
             #[cfg(feature = "yaml-load")]
             ParseSyntax(ref error) => error.description(),
+            ParseJson(_) => "Failed to parse JSON",
             ParseTheme(_) => "Invalid syntax theme",
             ReadSettings(_) => "Invalid syntax theme settings",
             BadPath => "Invalid path",

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -1,0 +1,372 @@
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::fs::File;
+use std::io::BufReader;
+
+use onig::{Regex, SearchOptions};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json;
+
+use super::scope::Scope;
+use super::super::LoadingError;
+use super::super::highlighting::settings::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Indentation {
+    pub increase_indent_pattern: Pattern,
+    #[serde(default)]
+    pub decrease_indent_pattern: Option<Pattern>,
+    #[serde(default)]
+    pub bracket_indent_next_line_pattern: Option<Pattern>,
+    #[serde(default)]
+    pub disable_indent_next_line_pattern: Option<Pattern>,
+    #[serde(default, rename = "unIndentedLinePattern")]
+    pub unindented_line_pattern: Option<Pattern>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Pattern {
+    regex_str: String,
+    regex: RefCell<Option<Regex>>,
+}
+
+/// Describes the indentaion state for a line.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct IndentationState {
+    /// The indent level for subsequent lines.
+    pub next_indent_level: usize,
+    /// If `true`, the next line should be indented one extra level.
+    /// This is used for things like indenting chained functions, e.g:
+    ///
+    /// ```
+    /// "hello".chars()
+    ///     .collect::<String>();
+    /// ```
+    pub extra_indent_next_line: bool,
+    /// If `true`, the _current_ line (that is, the line that was passed
+    /// in to generate this `IndentState`) should have its indent level
+    /// increased.
+    ///
+    /// `next_indent_level` will still be correct in this case.
+    pub decrease_current_indent: bool,
+}
+
+//#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+//pub struct Comments {
+    //shell_variables: serde_json::Map,
+//}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Metadata {
+    pub indentation: Option<Indentation>,
+    //comments: Option<Comments>,
+}
+
+//FIXME: using a newtype so I can strip trailing "- something" annotations
+//from metadata scope selectors
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Default, Hash)]
+struct BareScope(pub Scope);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawMetadataEntry {
+    scope: BareScope,
+    settings: BTreeMap<String, Settings>,
+}
+
+/// Convenience type for loading heterogeneous metadata.
+#[derive(Debug, Default)]
+pub struct LoadMetadata {
+    loaded: BTreeMap<Scope, Settings>,
+}
+
+impl LoadMetadata {
+    pub fn add_raw(&mut self, raw: RawMetadataEntry) {
+        let RawMetadataEntry { scope, settings } = raw;
+        let scoped_settings = self.loaded.entry(scope.0)
+            .or_insert_with(|| {
+                let map: serde_json::Map<String, Settings> = serde_json::Map::new();
+                map.into()
+            })
+            .as_object_mut()
+            .unwrap();
+
+            scoped_settings.extend(settings)
+    }
+
+    pub fn metadata_for_scope(&mut self, scope: Scope) -> Option<Metadata> {
+        let indentation: Option<Indentation> = self.loaded.remove(&scope)
+            .and_then(|raw| serde_json::from_value(raw)
+                 .map_err(|e| eprintln!("metadata error in {}: {:?}", scope, e))
+                 .ok()
+             );
+        Some(Metadata { indentation })
+    }
+}
+
+impl Indentation {
+    /// Given the state of the previous line, computes the state for the current line.
+    pub fn state_for_line<S: AsRef<str>>(
+        &self,
+        line: S,
+        prev_state: IndentationState) -> IndentationState {
+        let line = line.as_ref();
+        if self.unindented_line_pattern.as_ref()
+            .map(|p| p.is_match(line))
+            .unwrap_or(false)
+        {
+            prev_state
+        } else if self.decrease_indent_pattern.as_ref()
+            .map(|p| p.is_match(line))
+            .unwrap_or(false)
+        {
+            prev_state.new_by_decreasing_level()
+        } else if self.increase_indent_pattern.is_match(line) {
+            let mut next = prev_state.next_base_state();
+            next.next_indent_level += 1;
+            next
+        } else {
+            let indent_next_line = self.bracket_indent_next_line_pattern
+            .as_ref()
+            .map(|p| p.is_match(line))
+            .unwrap_or(false)
+            && !self.disable_indent_next_line_pattern.as_ref()
+                .map(|p| p.is_match(line))
+                .unwrap_or(false);
+
+            let mut next = prev_state.next_base_state();
+            next.extra_indent_next_line = indent_next_line;
+            next
+        }
+    }
+}
+
+impl IndentationState {
+    fn next_base_state(self) -> Self {
+        let IndentationState { next_indent_level, .. } = self;
+        IndentationState {
+            next_indent_level,
+            extra_indent_next_line: false,
+            decrease_current_indent: false,
+        }
+    }
+
+    fn new_by_decreasing_level(self) -> IndentationState {
+        let mut next = self.next_base_state();
+        next.next_indent_level = next.next_indent_level.saturating_sub(1);
+        next.decrease_current_indent = true;
+        next
+    }
+}
+
+    ///// **Naively** guesses the current whitespace setting.
+    //fn guess_state_from_line<S: AsRef<str>>(line: S) -> Self {
+        //let line = line.as_ref();
+        //let is_spaces = line.starts_with(' ');
+        //let indent_level = if is_spaces {
+            //match line.chars()
+                //.take_while(|c| *c == ' ')
+                //.count()
+            //{
+                //0 => 0,
+                //2 => 2,
+                //num  if num % 4 == 0 => num / 4,
+                //_ => 0,
+            //}
+        //} else {
+            //line.chars().take_while(|c| *c == '\t').count()
+        //};
+
+        //let mut preceding_state = IndentationState::default();
+        //preceding_state.next_indent_level = indent_level;
+        //preceding_state
+    //}
+//}
+
+impl Pattern {
+    pub fn is_match<S: AsRef<str>>(&self, string: S) -> bool {
+        self.compile_if_needed();
+        self.regex.borrow_mut()
+            .as_ref()
+            .unwrap()
+            .match_with_options(
+                string.as_ref(),
+                0,
+                SearchOptions::SEARCH_OPTION_NONE,
+                None)
+            .is_some()
+    }
+
+    fn compile_if_needed(&self) {
+        if self.regex.borrow().is_some() { return; }
+        *self.regex.borrow_mut() = Some(Regex::new(&self.regex_str)
+            .expect("regex strings should be pre tested"))
+    }
+}
+
+impl RawMetadataEntry {
+    pub fn load<P: AsRef<Path>>(file: P) -> Result<Self, LoadingError> {
+        let file = File::open(file)?;
+        let file = BufReader::new(file);
+        let contents = read_plist(file)?;
+        Ok(serde_json::from_value(contents)?)
+    }
+}
+
+impl Serialize for Pattern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(&self.regex_str)
+    }
+}
+
+impl<'de> Deserialize<'de> for Pattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        let regex_str = String::deserialize(deserializer)?;
+        Ok(Pattern { regex_str, regex: RefCell::default() })
+    }
+}
+
+impl<'de> Deserialize<'de> for BareScope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        let s = String::deserialize(deserializer)?;
+        let scope = Scope::new(&s.split(" -").next().unwrap())
+            .map_err(|e| de::Error::custom(format!("Invalid scope: {:?}", e)))?;
+        Ok(BareScope(scope))
+    }
+}
+
+impl Serialize for BareScope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        self.0.serialize(serializer)
+    }
+}
+
+
+impl Clone for Pattern {
+    fn clone(&self) -> Self {
+        //FIXME: probably we should keep our compiled regex in a shared pointer?
+        //I'm not sure how often patterns are going to be passed around.
+        Pattern { regex_str: self.regex_str.clone(), regex: RefCell::default() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parsing::SyntaxSet;
+    #[test]
+    fn try_load() {
+        let comments_file: &str = "testdata/Packages/Go/Comments.tmPreferences";
+        assert!(Path::new(comments_file).exists());
+
+        let r = RawMetadataEntry::load(comments_file);
+        assert!(r.is_ok());
+
+        let indent_file: &str = "testdata/Packages/Go/Indentation Rules.tmPreferences";
+        assert!(Path::new(indent_file).exists());
+
+        let r = RawMetadataEntry::load(indent_file).unwrap();
+        assert_eq!(r.scope.0, Scope::new("source.go").unwrap());
+
+        let indent_file: &str = "testdata/Packages/Rust/RustIndent.tmPreferences";
+        assert!(Path::new(indent_file).exists());
+
+        let r = RawMetadataEntry::load(indent_file).unwrap();
+        assert_eq!(r.scope.0, Scope::new("source.rust").unwrap())
+    }
+
+    #[test]
+    fn load_groups() {
+        let mut loaded = LoadMetadata::default();
+        let indent_file: &str = "testdata/Packages/Rust/RustIndent.tmPreferences";
+        let raw = RawMetadataEntry::load(indent_file).unwrap();
+        loaded.add_raw(raw);
+        let rust_meta = loaded.metadata_for_scope(Scope::new("source.rust").unwrap()).unwrap();
+        let _ = rust_meta.indentation.unwrap();
+    }
+
+    #[test]
+    fn serde_pattern() {
+        let pattern: Pattern = serde_json::from_str("\"just a string\"").unwrap();
+        assert_eq!(pattern.regex_str, "just a string");
+        let back_to_str = serde_json::to_string(&pattern).unwrap();
+        assert_eq!(back_to_str, "\"just a string\"");
+    }
+
+    #[test]
+    fn indent_rust() {
+        let ps = SyntaxSet::load_from_folder("testdata/Packages/Rust").unwrap();
+        let syntax = ps.find_syntax_by_extension("rs").unwrap();
+        //eprintln!("{:?}", syntax.metadata);
+        let indentation = syntax.metadata.as_ref().and_then(|m| m.indentation.as_ref())
+            .unwrap();
+        let base_state = IndentationState::default();
+
+        let state = indentation.state_for_line("struct This {", base_state);
+        assert_eq!(state.next_indent_level, 1);
+
+        let state = indentation.state_for_line("}", state);
+        assert_eq!(state.next_indent_level, 0);
+        assert!(state.decrease_current_indent);
+
+        assert!(indentation.increase_indent_pattern.is_match("struct This {"));
+        assert!(indentation.increase_indent_pattern.is_match("struct That ("));
+        assert!(indentation.increase_indent_pattern.is_match("fn my_fun("));
+
+        let state = indentation.state_for_line("fn my_fn(", state);
+        assert_eq!(state.next_indent_level, 1);
+        let state = indentation.state_for_line("    arg1,", state);
+        assert_eq!(state.next_indent_level, 1);
+        let state = indentation.state_for_line("    arg2(", state);
+        assert_eq!(state.next_indent_level, 2);
+        let state = indentation.state_for_line("    arg2_arg", state);
+        assert_eq!(state.next_indent_level, 2);
+        let state = indentation.state_for_line("        arg2_arg2)", state);
+        assert_eq!(state.next_indent_level, 1);
+        let state = indentation.state_for_line("    )", state);
+        assert_eq!(state.next_indent_level, 0);
+        let state = indentation.state_for_line("    )", state);
+        assert_eq!(state.next_indent_level, 0);
+        let state = indentation.state_for_line("    )", state);
+        assert_eq!(state.next_indent_level, 0);
+    }
+
+    #[test]
+    fn indent_python() {
+        let ps = SyntaxSet::load_from_folder("testdata/Packages/Python").unwrap();
+        let syntax = ps.find_syntax_by_extension("py").unwrap();
+        let indentation = syntax.metadata.as_ref().and_then(|m| m.indentation.as_ref())
+            .unwrap();
+
+        assert!(indentation.increase_indent_pattern.is_match("class T:"));
+        assert!(indentation.increase_indent_pattern.is_match("def F:"));
+        assert!(indentation.increase_indent_pattern.is_match("for x in y:"));
+        assert!(!indentation.increase_indent_pattern.is_match("snore x in y:"));
+        assert!(!indentation.increase_indent_pattern.is_match("grass T:"));
+        assert!(!indentation.increase_indent_pattern.is_match("fed F:"));
+
+        let state = IndentationState::default();
+        let state = indentation.state_for_line("if __name__ == '__main__':", state);
+        assert_eq!(state.next_indent_level, 1);
+        let state = indentation.state_for_line("stream = StreamHandler()", state);
+        assert_eq!(state.next_indent_level, 1);
+        let state = indentation.state_for_line("try:", state);
+        assert_eq!(state.next_indent_level, 2);
+        let state = indentation.state_for_line("for t in stream:", state);
+        assert_eq!(state.next_indent_level, 3);
+        let state = indentation.state_for_line("if not t: ", state);
+        assert_eq!(state.next_indent_level, 4);
+        let state = indentation.state_for_line("continue", state);
+        assert_eq!(state.next_indent_level, 4);
+        let state = indentation.state_for_line("else:", state);
+        assert_eq!(state.next_indent_level, 3);
+        let state = indentation.state_for_line("break", state);
+        assert_eq!(state.next_indent_level, 3);
+        let state = indentation.state_for_line("except Exception as e:", state);
+        assert_eq!(state.next_indent_level, 2);
+    }
+}

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -8,6 +8,7 @@ mod yaml_load;
 mod syntax_set;
 #[cfg(feature = "parsing")]
 mod parser;
+pub mod metadata;
 
 mod scope;
 

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -12,6 +12,8 @@ use super::scope::*;
 use regex_syntax::escape;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use super::metadata::Metadata;
+
 pub type CaptureMapping = Vec<(usize, Vec<Scope>)>;
 pub type ContextPtr = Rc<RefCell<Context>>;
 
@@ -37,6 +39,8 @@ pub struct SyntaxDefinition {
     pub variables: HashMap<String, String>,
     #[serde(serialize_with = "ordered_map")]
     pub contexts: HashMap<String, ContextPtr>,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub metadata: Option<Metadata>,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -176,6 +176,8 @@ impl SyntaxDefinition {
             hidden: get_key(h, "hidden", |x| x.as_bool()).unwrap_or(false),
 
             variables: state.variables.clone(),
+            //#[cfg(feature(metadata))]
+            metadata: None,
             contexts: contexts,
             prototype: None,
         };


### PR DESCRIPTION
**this is not ready, the code is bad, do not merge, etc**

I'd been intending to write up a proposal for this but I was feeling motivated on the train yesterday and ended up just hacking together a proof of concept. This includes a new example, `indent_toy`, which you can use like so:

```bash
cargo run --example=indent_toy -- --extra-syntaxes=testdata/Packages --spaces=4 FILE
```

this will print out a bunch of errors, but will then also reindent files in a bunch of languages. Some work better than others; there's lots of stuff missing from the implementation.

The main question: @trishume, do you have any interest in possibly including these features (starting with indentation) in syntect? I think I should be able to keep this stuff pretty isolated (behind a new cfg flag), i.e. this shouldn't have any impact on other consumers of syntect.

If the answer to that is yes, I'll open a tracking issue and figure out what needs to happen to get this mergeable.