### PR TITLE
Store ContextId in ParseState instead of &Context

### DIFF
--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -12,10 +12,10 @@ use std::fs::File;
 use std::io::Read;
 
 fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> usize {
-    let mut h = HighlightLines::new(syntax_set, syntax, theme);
+    let mut h = HighlightLines::new(syntax, theme);
     let mut count = 0;
     for line in s.lines() {
-        let regions = h.highlight(line);
+        let regions = h.highlight(line, syntax_set);
         count += regions.len();
     }
     count

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -8,10 +8,10 @@ use std::io::Read;
 use syntect::parsing::{ParseState, SyntaxReference, SyntaxSet};
 
 fn do_parse(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference) -> usize {
-    let mut state = ParseState::new(ss, syntax);
+    let mut state = ParseState::new(syntax);
     let mut count = 0;
     for line in s.lines() {
-        let ops = state.parse_line(line);
+        let ops = state.parse_line(line, ss);
         count += ops.len();
     }
     count

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -49,7 +49,7 @@ fn main() {
             let mut highlighter = HighlightFile::new(filename, &syntax_set, theme).unwrap();
 
             for line in contents {
-                for region in highlighter.highlight_lines.highlight(line) {
+                for region in highlighter.highlight_lines.highlight(line, &syntax_set) {
                     regions.push(region);
                 }
             }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -109,7 +109,7 @@ fn main() {
                 }
 
                 {
-                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line);
+                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
                     print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
                 }
                 line.clear();

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -127,7 +127,7 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
         None => return
     };
     stats.files += 1;
-    let mut state = ParseState::new(&ss, syntax);
+    let mut state = ParseState::new(syntax);
 
     let f = File::open(path).unwrap();
     let mut reader = BufReader::new(f);
@@ -135,7 +135,7 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let mut stack = ScopeStack::new();
     while reader.read_line(&mut line).unwrap() > 0 {
         {
-            let ops = state.parse_line(&line);
+            let ops = state.parse_line(&line, &ss);
             stats.chars += line.len();
             count_line(&ops, &line, &mut stack, stats);
         }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -169,7 +169,7 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool, out_opts: Outp
     let syntax = ss.find_syntax_by_path(syntax_file).ok_or(SyntaxTestHeaderError::SyntaxDefinitionNotFound)?;
 
     // iterate over the lines of the file, testing them
-    let mut state = ParseState::new(&ss, syntax);
+    let mut state = ParseState::new(syntax);
     let mut stack = ScopeStack::new();
 
     let mut current_line_number = 1;
@@ -214,7 +214,7 @@ fn test_file(ss: &SyntaxSet, path: &Path, parse_test_lines: bool, out_opts: Outp
             if out_opts.debug && !line_only_has_assertion {
                 println!("-- debugging line {} -- scope stack: {:?}", current_line_number, stack);
             }
-            let ops = state.parse_line(&line);
+            let ops = state.parse_line(&line, &ss);
             if out_opts.debug && !line_only_has_assertion {
                 if ops.is_empty() && !line.is_empty() {
                     println!("no operations for this line...");

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -283,14 +283,14 @@ mod tests {
         let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
         let mut state = {
             let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
-            ParseState::new(&ps, syntax)
+            ParseState::new(syntax)
         };
         let ts = ThemeSet::load_defaults();
         let highlighter = Highlighter::new(&ts.themes["base16-ocean.dark"]);
 
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = "module Bob::Wow::Troll::Five; 5; end";
-        let ops = state.parse_line(line);
+        let ops = state.parse_line(line, &ps);
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str)> = iter.collect();
         // println!("{:#?}", regions);

--- a/src/html.rs
+++ b/src/html.rs
@@ -40,7 +40,7 @@ fn scope_to_classes(s: &mut String, scope: Scope, style: ClassStyle) {
 /// choice of `SyntaxSet` to accept, I'm not sure of it either, email me.
 pub fn highlighted_snippet_for_string(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> String {
     let mut output = String::new();
-    let mut highlighter = HighlightLines::new(ss, syntax, theme);
+    let mut highlighter = HighlightLines::new(syntax, theme);
     let c = theme.settings.background.unwrap_or(Color::WHITE);
     write!(output,
            "<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
@@ -49,7 +49,7 @@ pub fn highlighted_snippet_for_string(s: &str, ss: &SyntaxSet, syntax: &SyntaxRe
            c.b)
         .unwrap();
     for line in s.lines() {
-        let regions = highlighter.highlight(line);
+        let regions = highlighter.highlight(line, ss);
         let html = styles_to_coloured_html(&regions[..], IncludeBackground::IfDifferent(c));
         output.push_str(&html);
         output.push('\n');
@@ -81,7 +81,7 @@ pub fn highlighted_snippet_for_file<P: AsRef<Path>>(path: P,
         .unwrap();
     for maybe_line in highlighter.reader.lines() {
         let line = maybe_line?;
-        let regions = highlighter.highlight_lines.highlight(&line);
+        let regions = highlighter.highlight_lines.highlight(&line, ss);
         let html = styles_to_coloured_html(&regions[..], IncludeBackground::IfDifferent(c));
         output.push_str(&html);
         output.push('\n');
@@ -164,8 +164,8 @@ fn write_css_color(s: &mut String, c: Color) {
 /// let ts = ThemeSet::load_defaults();
 ///
 /// let syntax = ps.find_syntax_by_name("Ruby").unwrap();
-/// let mut h = HighlightLines::new(&ps, syntax, &ts.themes["base16-ocean.dark"]);
-/// let regions = h.highlight("5");
+/// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
+/// let regions = h.highlight("5", &ps);
 /// let html = styles_to_coloured_html(&regions[..], IncludeBackground::No);
 /// assert_eq!(html, "<span style=\"color:#d08770;\">5</span>");
 /// ```
@@ -243,9 +243,9 @@ mod tests {
     fn tokens() {
         let ss = SyntaxSet::load_defaults_nonewlines();
         let syntax = ss.find_syntax_by_name("Markdown").unwrap();
-        let mut state = ParseState::new(&ss, syntax);
+        let mut state = ParseState::new(syntax);
         let line = "[w](t.co) *hi* **five**";
-        let ops = state.parse_line(line);
+        let ops = state.parse_line(line, &ss);
 
         // use util::debug_print_ops;
         // debug_print_ops(line, &ops);


### PR DESCRIPTION
This means ParseState doesn't contain a reference to SyntaxSet anymore
and doesn't need a lifetime.

This makes it simpler for code that wants to cache it, but it also means
parse_line needs to be called with the SyntaxSet as an argument so that
it can look up contexts.