### PR TITLE
Update plist to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"
 bitflags = "1.0"
-plist = "0.3"
+plist = "0.4"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }

--- a/src/highlighting/settings.rs
+++ b/src/highlighting/settings.rs
@@ -3,7 +3,6 @@
 
 use std::io::{Read, Seek};
 use plist::{Error as PlistError};
-use plist::serde::deserialize;
 
 pub use serde_json::Value as Settings;
 pub use serde_json::Value::Array as SettingsArray;
@@ -33,6 +32,6 @@ impl From<PlistError> for SettingsError {
 }
 
 pub fn read_plist<R: Read + Seek>(reader: R) -> Result<Settings, SettingsError> {
-    let settings = deserialize(reader)?;
+    let settings = plist::from_reader(reader)?;
     Ok(settings)
 }


### PR DESCRIPTION
Fixes #231, re-generating the theme dump results in the same file which is good.