### PR TITLE
Benchmarking tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ default = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create"]
 # [profile.release]
 # debug = true
 
+[lib]
+bench = false
+
 [[bench]]
 name = "highlighting"
 harness = false

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,6 +1,7 @@
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use std::fs::File;
 use std::io::Read;
+use std::time::Duration;
 use syntect::parsing::{ParseState, SyntaxReference, SyntaxSet};
 
 fn do_parse(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference) -> usize {
@@ -52,7 +53,7 @@ fn parsing_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(20);
+    config = Criterion::default().sample_size(50).warm_up_time(Duration::from_secs(30));
     targets = parsing_benchmark
 }
 criterion_main!(benches);


### PR DESCRIPTION
* Allow passing options to criterion, see
  https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
* Increase sample size and warm up size for parsing benches
  There was too much variance before