### PR TITLE
Resolved deprecated libstd warnings

### DIFF
--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -136,7 +136,7 @@ impl ScopeRepository {
         if s.is_empty() {
             return Ok(Scope { a: 0, b: 0 });
         }
-        let parts: Vec<usize> = s.trim_right_matches('.').split('.').map(|a| self.atom_to_index(a)).collect();
+        let parts: Vec<usize> = s.trim_end_matches('.').split('.').map(|a| self.atom_to_index(a)).collect();
         if parts.len() > 8 {
             return Err(ParseScopeError::TooManyAtoms);
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,7 +44,7 @@ pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
 #[cfg(feature = "parsing")]
 pub fn debug_print_ops(line: &str, ops: &[(usize, ScopeStackOp)]) {
     for &(i, ref op) in ops.iter() {
-        println!("{}", line.trim_right());
+        println!("{}", line.trim_end());
         print!("{: <1$}", "", i);
         match *op {
             ScopeStackOp::Push(s) => {


### PR DESCRIPTION
trim_right_matches:
`Deprecated since 1.33.0: superseded by trim_end_matches`

trim_right:
`Deprecated since 1.33.0: superseded by trim_end`

From what I understand this is because of right-to-left languages, where the phrases `_right_` and `_left_` would be inconsistent