### PR TITLE
Also mark contexts referenced by name as "no prototype" (same as ST)

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -282,8 +282,16 @@ impl SyntaxSet {
                         };
                         if let Some(context_refs) = maybe_context_refs {
                             for context_ref in context_refs.iter() {
-                                if let ContextReference::Inline(ref context_ptr) = *context_ref {
-                                    Self::recursively_mark_no_prototype(syntax, context_ptr.clone());
+                                match context_ref {
+                                    ContextReference::Inline(ref context_ptr) => {
+                                        Self::recursively_mark_no_prototype(syntax, context_ptr.clone());
+                                    },
+                                    ContextReference::Named(ref s) => {
+                                        if let Some(context_ptr) = syntax.contexts.get(s) {
+                                            Self::recursively_mark_no_prototype(syntax, context_ptr.clone());
+                                        }
+                                    },
+                                    _ => (),
                                 }
                             }
                         }


### PR DESCRIPTION
Noticed this while working on changing things to an arena. This doesn't
fix any syntests, but mirrors what ST does.

It affects the C# syntax. Here's a tiny syncat example that changed; before:

<img width="144" alt="screen shot 2018-06-28 at 11 06 02" src="https://user-images.githubusercontent.com/16778/42007804-5c4cd20a-7ac5-11e8-9c26-76496b106cea.png">

After (same as ST):

<img width="137" alt="screen shot 2018-06-28 at 11 06 10" src="https://user-images.githubusercontent.com/16778/42007808-61976306-7ac5-11e8-8f19-7da9bbc2fb43.png">
