### PR TITLE
restore cleared scopes when a context is "set" away from

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -534,6 +534,10 @@ impl ParseState {
                 };
                 // a match pattern that "set"s keeps the meta_content_scope and meta_scope from the previous context
                 if initial {
+                    if is_set && cur_context.clear_scopes != None {
+                        // cleared scopes from the old context are restored immediately
+                        ops.push((index, ScopeStackOp::Restore));
+                    }
                     // add each context's meta scope
                     for r in context_refs.iter() {
                         let ctx = r.resolve(syntax_set);


### PR DESCRIPTION
this change ensures that cleared scopes are correctly restored by a "set" operation - prior to this change those scopes would be cleared forever and never restored. This fixes a couple of syntax test assertions from the latest JSON syntax definition.
https://github.com/sublimehq/Packages/blob/8a33060da538d80cef760b13c10f95c52ef920fa/JavaScript/JSON.sublime-syntax#L118-L122
No unit test (yet) I'm afraid, it's hard to come up with one when working from a phone...