### PR TITLE
Upgrade plist to 0.3 and take advantage of serde integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "1.0"
 bitflags = "1.0"
-plist = "0.2"
+plist = "0.3"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }


### PR DESCRIPTION
I noticed that plist comes with serde integration now, so we can just directly deserialize into the serde_json Value types using the magic of serde :).

Output of `cargo update`:

```
    Updating registry `https://github.com/rust-lang/crates.io-index`
    Updating base64 v0.8.0 -> v0.9.2
      Adding humantime v1.1.1
    Updating plist v0.2.4 -> v0.3.0
```