### PR TITLE
Add delta to client projects in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -171,6 +171,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [catmark](https://github.com/bestouff/catmark), a console markdown printer, uses `syntect` for code blocks.
 - [Cobalt](https://github.com/cobalt-org/cobalt.rs), a static site generator that uses `syntect` for highlighting code snippets.
 - [crowbook](https://github.com/lise-henry/crowbook), a Markdown book generator, uses `syntect` for code blocks.
+- [delta](https://github.com/dandavison/delta), a syntax-highlighting pager for Git.
 - [hors](https://github.com/WindSoilder/hors), instant coding answers via command line, uses `syntect` for highlighting code blocks.
 - [mdcat](https://github.com/lunaryorn/mdcat), a console markdown printer, uses `syntect` for code blocks.
 - [Scribe](https://github.com/jmacdonald/scribe), a Rust text editor framework which uses `syntect` for highlighting.

--- a/Readme.md
+++ b/Readme.md
@@ -167,17 +167,18 @@ Characters of comment:                 41099
 
 Below is a list of projects using Syntect, in approximate order by how long they've been using `syntect` (feel free to send PRs to add to this list):
 
-- [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
-- [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
-- [Scribe](https://github.com/jmacdonald/scribe), a Rust text editor framework which uses `syntect` for highlighting.
-- [tokio-cassandra](https://github.com/nhellwig/tokio-cassandra), CQL shell in Rust, uses `syntect` for shell colouring.
-- [Cobalt](https://github.com/cobalt-org/cobalt.rs), a static site generator that uses `syntect` for highlighting code snippets.
-- [catmark](https://github.com/bestouff/catmark), a console markdown printer, uses `syntect` for code blocks.
-- [crowbook](https://github.com/lise-henry/crowbook), a Markdown book generator, uses `syntect` for code blocks.
-- [syntect_server](https://github.com/sourcegraph/syntect_server), an HTTP server for syntax highlighting.
-- [mdcat](https://github.com/lunaryorn/mdcat), a console markdown printer, uses `syntect` for code blocks.
 - [bat](https://github.com/sharkdp/bat), a `cat(1)` clone, uses `syntect` for syntax highlighting.
+- [catmark](https://github.com/bestouff/catmark), a console markdown printer, uses `syntect` for code blocks.
+- [Cobalt](https://github.com/cobalt-org/cobalt.rs), a static site generator that uses `syntect` for highlighting code snippets.
+- [crowbook](https://github.com/lise-henry/crowbook), a Markdown book generator, uses `syntect` for code blocks.
 - [hors](https://github.com/WindSoilder/hors), instant coding answers via command line, uses `syntect` for highlighting code blocks.
+- [mdcat](https://github.com/lunaryorn/mdcat), a console markdown printer, uses `syntect` for code blocks.
+- [Scribe](https://github.com/jmacdonald/scribe), a Rust text editor framework which uses `syntect` for highlighting.
+- [syntect_server](https://github.com/sourcegraph/syntect_server), an HTTP server for syntax highlighting.
+- [tokio-cassandra](https://github.com/nhellwig/tokio-cassandra), CQL shell in Rust, uses `syntect` for shell colouring.
+- [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
+- [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
+
 
 ## License and Acknowledgements
 


### PR DESCRIPTION
Thanks for syntect @trishume! It's been great using it.

This PR:

- Sorts the list of client projects in the Readme (202d753)
- Adds [delta](https://github.com/dandavison/delta) to the list of client projects (1fdd9ed)