### PR TITLE
Rename methods on SyntaxSetBuilder

### DIFF
--- a/benches/loading.rs
+++ b/benches/loading.rs
@@ -25,16 +25,16 @@ fn bench_load_theme(b: &mut Bencher) {
     });
 }
 
-fn bench_load_syntaxes(b: &mut Bencher) {
+fn bench_load_from_folder(b: &mut Bencher) {
     b.iter(|| {
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_syntaxes("testdata/Packages", false).unwrap()
+        builder.load_from_folder("testdata/Packages", false).unwrap()
     });
 }
 
 fn bench_link_syntaxes(b: &mut Bencher) {
     let mut builder = SyntaxSetBuilder::new();
-    builder.load_syntaxes("testdata/Packages", false).unwrap();
+    builder.load_from_folder("testdata/Packages", false).unwrap();
     b.iter(|| {
         builder.clone().build();
     });
@@ -44,7 +44,7 @@ fn loading_benchmark(c: &mut Criterion) {
     c.bench_function("load_internal_dump", bench_load_internal_dump);
     c.bench_function("load_internal_themes", bench_load_internal_themes);
     c.bench_function("load_theme", bench_load_theme);
-    c.bench_function("load_syntaxes", bench_load_syntaxes);
+    c.bench_function("load_from_folder", bench_load_from_folder);
     c.bench_function("link_syntaxes", bench_link_syntaxes);
 }
 

--- a/examples/gendata.rs
+++ b/examples/gendata.rs
@@ -23,14 +23,14 @@ fn main() {
          Some(ref packpath_newlines),
          Some(ref packpath_nonewlines)) if cmd == "synpack" => {
             let mut builder = SyntaxSetBuilder::new();
-            builder.load_plain_text_syntax();
-            builder.load_syntaxes(package_dir, true).unwrap();
+            builder.add_plain_text_syntax();
+            builder.load_from_folder(package_dir, true).unwrap();
             let ss = builder.build();
             dump_to_file(&ss, packpath_newlines).unwrap();
 
             let mut builder_nonewlines = SyntaxSetBuilder::new();
-            builder_nonewlines.load_plain_text_syntax();
-            builder_nonewlines.load_syntaxes(package_dir, false).unwrap();
+            builder_nonewlines.add_plain_text_syntax();
+            builder_nonewlines.load_from_folder(package_dir, false).unwrap();
             let ss_nonewlines = builder_nonewlines.build();
             dump_to_file(&ss_nonewlines, packpath_nonewlines).unwrap();
         }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -59,7 +59,7 @@ fn main() {
     if let Some(folder) = matches.opt_str("extra-syntaxes") {
         // TODO: no way to go back to builder anymore :/
         let mut builder = ss.into_builder();
-        builder.load_syntaxes(folder, !no_newlines).unwrap();
+        builder.load_from_folder(folder, !no_newlines).unwrap();
         ss = builder.build();
     }
 
@@ -100,7 +100,7 @@ fn main() {
 
             // We use read_line instead of `for line in highlighter.reader.lines()` because that
             // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
-            // See the documentation for `SyntaxSet::load_syntaxes`.
+            // See the documentation for `SyntaxSetBuilder::load_from_folder`.
             // It also allows re-using the line buffer, which should be a tiny bit faster.
             let mut line = String::new();
             while highlighter.reader.read_line(&mut line).unwrap() > 0 {

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -305,7 +305,7 @@ fn main() {
     if !syntaxes_path.is_empty() {
         println!("loading syntax definitions from {}", syntaxes_path);
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_syntaxes(&syntaxes_path, true).unwrap(); // note that we load the version with newlines
+        builder.load_from_folder(&syntaxes_path, true).unwrap(); // note that we load the version with newlines
         ss = builder.build();
     }
 

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -85,7 +85,7 @@ impl SyntaxSet {
     ///
     /// This method loads the version for parsing line strings with no `\n` characters at the end.
     /// If you're able to efficiently include newlines at the end of strings, use `load_defaults_newlines`
-    /// since it works better. See `SyntaxSet#load_syntaxes` for more info on this issue.
+    /// since it works better. See `SyntaxSetBuilder::load_from_folder` for more info on this issue.
     ///
     /// This is the recommended way of creating a syntax set for
     /// non-advanced use cases. It is also significantly faster than loading the YAML files.
@@ -129,7 +129,7 @@ mod tests {
         use super::*;
         use parsing::SyntaxSetBuilder;
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_syntaxes("testdata/Packages", false).unwrap();
+        builder.load_from_folder("testdata/Packages", false).unwrap();
         let ss = builder.build();
 
         let bin = dump_binary(&ss);
@@ -145,12 +145,12 @@ mod tests {
         use parsing::SyntaxSetBuilder;
 
         let mut builder1 = SyntaxSetBuilder::new();
-        builder1.load_syntaxes("testdata/Packages", false).unwrap();
+        builder1.load_from_folder("testdata/Packages", false).unwrap();
         let ss1 = builder1.build();
         let bin1 = dump_binary(&ss1);
 
         let mut builder2 = SyntaxSetBuilder::new();
-        builder2.load_syntaxes("testdata/Packages", false).unwrap();
+        builder2.load_from_folder("testdata/Packages", false).unwrap();
         let ss2 = builder2.build();
         let bin2 = dump_binary(&ss2);
         // This is redundant, but assert_eq! can be really slow on a large

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1398,7 +1398,7 @@ contexts:
         // check that each expected scope stack appears at least once while parsing the given test line
 
         let mut builder = SyntaxSetBuilder::new();
-        builder.add_syntax(syntax);
+        builder.add(syntax);
         let syntax_set = builder.build();
 
         let mut state = ParseState::new(&syntax_set.syntaxes()[0]);
@@ -1424,7 +1424,7 @@ contexts:
     fn parse(line: &str, syntax: &str) -> Vec<(usize, ScopeStackOp)> {
         let syntax = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         let mut builder = SyntaxSetBuilder::new();
-        builder.add_syntax(syntax);
+        builder.add(syntax);
         let syntax_set = builder.build();
 
         let mut state = ParseState::new(&syntax_set.syntaxes()[0]);


### PR DESCRIPTION
While we're breaking API anyway, I think this makes them a bit clearer:

* `add_syntax` -> `add`
* `load_syntaxes` -> `load_from_folder`
* `load_plain_text_syntax` -> `add_plain_text_syntax`