### PR TITLE
Fix error with bitflags < 1.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"
-bitflags = "1.0"
+bitflags = "1.0.4"
 plist = "0.5"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }


### PR DESCRIPTION
Only bitflags 1.0.4 supports imports like `use bitflags::bitflags;`, see https://github.com/bitflags/bitflags/releases. My lock file still had 1.0.3 and so I was getting a compile error.

Bump the minimum version in Cargo.toml.