### PR TITLE
initial rework of syntest to be usable internally

### DIFF
--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -15,16 +15,14 @@ extern crate regex;
 extern crate getopts;
 
 //extern crate onig;
-use syntect::parsing::{SyntaxSet, ParseState, ScopeStack, Scope};
-use syntect::highlighting::ScopeSelectors;
-use syntect::easy::{ScopeRegionIterator};
+use syntect::parsing::{SyntaxSet};
+use syntect::easy::{SyntaxTestFileResult, SyntaxTestOutputOptions, process_syntax_test_assertions};
 
 use std::path::Path;
+use std::io::prelude::*;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
-use std::cmp::{min, max};
 use std::time::Instant;
-use std::str::FromStr;
 
 use getopts::Options;
 use regex::Regex;
@@ -36,12 +34,6 @@ pub enum SyntaxTestHeaderError {
     SyntaxDefinitionNotFound,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SyntaxTestFileResult {
-    FailedAssertions(usize, usize),
-    Success(usize),
-}
-
 lazy_static! {
     pub static ref SYNTAX_TEST_HEADER_PATTERN: Regex = Regex::new(r#"(?xm)
             ^(?P<testtoken_start>\s*\S+)
@@ -49,113 +41,19 @@ lazy_static! {
             "(?P<syntax_file>[^"]+)"
             \s*(?P<testtoken_end>\S+)?$
         "#).unwrap();
-    pub static ref SYNTAX_TEST_ASSERTION_PATTERN: Regex = Regex::new(r#"(?xm)
-        \s*(?:
-            (?P<begin_of_token><-)|(?P<range>\^+)
-        )(.*)$"#).unwrap();
 }
 
-#[derive(Clone, Copy)]
-struct OutputOptions {
-    time: bool,
-    debug: bool,
-    summary: bool,
-}
-
-#[derive(Debug)]
-struct AssertionRange<'a> {
-    begin_char: usize,
-    end_char: usize,
-    scope_selector_text: &'a str,
-    is_pure_assertion_line: bool,
-}
-
-#[derive(Debug)]
-struct ScopedText {
-    scope: Vec<Scope>,
-    char_start: usize,
-    text_len: usize,
-}
-
-#[derive(Debug)]
-struct RangeTestResult {
-    column_begin: usize,
-    column_end: usize,
-    success: bool,
-}
-
-fn get_line_assertion_details<'a>(testtoken_start: &str, testtoken_end: Option<&str>, line: &'a str) -> Option<AssertionRange<'a>> {
-    // if the test start token specified in the test file's header is on the line
-    if let Some(index) = line.find(testtoken_start) {
-        let (before_token_start, token_and_rest_of_line) = line.split_at(index);
-
-        if let Some(captures) = SYNTAX_TEST_ASSERTION_PATTERN.captures(&token_and_rest_of_line[testtoken_start.len()..]) {
-            let mut sst = captures.get(3).unwrap().as_str(); // get the scope selector text
-            let mut only_whitespace_after_token_end = true;
-
-            if let Some(token) = testtoken_end { // if there is an end token defined in the test file header
-                if let Some(end_token_pos) = sst.find(token) { // and there is an end token in the line
-                    let (ss, after_token_end) = sst.split_at(end_token_pos); // the scope selector text ends at the end token
-                    sst = &ss;
-                    only_whitespace_after_token_end = after_token_end.trim_right().is_empty();
-                }
-            }
-            return Some(AssertionRange {
-                begin_char: index + if captures.get(2).is_some() { testtoken_start.len() + captures.get(2).unwrap().start() } else { 0 },
-                end_char: index + if captures.get(2).is_some() { testtoken_start.len() + captures.get(2).unwrap().end() } else { 1 },
-                scope_selector_text: sst,
-                is_pure_assertion_line: before_token_start.trim_left().is_empty() && only_whitespace_after_token_end, // if only whitespace surrounds the test tokens on the line, then it is a pure assertion line
-            });
-        }
-    }
-    None
-}
-
-fn process_assertions(assertion: &AssertionRange, test_against_line_scopes: &Vec<ScopedText>) -> Vec<RangeTestResult> {
-    // format the scope selector to include a space at the beginning, because, currently, ScopeSelector expects excludes to begin with " -"
-    // and they are sometimes in the syntax test as ^^^-comment, for example
-    let selector = ScopeSelectors::from_str(&format!(" {}", &assertion.scope_selector_text)).unwrap();
-    // find the scope at the specified start column, and start matching the selector through the rest of the tokens on the line from there until the end column is reached
-    let mut results = Vec::new();
-    for scoped_text in test_against_line_scopes.iter().skip_while(|s|s.char_start + s.text_len <= assertion.begin_char).take_while(|s|s.char_start < assertion.end_char) {
-        let match_value = selector.does_match(scoped_text.scope.as_slice());
-        let result = RangeTestResult {
-            column_begin: max(scoped_text.char_start, assertion.begin_char),
-            column_end: min(scoped_text.char_start + scoped_text.text_len, assertion.end_char),
-            success: match_value.is_some()
-        };
-        results.push(result);
-    }
-    // don't ignore assertions after the newline, they should be treated as though they are asserting against the newline
-    let last = test_against_line_scopes.last().unwrap();
-    if last.char_start + last.text_len < assertion.end_char {
-        let match_value = selector.does_match(last.scope.as_slice());
-        let result = RangeTestResult {
-            column_begin: max(last.char_start + last.text_len, assertion.begin_char),
-            column_end: assertion.end_char,
-            success: match_value.is_some()
-        };
-        results.push(result);
-    }
-    results
-}
-
-/// If `parse_test_lines` is `false` then lines that only contain assertions are not parsed
-fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool, out_opts: OutputOptions) -> Result<SyntaxTestFileResult, SyntaxTestHeaderError> {
-    use syntect::util::debug_print_ops;
+fn test_file(ss: &SyntaxSet, path: &Path, out_opts: SyntaxTestOutputOptions) -> Result<SyntaxTestFileResult, SyntaxTestHeaderError> {
     let f = File::open(path).unwrap();
     let mut reader = BufReader::new(f);
-    let mut line = String::new();
+    let mut header_line = String::new();
 
     // read the first line from the file - if we have reached EOF already, it's an invalid file
-    if reader.read_line(&mut line).unwrap() == 0 {
+    if reader.read_line(&mut header_line).unwrap() == 0 {
         return Err(SyntaxTestHeaderError::MalformedHeader);
     }
 
-    line = line.replace("\r", &"");
-
     // parse the syntax test header in the first line of the file
-    let header_line = line.clone();
     let search_result = SYNTAX_TEST_HEADER_PATTERN.captures(&header_line);
     let captures = search_result.ok_or(SyntaxTestHeaderError::MalformedHeader)?;
 
@@ -165,101 +63,19 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool, out_opts: Outp
 
     // find the relevant syntax definition to parse the file with - case is important!
     if !out_opts.summary {
-        println!("The test file references syntax definition file: {}", syntax_file);
+        println!("The test file references syntax definition file: {}", syntax_file); //" and the start test token is {} and the end token is {:?}", testtoken_start, testtoken_end);
     }
     let syntax = ss.find_syntax_by_path(syntax_file).ok_or(SyntaxTestHeaderError::SyntaxDefinitionNotFound)?;
 
-    // iterate over the lines of the file, testing them
-    let mut state = ParseState::new(syntax);
-    let mut stack = ScopeStack::new();
+    let mut contents = String::new();
+    contents.push_str(&header_line);
+    reader.read_to_string(&mut contents).expect("Unable to read file");
+    contents = contents.replace("\r", &"");
 
-    let mut current_line_number = 1;
-    let mut test_against_line_number = 1;
-    let mut scopes_on_line_being_tested = Vec::new();
-    let mut previous_non_assertion_line = line.to_string();
-
-    let mut assertion_failures: usize = 0;
-    let mut total_assertions: usize = 0;
-
-    loop { // over lines of file, starting with the header line
-        let mut line_only_has_assertion = false;
-        let mut line_has_assertion = false;
-        if let Some(assertion) = get_line_assertion_details(testtoken_start, testtoken_end, &line) {
-            let result = process_assertions(&assertion, &scopes_on_line_being_tested);
-            total_assertions += &assertion.end_char - &assertion.begin_char;
-            for failure in result.iter().filter(|r|!r.success) {
-                let length = failure.column_end - failure.column_begin;
-                let text: String = previous_non_assertion_line.chars().skip(failure.column_begin).take(length).collect();
-                if !out_opts.summary {
-                    println!("  Assertion selector {:?} \
-                        from line {:?} failed against line {:?}, column range {:?}-{:?} \
-                        (with text {:?}) \
-                        has scope {:?}",
-                        assertion.scope_selector_text.trim(),
-                        current_line_number, test_against_line_number, failure.column_begin, failure.column_end,
-                        text,
-                        scopes_on_line_being_tested.iter().skip_while(|s|s.char_start + s.text_len <= failure.column_begin).next().unwrap_or(scopes_on_line_being_tested.last().unwrap()).scope
-                    );
-                }
-                assertion_failures += failure.column_end - failure.column_begin;
-            }
-            line_only_has_assertion = assertion.is_pure_assertion_line;
-            line_has_assertion = true;
-        }
-        if !line_only_has_assertion || parse_test_lines {
-            if !line_has_assertion { // ST seems to ignore lines that have assertions when calculating which line the assertion tests against
-                scopes_on_line_being_tested.clear();
-                test_against_line_number = current_line_number;
-                previous_non_assertion_line = line.to_string();
-            }
-            if out_opts.debug && !line_only_has_assertion {
-                println!("-- debugging line {} -- scope stack: {:?}", current_line_number, stack);
-            }
-            let ops = state.parse_line(&line);
-            if out_opts.debug && !line_only_has_assertion {
-                if ops.is_empty() && !line.is_empty() {
-                    println!("no operations for this line...");
-                } else {
-                    debug_print_ops(&line, &ops);
-                }
-            }
-            let mut col: usize = 0;
-            for (s, op) in ScopeRegionIterator::new(&ops, &line) {
-                stack.apply(op);
-                if s.is_empty() { // in this case we don't care about blank tokens
-                    continue;
-                }
-                if !line_has_assertion {
-                    // if the line has no assertions on it, remember the scopes on the line so we can test against them later
-                    let len = s.chars().count();
-                    scopes_on_line_being_tested.push(
-                        ScopedText {
-                            char_start: col,
-                            text_len: len,
-                            scope: stack.as_slice().to_vec()
-                        }
-                    );
-                    // TODO: warn when there are duplicate adjacent (non-meta?) scopes, as it is almost always undesired
-                    col += len;
-                }
-            }
-        }
-
-        line.clear();
-        current_line_number += 1;
-        if reader.read_line(&mut line).unwrap() == 0 {
-            break;
-        }
-        line = line.replace("\r", &"");
-    }
-    let res = if assertion_failures > 0 {
-        Ok(SyntaxTestFileResult::FailedAssertions(assertion_failures, total_assertions))
-    } else {
-        Ok(SyntaxTestFileResult::Success(total_assertions))
-    };
+    let res = process_syntax_test_assertions(&syntax, &contents, testtoken_start, testtoken_end, &out_opts);
 
     if out_opts.summary {
-        if let Ok(SyntaxTestFileResult::FailedAssertions(failures, _)) = res {
+        if let SyntaxTestFileResult::FailedAssertions(failures, _) = res {
             // Don't print total assertion count so that diffs don't pick up new succeeding tests
             println!("FAILED {}: {}", path.display(), failures);
         }
@@ -267,7 +83,7 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool, out_opts: Outp
         println!("{:?}", res);
     }
 
-    res
+    Ok(res)
 }
 
 fn main() {
@@ -309,7 +125,7 @@ fn main() {
         ss.link_syntaxes();
     }
 
-    let out_opts = OutputOptions {
+    let out_opts = SyntaxTestOutputOptions {
         debug: matches.opt_present("debug"),
         time: matches.opt_present("time"),
         summary: matches.opt_present("summary"),
@@ -322,7 +138,7 @@ fn main() {
 }
 
 
-fn recursive_walk(ss: &SyntaxSet, path: &str, out_opts: OutputOptions) -> i32 {
+fn recursive_walk(ss: &SyntaxSet, path: &str, out_opts: SyntaxTestOutputOptions) -> i32 {
     let mut exit_code: i32 = 0; // exit with code 0 by default, if all tests pass
     let walker = WalkDir::new(path).into_iter();
 
@@ -341,7 +157,7 @@ fn recursive_walk(ss: &SyntaxSet, path: &str, out_opts: OutputOptions) -> i32 {
             println!("Testing file {}", path.display());
         }
         let start = Instant::now();
-        let result = test_file(&ss, path, true, out_opts);
+        let result = test_file(&ss, path, out_opts);
         let elapsed = start.elapsed();
         if out_opts.time {
             let ms = (elapsed.as_secs() * 1_000) + (elapsed.subsec_nanos() / 1_000_000) as u64;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -2,7 +2,7 @@
 //! files without caring about intermediate semantic representation
 //! and caching.
 
-use parsing::{ScopeStack, ParseState, SyntaxDefinition, SyntaxSet, ScopeStackOp};
+use parsing::{ScopeStack, ParseState, SyntaxDefinition, SyntaxSet, ScopeStackOp, Scope};
 use highlighting::{Highlighter, HighlightState, HighlightIterator, Theme, Style};
 use std::io::{self, BufReader};
 use std::fs::File;
@@ -172,6 +172,236 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
         self.index += 1;
         Some((substr, op))
     }
+}
+
+#[derive(Clone, Copy)]
+pub struct SyntaxTestOutputOptions {
+    pub time: bool,
+    pub debug: bool,
+    pub summary: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyntaxTestFileResult {
+    FailedAssertions(usize, usize),
+    Success(usize),
+}
+
+pub fn process_syntax_test_assertions(syntax: &SyntaxDefinition, text: &str, testtoken_start: &str, testtoken_end: Option<&str>, out_opts: &SyntaxTestOutputOptions) -> SyntaxTestFileResult {
+    use std::collections::VecDeque;
+    use highlighting::ScopeSelectors;
+
+    #[derive(Debug)]
+    struct SyntaxTestAssertionRange {
+        test_line_offset: usize,
+        line_number: usize,
+        begin_char: usize,
+        end_char: usize,
+        scope_selector: ScopeSelectors,
+        scope_selector_text: String,
+    }
+
+    fn get_syntax_test_assertions(token_start: &str, token_end: Option<&str>, text: &str) -> VecDeque<SyntaxTestAssertionRange> {
+        use std::str::FromStr;
+        
+        let mut assertions = VecDeque::new();
+        let mut test_line_offset = 0;
+        //let mut test_line_len = 0;
+        let mut line_number = 0;
+        let mut offset = 0;
+        //let mut remainder = None;
+        for line in text.lines() {
+            line_number += 1;
+            let mut line_has_assertions = false;
+            
+            // if the test start token specified is on the line
+            if let Some(index) = line.find(token_start) {
+                let token_and_rest_of_line = line.split_at(index).1;
+
+                let rest_of_line = &token_and_rest_of_line[token_start.len()..];
+                if let Some(assertion_index) = rest_of_line.find("<-").or_else(|| rest_of_line.find('^')) {
+                    let mut assertion_range = 0;
+                    while rest_of_line.chars().nth(assertion_index + assertion_range) == Some('^') {
+                        assertion_range += 1;
+                    }
+                    let skip_assertion_chars = if assertion_range == 0 { 2 } else { assertion_range };
+
+                    let mut selector_text : String = rest_of_line.chars().skip(assertion_index + skip_assertion_chars).collect(); // get the scope selector text
+
+                    if let Some(token) = token_end { // if there is an end token defined in the test file header
+                        if let Some(end_token_pos) = selector_text.find(token) { // and there is an end token in the line
+                            selector_text = selector_text.chars().take(end_token_pos).collect(); // the scope selector text ends at the end token
+                        }
+                    }
+
+                    let assertion = SyntaxTestAssertionRange {
+                        test_line_offset: test_line_offset,
+                        line_number: line_number,
+                        begin_char: index + if assertion_range > 0 { token_start.len() + assertion_index } else { 0 },
+                        end_char: index + if assertion_range > 0 { token_start.len() + assertion_index + assertion_range } else { 1 },
+
+                        // format the scope selector to include a space at the beginning, because, currently, ScopeSelector expects excludes to begin with " -"
+                        // and they are sometimes in the syntax test as ^^^-comment, for example
+                        scope_selector: ScopeSelectors::from_str(&format!(" {}", &selector_text)).expect(&format!("Scope selector invalid on line {}", line_number)),
+                        scope_selector_text: selector_text,
+                    };
+                    /*if assertion.end_char > test_line_len {
+                        remainder = Some(SyntaxTestAssertionRange {
+                            test_line_offset: test_line_offset + test_line_len,
+                            line_number: line_number,
+                            begin_char: assertion.begin_char - test_line_len,
+                            end_char: assertion.end_char - test_line_len,
+                            scope_selector: assertion.scope_selector.clone(),
+                            scope_selector_text: assertion.scope_selector_text.clone(),
+                        });
+                    }*/
+                    assertions.push_back(assertion);
+                    
+                    line_has_assertions = true;
+                }
+            }
+            if !line_has_assertions { // ST seems to ignore lines that have assertions when calculating which line the assertion tests against, regardless of whether they contain any other text
+                test_line_offset = offset;
+                //test_line_len = line.len() + 1;
+            }
+            offset += line.len() + 1; // the +1 is for the `\n`. TODO: maybe better to loop over the lines including the newline chars, using https://stackoverflow.com/a/40457615/4473405
+        }
+        assertions
+    }
+    
+    #[derive(Debug)]
+    struct ScopedText {
+        scope: Vec<Scope>,
+        char_start: usize,
+        text_len: usize,
+    }
+    
+    #[derive(Debug)]
+    struct RangeTestResult {
+        column_begin: usize,
+        column_end: usize,
+        success: bool,
+        actual_scope: String,
+    }
+    
+    fn process_assertions(assertion: &SyntaxTestAssertionRange, test_against_line_scopes: &Vec<ScopedText>) -> Vec<RangeTestResult> {
+        use std::cmp::{min, max};
+        // find the scope at the specified start column, and start matching the selector through the rest of the tokens on the line from there until the end column is reached
+        let mut results = Vec::new();
+        for scoped_text in test_against_line_scopes.iter().skip_while(|s|s.char_start + s.text_len <= assertion.begin_char).take_while(|s|s.char_start < assertion.end_char) {
+            let match_value = assertion.scope_selector.does_match(scoped_text.scope.as_slice());
+            let result = RangeTestResult {
+                column_begin: max(scoped_text.char_start, assertion.begin_char),
+                column_end: min(scoped_text.char_start + scoped_text.text_len, assertion.end_char),
+                success: match_value.is_some(),
+                actual_scope: format!("{:?}", scoped_text.scope.as_slice()),
+            };
+            results.push(result);
+        }
+        results
+    }
+    
+    let mut assertions = get_syntax_test_assertions(testtoken_start, testtoken_end, &text);
+    //println!("{:?}", assertions);
+    use util::debug_print_ops;
+    
+    // iterate over the lines of the file, testing them
+    let mut state = ParseState::new(syntax);
+    let mut stack = ScopeStack::new();
+
+    let mut offset = 0;
+    let mut scopes_on_line_being_tested = Vec::new();
+    let mut line_number = 0;
+    let mut relevant_assertions = Vec::new();
+    
+    let mut assertion_failures: usize = 0;
+    let mut total_assertions: usize = 0;
+
+    for line_without_char in text.lines() {
+        let line = &(line_without_char.to_owned() + "\n");
+        line_number += 1;
+        
+        let eol_offset = offset + line.len();
+        
+        // parse the line
+        let ops = state.parse_line(&line);
+        // find assertions that relate to the current line
+        relevant_assertions.clear();
+        while let Some(assertion) = assertions.pop_front() {
+            let pos = assertion.test_line_offset + assertion.begin_char;
+            if pos >= offset && pos < eol_offset {
+                relevant_assertions.push(assertion);
+            } else {
+                assertions.push_front(assertion);
+                break;
+            }
+        }
+        if !relevant_assertions.is_empty() {
+            scopes_on_line_being_tested.clear();
+            if out_opts.debug {
+                println!("-- debugging line {} -- scope stack: {:?}", line_number, stack);
+                if ops.is_empty() && !line.is_empty() {
+                    println!("no operations for this line...");
+                } else {
+                    debug_print_ops(&line, &ops);
+                }
+            }
+        }
+        
+        {
+            let mut col: usize = 0;
+            for (s, op) in ScopeRegionIterator::new(&ops, &line) {
+                stack.apply(op);
+                if s.is_empty() { // in this case we don't care about blank tokens
+                    continue;
+                }
+                if !relevant_assertions.is_empty() {
+                    let len = s.chars().count();
+                    scopes_on_line_being_tested.push(
+                        ScopedText {
+                            char_start: col,
+                            text_len: len,
+                            scope: stack.as_slice().to_vec()
+                        }
+                    );
+                    col += len;
+                }
+            }
+        }
+        
+        for assertion in &relevant_assertions {
+            let results = process_assertions(&assertion, &scopes_on_line_being_tested);
+            
+            for result in results {
+                let length = result.column_end - result.column_begin;
+                total_assertions += length;
+                if !result.success {
+                    assertion_failures += length;
+                    let text: String = line.chars().skip(result.column_begin).take(length).collect();
+                    if !out_opts.summary {
+                        println!("  Assertion selector {:?} \
+                            from line {:?} failed against line {:?}, column range {:?}-{:?} \
+                            (with text {:?}) \
+                            has scope {:?}",
+                            &assertion.scope_selector_text.trim(),
+                            &assertion.line_number, line_number, result.column_begin, result.column_end,
+                            text,
+                            result.actual_scope,
+                        );
+                    }
+                }
+            }
+        }
+        
+        offset = eol_offset;
+    }
+    
+    let res = if assertion_failures > 0 {
+        SyntaxTestFileResult::FailedAssertions(assertion_failures, total_assertions)
+    } else {
+        SyntaxTestFileResult::Success(total_assertions)
+    };
+    res
 }
 
 #[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]


### PR DESCRIPTION
this is an initial rework of the `syntest` example, to make it usable internally, as it would be useful for parser tests (see https://github.com/trishume/syntect/pull/180#discussion_r198685953). I think it will need some more work to properly support assertions that extend over the end of the line (https://github.com/trishume/syntect/issues/175) and spill over onto not only the next line, but also the line afterwards etc. although such a scenario may never come up in real life use.