### PR TITLE
Add helpers for modifying highlighted lines

### DIFF
--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -82,6 +82,16 @@ impl Style {
     }
 }
 
+impl Default for Style {
+    fn default() -> Style {
+        Style {
+            foreground: Color::BLACK,
+            background: Color::WHITE,
+            font_style: FontStyle::empty(),
+        }
+    }
+}
+
 impl StyleModifier {
     /// Applies the other modifier to this one, creating a new modifier.
     /// Values in `other` are preferred.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
-//! Convenient utility methods, mostly for printing `syntect` data structures
-//! prettily to the terminal.
+//! Convenient helper functions for common use cases:
+//! printing to terminal, iterating lines with `\n`s, modifying ranges of highlighted output
 use highlighting::{Style, StyleModifier};
 use std::fmt::Write;
 use std::ops::Range;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,8 @@
 //! Convenient utility methods, mostly for printing `syntect` data structures
 //! prettily to the terminal.
-use highlighting::Style;
+use highlighting::{Style, StyleModifier};
 use std::fmt::Write;
+use std::ops::Range;
 #[cfg(feature = "parsing")]
 use parsing::ScopeStackOp;
 
@@ -112,6 +113,66 @@ impl<'a> Iterator for LinesWithEndings<'a> {
     }
 }
 
+/// Split a highlighted line at a byte index in the line into a before and
+/// after component. It's just a helper that does the somewhat tricky logic
+/// including splitting a span if the index lies on a boundary.
+///
+/// This can be used to extract a chunk of the line out for special treatment
+/// like wrapping it in an HTML tag for extra styling.
+///
+/// Generic for testing purposes and fancier use cases, but intended for use with
+/// the `Vec<(Style, &str)>` returned by `highlight` methods. Look at the source
+/// code for `modify_range` for an example usage.
+pub fn split_at<'a, A: Clone>(mut v: &[(A, &'a str)], mut split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
+  // Consume all tokens before the split
+  let mut before = Vec::new();
+  for tok in v {
+    if tok.1.len() > split_i {
+      break;
+    }
+    before.push(tok.clone());
+    split_i -= tok.1.len();
+  }
+  v = &v[before.len()..];
+
+  let mut after = Vec::new();
+  // If necessary, split the token the split falls inside
+  if v.len() > 0 && split_i > 0 {
+    let (sa, sb) = v[0].1.split_at(split_i);
+    before.push((v[0].0.clone(), sa));
+    after.push((v[0].0.clone(), sb));
+    v = &v[1..];
+  }
+
+  after.extend_from_slice(v);
+
+  return (before, after);
+}
+
+/// Modify part of a highlighted line using a style modifier, useful for highlighting sections of a line.
+///
+/// # Examples
+///
+/// ```
+/// use syntect::util::modify_range;
+/// use syntect::highlighting::{Style, StyleModifier, FontStyle};
+///
+/// let plain = Style::default();
+/// let boldmod = StyleModifier { foreground: None, background: None, font_style: Some(FontStyle::BOLD) };
+/// let bold = plain.apply(boldmod);
+///
+/// let l = &[(plain, "abc"), (plain, "def"), (plain, "ghi")];
+/// let l2 = modify_range(l, 1..6, boldmod);
+/// assert_eq!(l2, &[(plain, "a"), (bold, "bc"), (bold, "def"), (plain, "ghi")]);
+/// ```
+pub fn modify_range<'a>(v: &[(Style, &'a str)], r: Range<usize>, modifier: StyleModifier) -> Vec<(Style, &'a str)> {
+  let (mut result, in_and_after) = split_at(v, r.start);
+  let (inside, mut after) = split_at(&in_and_after, r.end - r.start);
+
+  result.extend(inside.iter().map(|(style, s)| { (style.apply(modifier), *s)}));
+  result.append(&mut after);
+  result
+}
 
 #[cfg(test)]
 mod tests {
@@ -133,5 +194,29 @@ mod tests {
         assert_eq!(lines("foo\r\nbar\r\n"), vec!["foo\r\n", "bar\r\n"]);
         assert_eq!(lines("\nfoo"), vec!["\n", "foo"]);
         assert_eq!(lines("\n\n\n"), vec!["\n", "\n", "\n"]);
+    }
+
+    #[test]
+    fn test_split_at() {
+      let l: &[(u8, &str)] = &[];
+      let (before, after) = split_at(l, 0); // empty
+      assert_eq!((&before[..], &after[..]), (&[][..],&[][..]));
+
+      let l = &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")];
+
+      let (before, after) = split_at(l, 0); // at start
+      assert_eq!((&before[..], &after[..]), (&[][..],&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..]));
+
+      let (before, after) = split_at(l, 4); // inside token
+      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "d")][..],&[(1u8, "ef"), (2u8, "ghi")][..]));
+
+      let (before, after) = split_at(l, 3); // between tokens
+      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc")][..],&[(1u8, "def"), (2u8, "ghi")][..]));
+
+      let (before, after) = split_at(l, 9); // just after last token
+      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
+
+      let (before, after) = split_at(l, 10); // out of bounds
+      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,29 +124,29 @@ impl<'a> Iterator for LinesWithEndings<'a> {
 /// the `Vec<(Style, &str)>` returned by `highlight` methods. Look at the source
 /// code for `modify_range` for an example usage.
 pub fn split_at<'a, A: Clone>(mut v: &[(A, &'a str)], mut split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
-  // Consume all tokens before the split
-  let mut before = Vec::new();
-  for tok in v {
-    if tok.1.len() > split_i {
-      break;
+    // Consume all tokens before the split
+    let mut before = Vec::new();
+    for tok in v {
+        if tok.1.len() > split_i {
+            break;
+        }
+        before.push(tok.clone());
+        split_i -= tok.1.len();
     }
-    before.push(tok.clone());
-    split_i -= tok.1.len();
-  }
-  v = &v[before.len()..];
+    v = &v[before.len()..];
 
-  let mut after = Vec::new();
-  // If necessary, split the token the split falls inside
-  if v.len() > 0 && split_i > 0 {
-    let (sa, sb) = v[0].1.split_at(split_i);
-    before.push((v[0].0.clone(), sa));
-    after.push((v[0].0.clone(), sb));
-    v = &v[1..];
-  }
+    let mut after = Vec::new();
+    // If necessary, split the token the split falls inside
+    if v.len() > 0 && split_i > 0 {
+        let (sa, sb) = v[0].1.split_at(split_i);
+        before.push((v[0].0.clone(), sa));
+        after.push((v[0].0.clone(), sb));
+        v = &v[1..];
+    }
 
-  after.extend_from_slice(v);
+    after.extend_from_slice(v);
 
-  return (before, after);
+    return (before, after);
 }
 
 /// Modify part of a highlighted line using a style modifier, useful for highlighting sections of a line.
@@ -166,12 +166,12 @@ pub fn split_at<'a, A: Clone>(mut v: &[(A, &'a str)], mut split_i: usize) -> (Ve
 /// assert_eq!(l2, &[(plain, "a"), (bold, "bc"), (bold, "def"), (plain, "ghi")]);
 /// ```
 pub fn modify_range<'a>(v: &[(Style, &'a str)], r: Range<usize>, modifier: StyleModifier) -> Vec<(Style, &'a str)> {
-  let (mut result, in_and_after) = split_at(v, r.start);
-  let (inside, mut after) = split_at(&in_and_after, r.end - r.start);
+    let (mut result, in_and_after) = split_at(v, r.start);
+    let (inside, mut after) = split_at(&in_and_after, r.end - r.start);
 
-  result.extend(inside.iter().map(|(style, s)| { (style.apply(modifier), *s)}));
-  result.append(&mut after);
-  result
+    result.extend(inside.iter().map(|(style, s)| { (style.apply(modifier), *s)}));
+    result.append(&mut after);
+    result
 }
 
 #[cfg(test)]
@@ -198,25 +198,25 @@ mod tests {
 
     #[test]
     fn test_split_at() {
-      let l: &[(u8, &str)] = &[];
-      let (before, after) = split_at(l, 0); // empty
-      assert_eq!((&before[..], &after[..]), (&[][..],&[][..]));
+        let l: &[(u8, &str)] = &[];
+        let (before, after) = split_at(l, 0); // empty
+        assert_eq!((&before[..], &after[..]), (&[][..],&[][..]));
 
-      let l = &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")];
+        let l = &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")];
 
-      let (before, after) = split_at(l, 0); // at start
-      assert_eq!((&before[..], &after[..]), (&[][..],&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..]));
+        let (before, after) = split_at(l, 0); // at start
+        assert_eq!((&before[..], &after[..]), (&[][..],&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..]));
 
-      let (before, after) = split_at(l, 4); // inside token
-      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "d")][..],&[(1u8, "ef"), (2u8, "ghi")][..]));
+        let (before, after) = split_at(l, 4); // inside token
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "d")][..],&[(1u8, "ef"), (2u8, "ghi")][..]));
 
-      let (before, after) = split_at(l, 3); // between tokens
-      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc")][..],&[(1u8, "def"), (2u8, "ghi")][..]));
+        let (before, after) = split_at(l, 3); // between tokens
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc")][..],&[(1u8, "def"), (2u8, "ghi")][..]));
 
-      let (before, after) = split_at(l, 9); // just after last token
-      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
+        let (before, after) = split_at(l, 9); // just after last token
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
 
-      let (before, after) = split_at(l, 10); // out of bounds
-      assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
+        let (before, after) = split_at(l, 10); // out of bounds
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -123,28 +123,32 @@ impl<'a> Iterator for LinesWithEndings<'a> {
 /// Generic for testing purposes and fancier use cases, but intended for use with
 /// the `Vec<(Style, &str)>` returned by `highlight` methods. Look at the source
 /// code for `modify_range` for an example usage.
-pub fn split_at<'a, A: Clone>(mut v: &[(A, &'a str)], mut split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
+pub fn split_at<'a, A: Clone>(v: &[(A, &'a str)], split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
+    // This function works by gradually reducing the problem into smaller sub-problems from the front
+    let mut rest = v;
+    let mut rest_split_i = split_i;
+
     // Consume all tokens before the split
     let mut before = Vec::new();
-    for tok in v {
-        if tok.1.len() > split_i {
+    for tok in rest { // Use for instead of a while to avoid bounds checks
+        if tok.1.len() > rest_split_i {
             break;
         }
         before.push(tok.clone());
-        split_i -= tok.1.len();
+        rest_split_i -= tok.1.len();
     }
-    v = &v[before.len()..];
+    rest = &rest[before.len()..];
 
     let mut after = Vec::new();
     // If necessary, split the token the split falls inside
-    if v.len() > 0 && split_i > 0 {
-        let (sa, sb) = v[0].1.split_at(split_i);
-        before.push((v[0].0.clone(), sa));
-        after.push((v[0].0.clone(), sb));
-        v = &v[1..];
+    if rest.len() > 0 && rest_split_i > 0 {
+        let (sa, sb) = rest[0].1.split_at(rest_split_i);
+        before.push((rest[0].0.clone(), sa));
+        after.push((rest[0].0.clone(), sb));
+        rest = &rest[1..];
     }
 
-    after.extend_from_slice(v);
+    after.extend_from_slice(rest);
 
     return (before, after);
 }


### PR DESCRIPTION
Based on use cases from syntect users, modifying the style of some part of the
highlighted source, most frequently changing the background colour to draw
attention, is a common use case. Implementing it well requires some logic that
we can provide a well-tested high quality implementation of.

See https://github.com/oli-obk/priroda/issues/9 and https://github.com/Keats/gutenberg/issues/127 for examples of use cases for this feature.