### PR TITLE
Tweak nonewlines regex rewriting (#211)

### DIFF
--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -556,9 +556,10 @@ impl<'a> RegexRewriter<'a> {
                     self.next();
                     if let Some(c2) = self.peek() {
                         self.next();
-                        // Replacing `\n?` with `$?` would make parsing later fail with
-                        // "target of repeat operator is invalid"
-                        if c2 == b'n' && self.peek() != Some(b'?') {
+                        // Replacing `\n` with `$` in `\n?` or `\n+` would make parsing later fail
+                        // with "target of repeat operator is invalid"
+                        let c3 = self.peek();
+                        if c2 == b'n' && c3 != Some(b'?') && c3 != Some(b'+') {
                             result.extend_from_slice(b"$");
                         } else {
                             result.push(c);
@@ -948,6 +949,7 @@ mod tests {
         assert_eq!(&rewrite(r"\n"), r"$");
         assert_eq!(&rewrite(r"\[\n"), r"\[$");
         assert_eq!(&rewrite(r"a\n?"), r"a\n?");
+        assert_eq!(&rewrite(r"a\n+"), r"a\n+");
         assert_eq!(&rewrite(r"[abc\n]"), r"(?:[abc\n]|$)");
         assert_eq!(&rewrite(r"[^\n]"), r"[^\n]");
         assert_eq!(&rewrite(r"[^]\n]"), r"[^]\n]");

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -559,7 +559,7 @@ impl<'a> RegexRewriter<'a> {
                         // Replacing `\n` with `$` in `\n?` or `\n+` would make parsing later fail
                         // with "target of repeat operator is invalid"
                         let c3 = self.peek();
-                        if c2 == b'n' && c3 != Some(b'?') && c3 != Some(b'+') {
+                        if c2 == b'n' && c3 != Some(b'?') && c3 != Some(b'+') && c3 != Some(b'*') {
                             result.extend_from_slice(b"$");
                         } else {
                             result.push(c);
@@ -950,6 +950,7 @@ mod tests {
         assert_eq!(&rewrite(r"\[\n"), r"\[$");
         assert_eq!(&rewrite(r"a\n?"), r"a\n?");
         assert_eq!(&rewrite(r"a\n+"), r"a\n+");
+        assert_eq!(&rewrite(r"a\n*"), r"a\n*");
         assert_eq!(&rewrite(r"[abc\n]"), r"(?:[abc\n]|$)");
         assert_eq!(&rewrite(r"[^\n]"), r"[^\n]");
         assert_eq!(&rewrite(r"[^]\n]"), r"[^]\n]");


### PR DESCRIPTION
Using `\n+` in a regex doesn't make any sense for Sublime Text syntaxes, but let's not produce an invalid regex in that case.