### PR TITLE
 Add filename to ParseSyntax error & update dumps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub enum LoadingError {
     Io(IoError),
     /// a syntax file was invalid in some way
     #[cfg(feature = "yaml-load")]
-    ParseSyntax(ParseSyntaxError),
+    ParseSyntax(ParseSyntaxError, Option<String>),
     /// a theme file was invalid in some way
     ParseTheme(ParseThemeError),
     /// a theme's Plist syntax was invalid in some way
@@ -105,7 +105,7 @@ impl From<ParseThemeError> for LoadingError {
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 impl From<ParseSyntaxError> for LoadingError {
     fn from(error: ParseSyntaxError) -> LoadingError {
-        LoadingError::ParseSyntax(error)
+        LoadingError::ParseSyntax(error, None)
     }
 }
 
@@ -117,7 +117,13 @@ impl fmt::Display for LoadingError {
             WalkDir(ref error) => error.fmt(f),
             Io(ref error) => error.fmt(f),
             #[cfg(feature = "yaml-load")]
-            ParseSyntax(ref error) => error.fmt(f),
+            ParseSyntax(ref error, ref filename) => {
+                if let Some(ref file) = filename {
+                    write!(f, "{}: {}", file, error.description())
+                } else {
+                    error.fmt(f)
+                }
+            },
             _ => write!(f, "{}", self.description()),
         }
     }
@@ -131,7 +137,7 @@ impl Error for LoadingError {
             WalkDir(ref error) => error.description(),
             Io(ref error) => error.description(),
             #[cfg(feature = "yaml-load")]
-            ParseSyntax(ref error) => error.description(),
+            ParseSyntax(ref error, ..) => error.description(),
             ParseTheme(_) => "Invalid syntax theme",
             ReadSettings(_) => "Invalid syntax theme settings",
             BadPath => "Invalid path",

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -67,7 +67,13 @@ fn load_syntax_file(p: &Path,
     let mut s = String::new();
     f.read_to_string(&mut s)?;
 
-    Ok(SyntaxDefinition::load_from_str(&s, lines_include_newline, p.file_stem().and_then(|x| x.to_str()))?)
+    Ok(
+        SyntaxDefinition::load_from_str(
+            &s,
+            lines_include_newline,
+            p.file_stem().and_then(|x| x.to_str())
+        ).map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))?
+    )
 }
 
 impl Clone for SyntaxSet {


### PR DESCRIPTION
When loading from a folder with dozens of syntaxes, it's nice to know immediately which one failed loading