### PR TITLE
support incremental styles from multiple matching scope selectors

### DIFF
--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -198,7 +198,7 @@ impl<'a> Highlighter<'a> {
                     .map(|score| (score, item))
             })
             .collect();
-        matching_items.sort_unstable_by_key(|&(score, _)| score);
+        matching_items.sort_by_key(|&(score, _)| score);
         let sorted = matching_items.iter()
             .map(|(_, item)| item);
         let mut modifier = StyleModifier {

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -207,17 +207,7 @@ impl<'a> Highlighter<'a> {
             font_style: None,
         };
         for item in sorted {
-            if item.style.background.is_some() {
-                modifier.background = item.style.background;
-            }
-            if item.style.foreground.is_some() {
-                modifier.foreground = item.style.foreground;
-            }
-            if let Some(apply_style) = item.style.font_style {
-                let mut font_style = modifier.font_style.unwrap_or_else(||FontStyle::default());
-                font_style.insert(apply_style);
-                modifier.font_style = Some(font_style);
-            }
+            modifier = modifier.apply(item.style);
         }
         return modifier;
     }
@@ -334,10 +324,7 @@ mod tests {
         use parsing::ScopeStack;
         use std::str::FromStr;
         use highlighting::{ThemeSettings, ScopeSelectors};
-        
-        let mut bold_and_italic = FontStyle::BOLD;
-        bold_and_italic.insert(FontStyle::ITALIC);
-        
+
         let test_color_scheme = Theme {
             name: None,
             author: None,
@@ -394,7 +381,7 @@ mod tests {
                            b: 64,
                            a: 0xFF,
                        },
-                       font_style: bold_and_italic,
+                       font_style: FontStyle::BOLD,
                    });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/trishume/syntect/issues/133 by applying all the `StyleModifier` matches in score order, lowest to highest, so that higher scored styles override the lower scoring ones.

This hopefully shouldn't have too much of a performance impact because color schemes don't often have multiple scope selector rules that match a single scope stack. However, if we need to, we potentially could improve the speed by iterating over the `ThemeItem` matches from highest score to lowest, and stop once all (relevant) `StyleModifier` fields have been populated. This would avoid applying styles which would later be overridden anyway.