### PR TITLE
Use newlines syntaxes in HTML and docs, fixes #196

### DIFF
--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -7,6 +7,7 @@ use criterion::{Bencher, Criterion};
 use syntect::parsing::{SyntaxSet, SyntaxReference, ScopeStack};
 use syntect::highlighting::{ThemeSet, Theme};
 use syntect::easy::HighlightLines;
+use syntect::html::highlighted_html_for_string;
 use std::str::FromStr;
 use std::fs::File;
 use std::io::Read;
@@ -56,8 +57,24 @@ fn stack_matching(b: &mut Bencher) {
     });
 }
 
+fn highlight_html(b: &mut Bencher) {
+    let ss = SyntaxSet::load_defaults_newlines();
+    let ts = ThemeSet::load_defaults();
+
+    let path = "testdata/parser.rs";
+    let syntax = ss.find_syntax_for_file(path).unwrap().unwrap();
+    let mut f = File::open(path).unwrap();
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+
+    b.iter(|| {
+        highlighted_html_for_string(&s, &ss, syntax, &ts.themes["base16-ocean.dark"])
+    });
+}
+
 fn highlighting_benchmark(c: &mut Criterion) {
     c.bench_function("stack_matching", stack_matching);
+    c.bench_function("highlight_html", highlight_html);
     c.bench_function_over_inputs(
         "highlight",
         |b, s| highlight_file(b, s),

--- a/examples/synhtml.rs
+++ b/examples/synhtml.rs
@@ -1,12 +1,12 @@
 //! Prints highlighted HTML for a file to stdout.
-//! Basically just wraps a body around `highlighted_snippet_for_file`
+//! Basically just wraps a body around `highlighted_html_for_file`
 extern crate syntect;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{Color, ThemeSet};
-use syntect::html::highlighted_snippet_for_file;
+use syntect::html::highlighted_html_for_file;
 
 fn main() {
-    let ss = SyntaxSet::load_defaults_nonewlines();
+    let ss = SyntaxSet::load_defaults_newlines();
     let ts = ThemeSet::load_defaults();
 
     let args: Vec<String> = std::env::args().collect();
@@ -24,7 +24,7 @@ fn main() {
     let theme = &ts.themes["base16-ocean.dark"];
     let c = theme.settings.background.unwrap_or(Color::WHITE);
     println!("<body style=\"background-color:#{:02x}{:02x}{:02x};\">\n", c.r, c.g, c.b);
-    let html = highlighted_snippet_for_file(&args[1], &ss, theme).unwrap();
+    let html = highlighted_html_for_file(&args[1], &ss, theme).unwrap();
     println!("{}", html);
     println!("</body>");
 }

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -22,16 +22,16 @@ use std::path::Path;
 /// use syntect::easy::HighlightLines;
 /// use syntect::parsing::SyntaxSet;
 /// use syntect::highlighting::{ThemeSet, Style};
-/// use syntect::util::as_24_bit_terminal_escaped;
+/// use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
 ///
 /// // Load these once at the start of your program
-/// let ps = SyntaxSet::load_defaults_nonewlines();
+/// let ps = SyntaxSet::load_defaults_newlines();
 /// let ts = ThemeSet::load_defaults();
 ///
 /// let syntax = ps.find_syntax_by_extension("rs").unwrap();
 /// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 /// let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
-/// for line in s.lines() {
+/// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
 ///     let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
 ///     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
 ///     println!("{}", escaped);
@@ -79,9 +79,35 @@ impl<'a> HighlightFile<'a> {
     /// Auto-detects the syntax from the extension and constructs a `HighlightLines` with the correct syntax and theme.
     ///
     /// # Examples
-    /// This example uses `reader.lines()` to get lines without a newline character.
-    /// See the `syncat` example for an example of reading lines with a newline character, which gets slightly more robust
-    /// and fast syntax highlighting, at the cost of a couple extra lines of code.
+    /// Using the `newlines` mode is a bit involved but yields more robust and glitch-free highlighting,
+    /// as well as being slightly faster since it can re-use a line buffer.
+    ///
+    /// ```
+    /// use syntect::parsing::SyntaxSet;
+    /// use syntect::highlighting::{ThemeSet, Style};
+    /// use syntect::util::as_24_bit_terminal_escaped;
+    /// use syntect::easy::HighlightFile;
+    /// use std::io::BufRead;
+    ///
+    /// # use std::io;
+    /// # fn foo() -> io::Result<()> {
+    /// let ss = SyntaxSet::load_defaults_newlines();
+    /// let ts = ThemeSet::load_defaults();
+    ///
+    /// let mut highlighter = HighlightFile::new("testdata/highlight_test.erb", &ss, &ts.themes["base16-ocean.dark"]).unwrap();
+    /// let mut line = String::new();
+    /// while highlighter.reader.read_line(&mut line)? > 0 {
+    ///     {
+    ///         let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
+    ///         println!("{}", as_24_bit_terminal_escaped(&regions[..], true));
+    ///     } // until NLL this scope is needed so we can clear the buffer after
+    ///     line.clear(); // read_line appends so we need to clear between lines
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This example uses `reader.lines()` to get lines without a newline character, it's simpler but may break on rare tricky cases.
     ///
     /// ```
     /// use syntect::parsing::SyntaxSet;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -9,14 +9,14 @@ use std::fs::File;
 use std::path::Path;
 // use util::debug_print_ops;
 
-/// Simple way to go directly from lines of text to coloured
+/// Simple way to go directly from lines of text to colored
 /// tokens.
 ///
 /// Depending on how you load the syntaxes (see the `SyntaxSet` docs)
 /// you can either pass this strings with trailing `\n`s or without.
 ///
 /// # Examples
-/// Prints coloured lines of a string to the terminal
+/// Prints colored lines of a string to the terminal
 ///
 /// ```
 /// use syntect::easy::HighlightLines;

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -1,6 +1,6 @@
 //! Everything having to do with turning parsed text into styled text.
 //! You might want to check out `Theme` for its handy text-editor related
-//! settings like selection colour, `ThemeSet` for loading themes,
+//! settings like selection color, `ThemeSet` for loading themes,
 //! as well as things starting with `Highlight` for how to highlight text.
 mod selector;
 mod settings;

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -23,9 +23,9 @@ pub struct StyleModifier {
     pub font_style: Option<FontStyle>,
 }
 
-/// RGBA colour, these numbers come directly from the theme so
-/// for now you might have to do your own colour space conversion if you are outputting
-/// a different colour space from the theme. This can be a problem because some Sublime
+/// RGBA color, these numbers come directly from the theme so
+/// for now you might have to do your own color space conversion if you are outputting
+/// a different color space from the theme. This can be a problem because some Sublime
 /// themes use sRGB and some don't. This is specified in an attribute syntect doesn't parse yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Color {

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -21,7 +21,7 @@ pub struct Theme {
 }
 
 /// Various properties meant to be used to style a text editor.
-/// Basically all the styles that aren't directly applied to text like selection colour.
+/// Basically all the styles that aren't directly applied to text like selection color.
 /// Use this to make your editor UI match the highlighted text.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ThemeSettings {
@@ -113,7 +113,7 @@ pub struct ThemeSettings {
 
     /// Foreground color for regions added via `sublime.add_regions()`
     /// with the `sublime.DRAW_OUTLINED` flag added.
-    /// 
+    ///
     /// Deprecated!
     /// This setting does not exist in any available documentation.
     /// Use is discouraged, and it may be removed in a future release.

--- a/src/html.rs
+++ b/src/html.rs
@@ -145,7 +145,7 @@ fn write_css_color(s: &mut String, c: Color) {
 /// use syntect::html::{styles_to_coloured_html, IncludeBackground};
 ///
 /// // Load these once at the start of your program
-/// let ps = SyntaxSet::load_defaults_nonewlines();
+/// let ps = SyntaxSet::load_defaults_newlines();
 /// let ts = ThemeSet::load_defaults();
 ///
 /// let syntax = ps.find_syntax_by_name("Ruby").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! Almost everything in syntect is divided up into either the `parsing` module
 //! for turning text into text annotated with scopes, and the `highlighting` module
-//! for turning annotated text into styled/coloured text.
+//! for turning annotated text into styled/colored text.
 //!
 //! Some docs have example code but a good place to look is the `syncat` example as well as the source code
 //! for the `easy` module in `easy.rs` as that shows how to plug the various parts together for common use cases.

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -186,7 +186,7 @@ impl SyntaxSet {
     ///
     /// ```
     /// use syntect::parsing::SyntaxSet;
-    /// let ss = SyntaxSet::load_defaults_nonewlines();
+    /// let ss = SyntaxSet::load_defaults_newlines();
     /// let syntax = ss.find_syntax_for_file("testdata/highlight_test.erb")
     ///     .unwrap() // for IO errors, you may want to use try!() or another plain text fallback
     ///     .unwrap_or_else(|| ss.find_syntax_plain_text());

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,14 +6,14 @@ use std::ops::Range;
 #[cfg(feature = "parsing")]
 use parsing::ScopeStackOp;
 
-/// Formats the styled fragments using 24-bit colour
+/// Formats the styled fragments using 24-bit color
 /// terminal escape codes. Meant for debugging and testing.
 /// It's currently fairly inefficient in its use of escape codes.
 ///
-/// Note that this does not currently ever un-set the colour so that
+/// Note that this does not currently ever un-set the color so that
 /// the end of a line will also get highlighted with the background.
 /// This means if you might want to use `println!("\x1b[0m");` after
-/// to clear the colouring.
+/// to clear the coloring.
 ///
 /// If `bg` is true then the background is also set
 pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {

--- a/testdata/test3.html
+++ b/testdata/test3.html
@@ -1,32 +1,32 @@
 <pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">&lt;</span><span style="color:#bf616a;">script </span><span style="color:#d08770;">type</span><span style="color:#c0c5ce;">=&quot;</span><span style="color:#a3be8c;">text/javascript</span><span style="color:#c0c5ce;">&quot;&gt;</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#b48ead;">var </span><span style="color:#bf616a;">lol </span><span style="color:#c0c5ce;">= &quot;</span><span style="color:#a3be8c;">JS nesting</span><span style="color:#c0c5ce;">&quot;;</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#b48ead;">class </span><span style="color:#ebcb8b;">WithES6 </span><span style="color:#b48ead;">extends </span><span style="color:#a3be8c;">THREE</span><span style="color:#eff1f5;">.</span><span style="color:#a3be8c;">Mesh </span><span style="color:#eff1f5;">{</span>
-<span style="color:#eff1f5;">    </span><span style="color:#b48ead;">static </span><span style="color:#8fa1b3;">highQuality</span><span style="color:#eff1f5;">() { </span><span style="color:#65737e;">// such classes</span>
-<span style="color:#eff1f5;">      </span><span style="color:#b48ead;">return </span><span style="color:#bf616a;">this</span><span style="color:#eff1f5;">.</span><span style="color:#8fa1b3;">toString</span><span style="color:#eff1f5;">();</span>
-<span style="color:#eff1f5;">    }</span>
-<span style="color:#eff1f5;">  }</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#ab7967;">&lt;%</span>
-<span style="color:#c0c5ce;">    </span><span style="color:#65737e;"># The outer syntax is HTML (Rails) detected from the .erb extension</span>
-<span style="color:#c0c5ce;">    </span><span style="color:#96b5b4;">puts </span><span style="color:#c0c5ce;">&quot;</span><span style="color:#a3be8c;">Ruby </span><span style="color:#ab7967;">#{</span><span style="color:#c0c5ce;">&#39;</span><span style="color:#a3be8c;">nesting</span><span style="color:#c0c5ce;">&#39; * </span><span style="color:#d08770;">2</span><span style="color:#ab7967;">}</span><span style="color:#c0c5ce;">&quot;</span>
-<span style="color:#c0c5ce;">    here = &lt;&lt;-WOWCOOL + </span><span style="color:#bf616a;">CORRECTLY_DOES_NOT_HIGHLIGHT_REST_OF_LINE</span>
-<span style="color:#a3be8c;">      high quality parsing even supports custom heredoc endings</span>
-<span style="color:#a3be8c;">      </span><span style="color:#ab7967;">#{</span>
-<span style="color:#a3be8c;">      nested </span><span style="color:#c0c5ce;">= </span><span style="color:#d08770;">5 </span><span style="color:#c0c5ce;">* &lt;&lt;-ZOMG</span>
-<span style="color:#a3be8c;">        nested heredocs! (no highlighting: 5 * 6, yes highlighting: </span><span style="color:#ab7967;">#{</span><span style="color:#d08770;">5 </span><span style="color:#c0c5ce;">* </span><span style="color:#d08770;">6</span><span style="color:#ab7967;">}</span><span style="color:#a3be8c;">)</span>
-<span style="color:#c0c5ce;">      ZOMG</span>
-<span style="color:#a3be8c;">      </span><span style="color:#ab7967;">}</span>
-<span style="color:#c0c5ce;">    WOWCOOL</span>
-<span style="color:#c0c5ce;">    sql = &lt;&lt;-SQL</span>
-<span style="color:#a3be8c;">      </span><span style="color:#b48ead;">select </span><span style="color:#c0c5ce;">* </span><span style="color:#b48ead;">from</span><span style="color:#a3be8c;"> heredocs </span><span style="color:#b48ead;">where</span><span style="color:#a3be8c;"> there_are_special_heredoc_names </span><span style="color:#c0c5ce;">= </span><span style="color:#d08770;">true</span>
-<span style="color:#c0c5ce;">    SQL</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#ab7967;">%&gt;</span>
-<span style="color:#c0c5ce;">&lt;/</span><span style="color:#bf616a;">script</span><span style="color:#c0c5ce;">&gt;</span>
-<span style="color:#c0c5ce;">&lt;</span><span style="color:#bf616a;">style </span><span style="color:#d08770;">type</span><span style="color:#c0c5ce;">=&quot;</span><span style="color:#a3be8c;">text/css</span><span style="color:#c0c5ce;">&quot;&gt;</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#65737e;">/* the HTML syntax also supports CSS of course */</span>
-<span style="color:#b48ead;">  </span><span style="color:#8fa1b3;">.</span><span style="color:#d08770;">stuff </span><span style="color:#8fa1b3;">#wow </span><span style="color:#c0c5ce;">{</span>
-<span style="color:#c0c5ce;">    border: </span><span style="color:#d08770;">5px </span><span style="color:#96b5b4;">#ffffff</span><span style="color:#c0c5ce;">;</span>
-<span style="color:#c0c5ce;">    background: </span><span style="color:#96b5b4;">url</span><span style="color:#c0c5ce;">(&quot;</span><span style="color:#a3be8c;">wow</span><span style="color:#c0c5ce;">&quot;);</span>
-<span style="color:#c0c5ce;">  }</span>
-<span style="color:#c0c5ce;">&lt;/</span><span style="color:#bf616a;">style</span><span style="color:#c0c5ce;">&gt;</span>
-</pre>
+<span style="color:#c0c5ce;">&lt;</span><span style="color:#bf616a;">script </span><span style="color:#d08770;">type</span><span style="color:#c0c5ce;">=&quot;</span><span style="color:#a3be8c;">text/javascript</span><span style="color:#c0c5ce;">&quot;&gt;
+</span><span style="color:#c0c5ce;">  </span><span style="color:#b48ead;">var </span><span style="color:#bf616a;">lol </span><span style="color:#c0c5ce;">= &quot;</span><span style="color:#a3be8c;">JS nesting</span><span style="color:#c0c5ce;">&quot;;
+</span><span style="color:#c0c5ce;">  </span><span style="color:#b48ead;">class </span><span style="color:#ebcb8b;">WithES6 </span><span style="color:#b48ead;">extends </span><span style="color:#a3be8c;">THREE</span><span style="color:#eff1f5;">.</span><span style="color:#a3be8c;">Mesh </span><span style="color:#eff1f5;">{
+</span><span style="color:#eff1f5;">    </span><span style="color:#b48ead;">static </span><span style="color:#8fa1b3;">highQuality</span><span style="color:#eff1f5;">() { </span><span style="color:#65737e;">// such classes
+</span><span style="color:#eff1f5;">      </span><span style="color:#b48ead;">return </span><span style="color:#bf616a;">this</span><span style="color:#eff1f5;">.</span><span style="color:#8fa1b3;">toString</span><span style="color:#eff1f5;">();
+</span><span style="color:#eff1f5;">    }
+</span><span style="color:#eff1f5;">  }
+</span><span style="color:#c0c5ce;">  </span><span style="color:#ab7967;">&lt;%
+</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;"># The outer syntax is HTML (Rails) detected from the .erb extension
+</span><span style="color:#c0c5ce;">    </span><span style="color:#96b5b4;">puts </span><span style="color:#c0c5ce;">&quot;</span><span style="color:#a3be8c;">Ruby </span><span style="color:#ab7967;">#{</span><span style="color:#c0c5ce;">&#39;</span><span style="color:#a3be8c;">nesting</span><span style="color:#c0c5ce;">&#39; * </span><span style="color:#d08770;">2</span><span style="color:#ab7967;">}</span><span style="color:#c0c5ce;">&quot;
+</span><span style="color:#c0c5ce;">    here = &lt;&lt;-WOWCOOL + </span><span style="color:#bf616a;">CORRECTLY_DOES_NOT_HIGHLIGHT_REST_OF_LINE
+</span><span style="color:#a3be8c;">      high quality parsing even supports custom heredoc endings
+</span><span style="color:#a3be8c;">      </span><span style="color:#ab7967;">#{
+</span><span style="color:#a3be8c;">      nested </span><span style="color:#c0c5ce;">= </span><span style="color:#d08770;">5 </span><span style="color:#c0c5ce;">* &lt;&lt;-ZOMG
+</span><span style="color:#a3be8c;">        nested heredocs! (no highlighting: 5 * 6, yes highlighting: </span><span style="color:#ab7967;">#{</span><span style="color:#d08770;">5 </span><span style="color:#c0c5ce;">* </span><span style="color:#d08770;">6</span><span style="color:#ab7967;">}</span><span style="color:#a3be8c;">)
+</span><span style="color:#c0c5ce;">      ZOMG
+</span><span style="color:#a3be8c;">      </span><span style="color:#ab7967;">}
+</span><span style="color:#c0c5ce;">    WOWCOOL
+</span><span style="color:#c0c5ce;">    sql = &lt;&lt;-SQL
+</span><span style="color:#a3be8c;">      </span><span style="color:#b48ead;">select </span><span style="color:#c0c5ce;">* </span><span style="color:#b48ead;">from</span><span style="color:#a3be8c;"> heredocs </span><span style="color:#b48ead;">where</span><span style="color:#a3be8c;"> there_are_special_heredoc_names </span><span style="color:#c0c5ce;">= </span><span style="color:#d08770;">true
+</span><span style="color:#c0c5ce;">    SQL
+</span><span style="color:#c0c5ce;">  </span><span style="color:#ab7967;">%&gt;
+</span><span style="color:#c0c5ce;">&lt;/</span><span style="color:#bf616a;">script</span><span style="color:#c0c5ce;">&gt;
+</span><span style="color:#c0c5ce;">&lt;</span><span style="color:#bf616a;">style </span><span style="color:#d08770;">type</span><span style="color:#c0c5ce;">=&quot;</span><span style="color:#a3be8c;">text/css</span><span style="color:#c0c5ce;">&quot;&gt;
+</span><span style="color:#c0c5ce;">  </span><span style="color:#65737e;">/* the HTML syntax also supports CSS of course */
+</span><span style="color:#b48ead;">  </span><span style="color:#8fa1b3;">.</span><span style="color:#d08770;">stuff </span><span style="color:#8fa1b3;">#wow </span><span style="color:#c0c5ce;">{
+</span><span style="color:#c0c5ce;">    border: </span><span style="color:#d08770;">5px </span><span style="color:#96b5b4;">#ffffff</span><span style="color:#c0c5ce;">;
+</span><span style="color:#c0c5ce;">    background: </span><span style="color:#96b5b4;">url</span><span style="color:#c0c5ce;">(&quot;</span><span style="color:#a3be8c;">wow</span><span style="color:#c0c5ce;">&quot;);
+</span><span style="color:#c0c5ce;">  }
+</span><span style="color:#c0c5ce;">&lt;/</span><span style="color:#bf616a;">style</span><span style="color:#c0c5ce;">&gt;
+</span></pre>

--- a/testdata/test4.html
+++ b/testdata/test4.html
@@ -1,16 +1,16 @@
 <pre style="background-color:#ffffff;">
-<span style="color:#323232;">%</span><span style="font-weight:bold;color:#a71d5d;">YAML </span><span style="color:#0086b3;">1.2</span>
-<span style="color:#323232;">---</span>
-<span style="font-style:italic;color:#969896;"># http://www.sublimetext.com/docs/3/syntax.html</span>
-<span style="color:#63a35c;">name</span><span style="color:#323232;">: </span><span style="color:#183691;">Cargo Build Results</span>
-<span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">source.build_results</span>
-<span style="color:#63a35c;">hidden</span><span style="color:#323232;">: </span><span style="color:#0086b3;">true</span>
-<span style="color:#63a35c;">contexts</span><span style="color:#323232;">:</span>
-<span style="color:#323232;">  </span><span style="color:#63a35c;">main</span><span style="color:#323232;">:</span>
-<span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;^(..[^:\n]*):([0-9]+):?([0-9]+)?:? &#39;</span>
-<span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">entity.name.filename</span>
-<span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;\berror: &#39;</span>
-<span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">message.error</span>
-<span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;^\[.+\]$&#39;</span>
-<span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">comment</span>
-</pre>
+<span style="color:#323232;">%</span><span style="font-weight:bold;color:#a71d5d;">YAML </span><span style="color:#0086b3;">1.2
+</span><span style="color:#323232;">---
+</span><span style="font-style:italic;color:#969896;"># http://www.sublimetext.com/docs/3/syntax.html
+</span><span style="color:#63a35c;">name</span><span style="color:#323232;">: </span><span style="color:#183691;">Cargo Build Results
+</span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">source.build_results
+</span><span style="color:#63a35c;">hidden</span><span style="color:#323232;">: </span><span style="color:#0086b3;">true
+</span><span style="color:#63a35c;">contexts</span><span style="color:#323232;">:
+</span><span style="color:#323232;">  </span><span style="color:#63a35c;">main</span><span style="color:#323232;">:
+</span><span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;^(..[^:\n]*):([0-9]+):?([0-9]+)?:? &#39;
+</span><span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">entity.name.filename
+</span><span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;\berror: &#39;
+</span><span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">message.error
+</span><span style="color:#323232;">    - </span><span style="color:#63a35c;">match</span><span style="color:#323232;">: </span><span style="color:#183691;">&#39;^\[.+\]$&#39;
+</span><span style="color:#323232;">      </span><span style="color:#63a35c;">scope</span><span style="color:#323232;">: </span><span style="color:#183691;">comment
+</span></pre>

--- a/testdata/test5.html
+++ b/testdata/test5.html
@@ -1,21 +1,21 @@
 <pre style="background-color:#2b303b;">
-<span style="color:#65737e;">hi</span><span style="color:#c0c5ce;"> lol</span>
-<span style="color:#a3be8c;">wow</span><span style="color:#c0c5ce;"> zoom</span>
-<span style="color:#c0c5ce;">html</span>
-<span style="color:#c0c5ce;">  &lt;</span><span style="color:#bf616a;">br </span><span style="color:#d08770;">style</span><span style="color:#c0c5ce;">=&quot;color: </span><span style="color:#96b5b4;">#555</span><span style="color:#c0c5ce;">;&quot;/&gt;</span>
-<span style="color:#c0c5ce;">  troll wow lol</span>
-<span style="color:#c0c5ce;">htmout</span>
-<span style="color:#c0c5ce;">inline</span>
-<span style="color:#c0c5ce;">  hi </span><span style="color:#d08770;">zoom </span><span style="color:#b48ead;">lol</span><span style="color:#c0c5ce;"> wow </span><span style="color:#b48ead;">bamf</span>
-<span style="color:#c0c5ce;">inout</span>
-<span style="color:#c0c5ce;">troll</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#a3be8c;">wow </span><span style="color:#b48ead;">lol</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#d08770;">zoom </span><span style="color:#b48ead;">lol bamf</span><span style="color:#c0c5ce;"> doopadoop</span>
-<span style="color:#c0c5ce;">out</span>
-<span style="color:#c0c5ce;">  </span><span style="color:#d08770;">zoom</span><span style="color:#c0c5ce;"> lol </span><span style="color:#b48ead;">bamf</span>
-<span style="color:#c0c5ce;">  nested</span>
-<span style="color:#c0c5ce;">    wow zoom lol bamf </span><span style="color:#65737e;">doopadoop</span>
-<span style="color:#c0c5ce;">  outnested</span>
-<span style="color:#c0c5ce;">zout</span>
-<span style="color:#c0c5ce;">  zoom lol </span><span style="color:#b48ead;">bamf</span>
-</pre>
+<span style="color:#65737e;">hi</span><span style="color:#c0c5ce;"> lol
+</span><span style="color:#a3be8c;">wow</span><span style="color:#c0c5ce;"> zoom
+</span><span style="color:#c0c5ce;">html
+</span><span style="color:#c0c5ce;">  &lt;</span><span style="color:#bf616a;">br </span><span style="color:#d08770;">style</span><span style="color:#c0c5ce;">=&quot;color: </span><span style="color:#96b5b4;">#555</span><span style="color:#c0c5ce;">;&quot;/&gt;
+</span><span style="color:#c0c5ce;">  troll wow lol
+</span><span style="color:#c0c5ce;">htmout
+</span><span style="color:#c0c5ce;">inline
+</span><span style="color:#c0c5ce;">  hi </span><span style="color:#d08770;">zoom </span><span style="color:#b48ead;">lol</span><span style="color:#c0c5ce;"> wow </span><span style="color:#b48ead;">bamf
+</span><span style="color:#c0c5ce;">inout
+</span><span style="color:#c0c5ce;">troll
+</span><span style="color:#c0c5ce;">  </span><span style="color:#a3be8c;">wow </span><span style="color:#b48ead;">lol
+</span><span style="color:#c0c5ce;">  </span><span style="color:#d08770;">zoom </span><span style="color:#b48ead;">lol bamf</span><span style="color:#c0c5ce;"> doopadoop
+</span><span style="color:#c0c5ce;">out
+</span><span style="color:#c0c5ce;">  </span><span style="color:#d08770;">zoom</span><span style="color:#c0c5ce;"> lol </span><span style="color:#b48ead;">bamf
+</span><span style="color:#c0c5ce;">  nested
+</span><span style="color:#c0c5ce;">    wow zoom lol bamf </span><span style="color:#65737e;">doopadoop
+</span><span style="color:#c0c5ce;">  outnested
+</span><span style="color:#c0c5ce;">zout
+</span><span style="color:#c0c5ce;">  zoom lol </span><span style="color:#b48ead;">bamf
+</span></pre>


### PR DESCRIPTION
This PR switches the HTML helpers to use newlines syntaxes so that they are faster and more correct and so fixes #196. It also refactors them to not allocate intermediate strings and share more code.

It renames the methods which had silent requirements changes so that people
upgrading get compile errors and hopefully then look at the release notes.

There are two other functionality changes: the position of the newline characters in the resulting HTML changed, in a way I think is reasonable and doesn't change the rendered output. And the `start_coloured_html_snippet` function got a semicolon added and now returns the background.

I also changed a number of doc tests to use newlines syntaxes so that the slightly more complex things you have to do to use the newlines syntaxes are demonstrated.

This is the last set of breaking API changes I wanted to do before the 3.0 release, so after this is done with I can work on getting the release out. Although it's plausible #203 might require breaking API changes, I should take a look before releasing.