### PR TITLE
Update oniguruma

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
-onig = { version = "3.2.1", optional = true }
+onig = { version = "4.0.0", default-features = false, optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.4", optional = true }
 lazy_static = "1.0"


### PR DESCRIPTION
Disables oniguruma's feature of replacing POSIX regex APIs (https://github.com/rust-onig/rust-onig/pull/85) which make libgit2 crash when used in the same executable as syntect (https://github.com/libgit2/libgit2/issues/4738).