### PR TITLE
Make parsing::syntax_set::tests::can_load work with newer syntaxes

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -695,10 +695,10 @@ mod tests {
         assert_eq!(&ps.find_syntax_for_file("testdata/parser.rs").unwrap().unwrap().name,
                    "Rust");
         assert_eq!(&ps.find_syntax_for_file("testdata/test_first_line.test")
-                       .unwrap()
-                       .unwrap()
+                       .expect("Error finding syntax for file")
+                       .expect("No syntax found for file")
                        .name,
-                   "Go");
+                   "Ruby");
         assert_eq!(&ps.find_syntax_for_file(".bashrc").unwrap().unwrap().name,
                    "Bourne Again Shell (bash)");
         assert_eq!(&ps.find_syntax_for_file("CMakeLists.txt").unwrap().unwrap().name,

--- a/testdata/test_first_line.test
+++ b/testdata/test_first_line.test
@@ -1,6 +1,6 @@
-// -*- Mode: Go -*-
+#!/usr/bin/ruby
 
-func blah() error {
-  test := "wow"
-  return ioutil.WriteFile(test, hi, 0700)
-}
+def blah
+  test = "wow"
+  puts test
+end


### PR DESCRIPTION
Looks like the Go syntax removed the first_line_match: https://github.com/sublimehq/Packages/commit/14a35f641f348b4ee0ead558e5ee474f7255b50f#diff-c06e69a4dd85794f1dd2e5688c83688eL7

Use a different syntax to test this.

(This is preparing for #228)