### PR TITLE
Cache compiled regexes with lazycell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ onig = { version = "3.2.1", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "1.0"
+lazycell = "1.0"
 bitflags = "1.0"
 plist = "0.3"
 bincode = { version = "1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate walkdir;
 extern crate regex_syntax;
 #[macro_use]
 extern crate lazy_static;
+extern crate lazycell;
 extern crate plist;
 #[cfg(any(feature = "dump-load-rs", feature = "dump-load", feature = "dump-create"))]
 extern crate bincode;
@@ -42,6 +43,7 @@ extern crate serde_json;
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+
 pub mod highlighting;
 pub mod parsing;
 pub mod util;

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -399,15 +399,14 @@ impl SyntaxDefinition {
             None
         };
 
-        let pattern = MatchPattern {
-            has_captures: has_captures,
-            regex_str: regex_str,
-            regex: None,
-            scope: scope,
-            captures: captures,
-            operation: operation,
-            with_prototype: with_prototype,
-        };
+        let pattern = MatchPattern::new(
+            has_captures,
+            regex_str,
+            scope,
+            captures,
+            operation,
+            with_prototype,
+        );
 
         Ok(pattern)
     }


### PR DESCRIPTION
With that, `MatchPattern` does not have to be mutably borrowed to do matching anymore.

It removes one obstacle for allowing `SyntaxSet` to be used by multiple threads, while still keeping regex compilation lazy.

This is one of the prerequisites for #182. I've created the PR against master so that we can benchmark the impact more directly. But I can integrate it into #182 if you prefer to not put it into master just yet.