### PR TITLE
Add `ThemeSet::load_themes` method

### DIFF
--- a/benches/loading.rs
+++ b/benches/loading.rs
@@ -25,16 +25,16 @@ fn bench_load_theme(b: &mut Bencher) {
     });
 }
 
-fn bench_load_from_folder(b: &mut Bencher) {
+fn bench_add_from_folder(b: &mut Bencher) {
     b.iter(|| {
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_from_folder("testdata/Packages", false).unwrap()
+        builder.add_from_folder("testdata/Packages", false).unwrap()
     });
 }
 
 fn bench_link_syntaxes(b: &mut Bencher) {
     let mut builder = SyntaxSetBuilder::new();
-    builder.load_from_folder("testdata/Packages", false).unwrap();
+    builder.add_from_folder("testdata/Packages", false).unwrap();
     b.iter(|| {
         builder.clone().build();
     });
@@ -44,7 +44,7 @@ fn loading_benchmark(c: &mut Criterion) {
     c.bench_function("load_internal_dump", bench_load_internal_dump);
     c.bench_function("load_internal_themes", bench_load_internal_themes);
     c.bench_function("load_theme", bench_load_theme);
-    c.bench_function("load_from_folder", bench_load_from_folder);
+    c.bench_function("add_from_folder", bench_add_from_folder);
     c.bench_function("link_syntaxes", bench_link_syntaxes);
 }
 

--- a/examples/gendata.rs
+++ b/examples/gendata.rs
@@ -24,13 +24,13 @@ fn main() {
          Some(ref packpath_nonewlines)) if cmd == "synpack" => {
             let mut builder = SyntaxSetBuilder::new();
             builder.add_plain_text_syntax();
-            builder.load_from_folder(package_dir, true).unwrap();
+            builder.add_from_folder(package_dir, true).unwrap();
             let ss = builder.build();
             dump_to_file(&ss, packpath_newlines).unwrap();
 
             let mut builder_nonewlines = SyntaxSetBuilder::new();
             builder_nonewlines.add_plain_text_syntax();
-            builder_nonewlines.load_from_folder(package_dir, false).unwrap();
+            builder_nonewlines.add_from_folder(package_dir, false).unwrap();
             let ss_nonewlines = builder_nonewlines.build();
             dump_to_file(&ss_nonewlines, packpath_nonewlines).unwrap();
         }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -59,7 +59,7 @@ fn main() {
     if let Some(folder) = matches.opt_str("extra-syntaxes") {
         // TODO: no way to go back to builder anymore :/
         let mut builder = ss.into_builder();
-        builder.load_from_folder(folder, !no_newlines).unwrap();
+        builder.add_from_folder(folder, !no_newlines).unwrap();
         ss = builder.build();
     }
 
@@ -100,7 +100,7 @@ fn main() {
 
             // We use read_line instead of `for line in highlighter.reader.lines()` because that
             // doesn't return strings with a `\n`, and including the `\n` gets us more robust highlighting.
-            // See the documentation for `SyntaxSetBuilder::load_from_folder`.
+            // See the documentation for `SyntaxSetBuilder::add_from_folder`.
             // It also allows re-using the line buffer, which should be a tiny bit faster.
             let mut line = String::new();
             while highlighter.reader.read_line(&mut line).unwrap() > 0 {

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -305,7 +305,7 @@ fn main() {
     if !syntaxes_path.is_empty() {
         println!("loading syntax definitions from {}", syntaxes_path);
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_from_folder(&syntaxes_path, true).unwrap(); // note that we load the version with newlines
+        builder.add_from_folder(&syntaxes_path, true).unwrap(); // note that we load the version with newlines
         ss = builder.build();
     }
 

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -85,7 +85,7 @@ impl SyntaxSet {
     ///
     /// This method loads the version for parsing line strings with no `\n` characters at the end.
     /// If you're able to efficiently include newlines at the end of strings, use `load_defaults_newlines`
-    /// since it works better. See `SyntaxSetBuilder::load_from_folder` for more info on this issue.
+    /// since it works better. See `SyntaxSetBuilder::add_from_folder` for more info on this issue.
     ///
     /// This is the recommended way of creating a syntax set for
     /// non-advanced use cases. It is also significantly faster than loading the YAML files.
@@ -129,7 +129,7 @@ mod tests {
         use super::*;
         use parsing::SyntaxSetBuilder;
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_from_folder("testdata/Packages", false).unwrap();
+        builder.add_from_folder("testdata/Packages", false).unwrap();
         let ss = builder.build();
 
         let bin = dump_binary(&ss);
@@ -145,12 +145,12 @@ mod tests {
         use parsing::SyntaxSetBuilder;
 
         let mut builder1 = SyntaxSetBuilder::new();
-        builder1.load_from_folder("testdata/Packages", false).unwrap();
+        builder1.add_from_folder("testdata/Packages", false).unwrap();
         let ss1 = builder1.build();
         let bin1 = dump_binary(&ss1);
 
         let mut builder2 = SyntaxSetBuilder::new();
-        builder2.load_from_folder("testdata/Packages", false).unwrap();
+        builder2.add_from_folder("testdata/Packages", false).unwrap();
         let ss2 = builder2.build();
         let bin2 = dump_binary(&ss2);
         // This is redundant, but assert_eq! can be really slow on a large

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -46,12 +46,12 @@ impl ThemeSet {
     /// Generate a `ThemeSet` from all themes in a folder
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<ThemeSet, LoadingError> {
         let mut theme_set = Self::new();
-        theme_set.load_themes(folder)?;
+        theme_set.add_from_folder(folder)?;
         Ok(theme_set)
     }
 
     /// Load all the themes in the folder into this `ThemeSet`
-    pub fn load_themes<P: AsRef<Path>>(&mut self, folder: P) -> Result<(), LoadingError> {
+    pub fn add_from_folder<P: AsRef<Path>>(&mut self, folder: P) -> Result<(), LoadingError> {
         let paths = Self::discover_theme_paths(folder)?;
         for p in &paths {
             let theme = Self::get_theme(p)?;

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -14,6 +14,11 @@ pub struct ThemeSet {
 
 /// A set of themes, includes convenient methods for loading and discovering themes.
 impl ThemeSet {
+    /// Creates an empty set
+    pub fn new() -> ThemeSet {
+        ThemeSet { themes: BTreeMap::new() }
+    }
+
     /// Returns all the themes found in a folder, good for enumerating before loading one with get_theme
     pub fn discover_theme_paths<P: AsRef<Path>>(folder: P) -> Result<Vec<PathBuf>, LoadingError> {
         let mut themes = Vec::new();
@@ -38,17 +43,24 @@ impl ThemeSet {
         Ok(Theme::parse_settings(read_plist(r)?)?)
     }
 
-    /// Loads all the themes in a folder
+    /// Generate a `ThemeSet` from all themes in a folder
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<ThemeSet, LoadingError> {
+        let mut theme_set = Self::new();
+        theme_set.load_themes(folder)?;
+        Ok(theme_set)
+    }
+
+    /// Load all the themes in the folder into this `ThemeSet`
+    pub fn load_themes<P: AsRef<Path>>(&mut self, folder: P) -> Result<(), LoadingError> {
         let paths = Self::discover_theme_paths(folder)?;
-        let mut map = BTreeMap::new();
         for p in &paths {
             let theme = Self::get_theme(p)?;
             let basename =
                 p.file_stem().and_then(|x| x.to_str()).ok_or(LoadingError::BadPath)?;
-            map.insert(basename.to_owned(), theme);
+            self.themes.insert(basename.to_owned(), theme);
         }
-        Ok(ThemeSet { themes: map })
+
+        Ok(())
     }
 }
 
@@ -60,6 +72,8 @@ mod tests {
     fn can_parse_common_themes() {
         let themes = ThemeSet::load_from_folder("testdata").unwrap();
         let all_themes: Vec<&str> = themes.themes.keys().map(|x| &**x).collect();
+        assert!(all_themes.contains(&"base16-ocean.dark"));
+
         println!("{:?}", all_themes);
 
         let theme = ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme").unwrap();

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -103,12 +103,12 @@ impl SyntaxSet {
     /// definitions from a folder and then building the syntax set.
     ///
     /// Note that this uses `lines_include_newline` set to `false`, see the
-    /// `load_from_folder` method docs on `SyntaxSetBuilder` for an explanation
+    /// `add_from_folder` method docs on `SyntaxSetBuilder` for an explanation
     /// as to why this might not be the best.
     #[cfg(feature = "yaml-load")]
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<SyntaxSet, LoadingError> {
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_from_folder(folder, false)?;
+        builder.add_from_folder(folder, false)?;
         Ok(builder.build())
     }
 
@@ -322,7 +322,7 @@ impl SyntaxSetBuilder {
     /// In the future I might include a "slow mode" that copies the lines passed in and appends a newline if there isn't one.
     /// but in the interest of performance currently this hacky fix will have to do.
     #[cfg(feature = "yaml-load")]
-    pub fn load_from_folder<P: AsRef<Path>>(
+    pub fn add_from_folder<P: AsRef<Path>>(
         &mut self,
         folder: P,
         lines_include_newline: bool
@@ -592,7 +592,7 @@ mod tests {
     #[test]
     fn can_load() {
         let mut builder = SyntaxSetBuilder::new();
-        builder.load_from_folder("testdata/Packages", false).unwrap();
+        builder.add_from_folder("testdata/Packages", false).unwrap();
 
         let cmake_dummy_syntax = SyntaxDefinition {
             name: "CMake".to_string(),


### PR DESCRIPTION
This adds a new `ThemeSet::load_themes` method (in analogy to `SyntaxSet::load_syntaxes`) which can be used to extend an existing `ThemeSet` by loading all files from a given folder into the set.

It also adds a `ThemeSet::new` function to make it possible to start from an empty set.


It is possible to [implement these methods](https://github.com/sharkdp/bat/blob/052425b12f79aa42b1ca6453725b501be87dcc8d/src/assets.rs#L197-L209) without adding them to syntect (because everything in `ThemeSet` is public), but I thought these methods might be useful for others.