### PR TITLE
Update Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ onig = { version = "4.2", optional = true }
 walkdir = "2.2"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.1.0"
-lazycell = "1.0"
+lazycell = "1.2.0"
 bitflags = "1.0"
 plist = "0.3"
 bincode = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ yaml-rust = { version = "0.4", optional = true }
 onig = { version = "4.2", optional = true }
 walkdir = "2.2"
 regex-syntax = { version = "0.6", optional = true }
-lazy_static = "1.0"
+lazy_static = "1.1.0"
 lazycell = "1.0"
 bitflags = "1.0"
 plist = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
-onig = { version = "4.1", optional = true }
+onig = { version = "4.2", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ serde_json = "1.0"
 
 [dev-dependencies]
 criterion = "0.2"
-rayon = "1.0.0"
+rayon = "1.0.2"
 regex = "1.0"
 getopts = "0.2"
-pretty_assertions = "0.5.0"
+pretty_assertions = "0.5.1"
 
 [features]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
 onig = { version = "4.2", optional = true }
-walkdir = "2.0"
+walkdir = "2.2"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"


### PR DESCRIPTION
As requested in #204 I took a look at the dependencies and update them.
The biggest change is in walkdir, which sets it's minimum rust version 1.23.
Finally I tested the new versions with `cargo test`.