### PR TITLE
No onig on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
 onig = { version = "5.0", optional = true }
-fancy-regex = { version = "0.2.0", optional = true }
+fancy-regex = { version = "0.3.0", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ exclude = [
 
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
-onig = { version = "5.0", optional = true }
-fancy-regex = { version = "0.3.2", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
@@ -33,6 +31,13 @@ fnv = { version = "1.0", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+
+[target.'cfg(windows)'.dependencies]
+fancy-regex = "0.3.2"
+
+[target.'cfg(not(windows))'.dependencies]
+onig = "5.0"
+fancy-regex = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -57,7 +62,6 @@ dump-create = ["flate2/default", "bincode"]
 dump-create-rs = ["flate2/rust_backend", "bincode"]
 
 regex-fancy = ["fancy-regex"]
-regex-onig = ["onig"]
 parsing = ["regex-syntax", "fnv"]
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
 metadata = ["parsing"]
@@ -66,9 +70,8 @@ metadata = ["parsing"]
 assets = []
 html = ["parsing", "assets"]
 yaml-load = ["yaml-rust", "parsing"]
-default-onig = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
-default-fancy = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
-default = ["default-onig"]
+
+default = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create"]
 
 # [profile.release]
 # debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
 onig = { version = "5.0", optional = true }
-fancy-regex = { version = "0.3.0", optional = true }
+fancy-regex = { version = "0.3.2", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 [dependencies]
 yaml-rust = { version = "0.4", optional = true }
 onig = { version = "5.0", optional = true }
+fancy-regex = { version = "0.2.0", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
@@ -55,7 +56,9 @@ dump-create = ["flate2/default", "bincode"]
 # Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
 dump-create-rs = ["flate2/rust_backend", "bincode"]
 
-parsing = ["onig", "regex-syntax", "fnv"]
+regex-fancy = ["fancy-regex"]
+regex-onig = ["onig"]
+parsing = ["regex-syntax", "fnv"]
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
 metadata = ["parsing"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
@@ -63,7 +66,9 @@ metadata = ["parsing"]
 assets = []
 html = ["parsing", "assets"]
 yaml-load = ["yaml-rust", "parsing"]
-default = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create"]
+default-onig = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
+default-fancy = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
+default = ["default-onig"]
 
 # [profile.release]
 # debug = true

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -12,6 +12,7 @@ mod syntax_set;
 mod yaml_load;
 
 mod scope;
+mod regex;
 
 #[cfg(feature = "parsing")]
 pub use self::syntax_definition::SyntaxDefinition;
@@ -23,5 +24,7 @@ pub use self::syntax_set::*;
 pub use self::parser::*;
 #[cfg(feature = "metadata")]
 pub use self::metadata::*;
+
+pub use self::regex::*;
 
 pub use self::scope::*;

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1523,7 +1523,7 @@ contexts:
         expect_scope_stacks_with_syntax("abcdb", &["<a>", "<b>", "<c>", "<d>", "<1>"], syntax);
     }
 
-        #[test]
+    #[test]
     fn can_parse_two_with_prototypes_at_same_stack_level_updated_captures_ignore_unexisting() {
         let syntax_yamlstr = r#"
 %YAML 1.2
@@ -1557,6 +1557,22 @@ contexts:
         // it seems that when ST encounters a non existing pop backreference, it just pops back to the with_prototype's original parent context - i.e. cdb is unscoped
         // TODO: it would be useful to have syntest functionality available here for easier testing and clarity
         expect_scope_stacks_with_syntax("a-bcdba-", &["<a>", "<b>"], syntax);
+    }
+
+    #[test]
+    fn can_parse_syntax_with_eol_and_newline() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: foo$\n
+      scope: foo.newline
+"#;
+
+        let line = "foo";
+        let expect = ["<source.test>, <foo.newline>"];
+        expect_scope_stacks(&line, &expect, syntax);
     }
 
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -244,13 +244,17 @@ impl ParseState {
 
                 // println!("pop_would_loop for match {:?}, start {}", reg_match, *start);
 
-                if *start == line.len() {
+                // nth(1) gets the next character if there is one. Need to do
+                // this instead of just += 1 because we have byte indices and
+                // unicode characters can be more than 1 byte.
+                if let Some((i, _)) = line[*start..].char_indices().nth(1) {
+                    *start += i;
+                    return true;
+                } else {
                     // End of line, no character to advance and no point trying
                     // any more patterns.
                     return false;
                 }
-                *start += 1;
-                return true;
             }
 
             let match_end = reg_match.regions.pos(0).unwrap().1;
@@ -1636,6 +1640,30 @@ contexts:
             (0, Push(Scope::new("other").unwrap())),
             (4, Pop(1))
         ]);
+    }
+
+    #[test]
+    fn can_parse_text_with_unicode_to_skip() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: (?=.)
+      push: test
+  test:
+    - match: (?=.)
+      pop: true
+    - match: x
+      scope: test.good
+"#;
+
+        // U+03C0 GREEK SMALL LETTER PI, 2 bytes in UTF-8
+        expect_scope_stacks("\u{03C0}x", &["<source.test>, <test.good>"], syntax);
+        // U+0800 SAMARITAN LETTER ALAF, 3 bytes in UTF-8
+        expect_scope_stacks("\u{0800}x", &["<source.test>, <test.good>"], syntax);
+        // U+1F600 GRINNING FACE, 4 bytes in UTF-8
+        expect_scope_stacks("\u{1F600}x", &["<source.test>, <test.good>"], syntax);
     }
 
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -693,6 +693,26 @@ mod tests {
     }
 
     #[test]
+    fn can_parse_yaml() {
+        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let mut state = {
+            let syntax = ps.find_syntax_by_name("YAML").unwrap();
+            ParseState::new(syntax)
+        };
+
+        assert_eq!(ops(&mut state, "key: value\n", &ps), vec![
+            (0, Push(Scope::new("source.yaml").unwrap())),
+            (0, Push(Scope::new("string.unquoted.plain.out.yaml").unwrap())),
+            (0, Push(Scope::new("entity.name.tag.yaml").unwrap())),
+            (3, Pop(2)),
+            (3, Push(Scope::new("punctuation.separator.key-value.mapping.yaml").unwrap())),
+            (4, Pop(1)),
+            (5, Push(Scope::new("string.unquoted.plain.out.yaml").unwrap())),
+            (10, Pop(1)),
+        ]);
+    }
+
+    #[test]
     fn can_parse_includes() {
         let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
         let mut state = {

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -1,0 +1,254 @@
+use lazycell::AtomicLazyCell;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::error::Error;
+
+/// An abstraction for regex patterns.
+///
+/// * Allows swapping out the regex implementation because it's only in this module.
+/// * Makes regexes serializable and deserializable using just the pattern string.
+/// * Lazily compiles regexes on first use to improve initialization time.
+#[derive(Debug)]
+pub struct Regex {
+    regex_str: String,
+    regex: AtomicLazyCell<regex_impl::Regex>,
+}
+
+/// A region contains text positions for capture groups in a match result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Region {
+    region: regex_impl::Region,
+}
+
+impl Regex {
+    /// Create a new regex from the pattern string.
+    ///
+    /// Note that the regex compilation happens on first use, which is why this method does not
+    /// return a result.
+    pub fn new(regex_str: String) -> Self {
+        Self {
+            regex_str,
+            regex: AtomicLazyCell::new(),
+        }
+    }
+
+    /// Check whether the pattern compiles as a valid regex or not.
+    pub fn try_compile(regex_str: &str) -> Option<Box<dyn Error>> {
+        regex_impl::Regex::new(regex_str).err()
+    }
+
+    /// Return the regex pattern.
+    pub fn regex_str(&self) -> &str {
+        &self.regex_str
+    }
+
+    /// Check if the regex matches the given text.
+    pub fn is_match(&self, text: &str) -> bool {
+        self.regex().is_match(text)
+    }
+
+    /// Search for the pattern in the given text from begin/end positions.
+    pub fn search(&self, text: &str, begin: usize, end: usize) -> Option<Region> {
+        self.regex()
+            .search(text, begin, end)
+            .map(|r| Region::new(r))
+    }
+
+    fn regex(&self) -> &regex_impl::Regex {
+        if let Some(regex) = self.regex.borrow() {
+            regex
+        } else {
+            let regex =
+                regex_impl::Regex::new(&self.regex_str).expect("regex string should be pre-tested");
+            self.regex.fill(regex).ok();
+            self.regex.borrow().unwrap()
+        }
+    }
+}
+
+impl Clone for Regex {
+    fn clone(&self) -> Self {
+        Regex {
+            regex_str: self.regex_str.clone(),
+            regex: AtomicLazyCell::new(),
+        }
+    }
+}
+
+impl PartialEq for Regex {
+    fn eq(&self, other: &Regex) -> bool {
+        self.regex_str == other.regex_str
+    }
+}
+
+impl Eq for Regex {}
+
+impl Serialize for Regex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.regex_str)
+    }
+}
+
+impl<'de> Deserialize<'de> for Regex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let regex_str = String::deserialize(deserializer)?;
+        Ok(Regex::new(regex_str))
+    }
+}
+
+impl Region {
+    fn new(region: regex_impl::Region) -> Self {
+        Self { region }
+    }
+
+    /// Get the start/end positions of the capture group with given index.
+    ///
+    /// If there is no match for that group or the index does not correspond to a group, `None` is
+    /// returned. The index 0 returns the whole match.
+    pub fn pos(&self, index: usize) -> Option<(usize, usize)> {
+        self.region.pos(index)
+    }
+}
+
+#[cfg(feature = "onig")]
+mod regex_impl {
+    pub use onig::Region;
+    use onig::{MatchParam, RegexOptions, SearchOptions, Syntax};
+    use std::error::Error;
+
+    #[derive(Debug)]
+    pub struct Regex {
+        regex: onig::Regex,
+    }
+
+    impl Regex {
+        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error>> {
+            let result = onig::Regex::with_options(
+                regex_str,
+                RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
+                Syntax::default(),
+            );
+            match result {
+                Ok(regex) => Ok(Regex { regex }),
+                Err(error) => Err(Box::new(error)),
+            }
+        }
+
+        pub fn is_match(&self, text: &str) -> bool {
+            self.regex
+                .match_with_options(text, 0, SearchOptions::SEARCH_OPTION_NONE, None)
+                .is_some()
+        }
+
+        pub fn search(&self, text: &str, begin: usize, end: usize) -> Option<Region> {
+            let mut region = Region::new();
+            let matched = self.regex.search_with_param(
+                text,
+                begin,
+                end,
+                SearchOptions::SEARCH_OPTION_NONE,
+                Some(&mut region),
+                MatchParam::default(),
+            );
+
+            // If there's an error during search, treat it as non-matching.
+            // For example, in case of catastrophic backtracking, onig should
+            // fail with a "retry-limit-in-match over" error eventually.
+            if let Ok(Some(_)) = matched {
+                Some(region)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[cfg(feature = "fancy-regex")]
+mod regex_impl {
+    use std::error::Error;
+
+    #[derive(Debug)]
+    pub struct Regex {
+        regex: fancy_regex::Regex,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct Region {
+        positions: Vec<Option<(usize, usize)>>,
+    }
+
+    impl Regex {
+        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error>> {
+            let result = fancy_regex::Regex::new(regex_str);
+            match result {
+                Ok(regex) => Ok(Regex { regex }),
+                Err(error) => Err(Box::new(error)),
+            }
+        }
+
+        pub fn is_match(&self, text: &str) -> bool {
+            // Errors are treated as non-matches
+            self.regex.is_match(text).unwrap_or(false)
+        }
+
+        pub fn search(&self, text: &str, begin: usize, end: usize) -> Option<Region> {
+            self.regex
+                .captures_from_pos(&text[..end], begin)
+                // Errors are treated as non-matches
+                .unwrap_or(None)
+                .map(|captures| Region::from_captures(&captures))
+        }
+    }
+
+    impl Region {
+        fn new() -> Region {
+            Region {
+                positions: Vec::new(),
+            }
+        }
+
+        fn from_captures(captures: &fancy_regex::Captures) -> Region {
+            let mut region = Region::new();
+            for i in 0..captures.len() {
+                let pos = captures.get(i).map(|m| (m.start(), m.end()));
+                region.positions.push(pos);
+            }
+            region
+        }
+
+        pub fn pos(&self, i: usize) -> Option<(usize, usize)> {
+            if i < self.positions.len() {
+                self.positions[i]
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caches_compiled_regex() {
+        let regex = Regex::new(String::from(r"\w+"));
+
+        assert!(!regex.regex.filled());
+        assert!(regex.is_match("test"));
+        assert!(regex.regex.filled());
+    }
+
+    #[test]
+    fn serde_as_string() {
+        let pattern: Regex = serde_json::from_str("\"just a string\"").unwrap();
+        assert_eq!(pattern.regex_str(), "just a string");
+        let back_to_str = serde_json::to_string(&pattern).unwrap();
+        assert_eq!(back_to_str, "\"just a string\"");
+    }
+}

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -126,7 +126,7 @@ impl Region {
     }
 }
 
-#[cfg(feature = "regex-onig")]
+#[cfg(all(not(windows), not(feature = "regex-fancy")))]
 mod regex_impl {
     pub use onig::Region;
     use onig::{MatchParam, RegexOptions, SearchOptions, Syntax};
@@ -188,8 +188,7 @@ mod regex_impl {
     }
 }
 
-// If both regex-fancy and regex-onig are requested, this condition makes regex-onig win.
-#[cfg(all(feature = "regex-fancy", not(feature = "regex-onig")))]
+#[cfg(any(windows, feature = "regex-fancy"))]
 mod regex_impl {
     use std::error::Error;
 

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -126,7 +126,7 @@ impl Region {
     }
 }
 
-#[cfg(feature = "onig")]
+#[cfg(feature = "regex-onig")]
 mod regex_impl {
     pub use onig::Region;
     use onig::{MatchParam, RegexOptions, SearchOptions, Syntax};
@@ -188,7 +188,8 @@ mod regex_impl {
     }
 }
 
-#[cfg(feature = "fancy-regex")]
+// If both regex-fancy and regex-onig are requested, this condition makes regex-onig win.
+#[cfg(all(feature = "regex-fancy", not(feature = "regex-onig")))]
 mod regex_impl {
     use std::error::Error;
 

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -294,9 +294,9 @@ mod tests {
         };
         let r = Regex::new(r"(\\\[\]\(\))(b)(c)(d)(e)".into());
         let s = r"\[]()bcde";
-        let result = r.search(s, 0, s.len());
-        assert!(result.is_some());
-        let region = result.unwrap();
+        let mut region = Region::new();
+        let matched = r.search(s, 0, s.len(), Some(&mut region));
+        assert!(matched);
 
         let regex_with_refs = pat.regex_with_refs(&region, s);
         assert_eq!(regex_with_refs.regex_str(), r"lol \\ b \\\[\]\(\) '' \wz");

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -5,9 +5,8 @@
 //! into this data structure?
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
-use lazycell::AtomicLazyCell;
-use onig::{Regex, RegexOptions, Region, Syntax};
 use super::scope::*;
+use super::regex::{Regex, Region};
 use regex_syntax::escape;
 use serde::{Serialize, Serializer};
 use crate::parsing::syntax_set::SyntaxSet;
@@ -86,17 +85,14 @@ pub struct MatchIter<'a> {
     index_stack: Vec<usize>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MatchPattern {
     pub has_captures: bool,
-    pub regex_str: String,
+    pub regex: Regex,
     pub scope: Vec<Scope>,
     pub captures: Option<CaptureMapping>,
     pub operation: MatchOperation,
     pub with_prototype: Option<ContextReference>,
-
-    #[serde(skip_serializing, skip_deserializing, default = "AtomicLazyCell::new")]
-    regex: AtomicLazyCell<Regex>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -249,81 +245,28 @@ impl MatchPattern {
     ) -> MatchPattern {
         MatchPattern {
             has_captures,
-            regex_str,
+            regex: Regex::new(regex_str),
             scope,
             captures,
             operation,
             with_prototype,
-            regex: AtomicLazyCell::new(),
         }
-    }
-
-    /// substitutes back-refs in Regex with regions from s
-    /// used for match patterns which refer to captures from the pattern
-    /// that pushed them.
-    pub fn regex_with_substitutes(&self, region: &Region, s: &str) -> String {
-        substitute_backrefs_in_regex(&self.regex_str, |i| {
-            region.pos(i).map(|(start, end)| escape(&s[start..end]))
-        })
     }
 
     /// Used by the parser to compile a regex which needs to reference
     /// regions from another matched pattern.
-    pub fn regex_with_refs(&self, region: &Region, s: &str) -> Regex {
-        // TODO don't panic on invalid regex
-        Regex::with_options(&self.regex_with_substitutes(region, s),
-                            RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
-                            Syntax::default())
-            .unwrap()
+    pub fn regex_with_refs(&self, region: &Region, text: &str) -> Regex {
+        let new_regex = substitute_backrefs_in_regex(self.regex.regex_str(), |i| {
+            region.pos(i).map(|(start, end)| escape(&text[start..end]))
+        });
+
+        return Regex::new(new_regex);
     }
 
     pub fn regex(&self) -> &Regex {
-        if let Some(regex) = self.regex.borrow() {
-            regex
-        } else {
-            // TODO don't panic on invalid regex
-            let regex = Regex::with_options(
-                &self.regex_str,
-                RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
-                Syntax::default(),
-            ).unwrap();
-            // Fill returns an error if it has already been filled. This might
-            // happen if two threads race here. In that case, just use the value
-            // that won and is now in the cell.
-            self.regex.fill(regex).ok();
-            self.regex.borrow().unwrap()
-        }
+        &self.regex
     }
 }
-
-impl Clone for MatchPattern {
-    fn clone(&self) -> MatchPattern {
-        MatchPattern {
-            has_captures: self.has_captures,
-            regex_str: self.regex_str.clone(),
-            scope: self.scope.clone(),
-            captures: self.captures.clone(),
-            operation: self.operation.clone(),
-            with_prototype: self.with_prototype.clone(),
-            // Can't clone Regex, will have to be recompiled when needed
-            regex: AtomicLazyCell::new(),
-        }
-    }
-}
-
-impl Eq for MatchPattern {}
-
-impl PartialEq for MatchPattern {
-    fn eq(&self, other: &MatchPattern) -> bool {
-        self.has_captures == other.has_captures &&
-            self.regex_str == other.regex_str &&
-            self.scope == other.scope &&
-            self.captures == other.captures &&
-            self.operation == other.operation &&
-            self.with_prototype == other.with_prototype
-    }
-}
-
 
 
 /// Serialize the provided map in natural key order, so that it's deterministic when dumping.
@@ -341,39 +284,21 @@ mod tests {
 
     #[test]
     fn can_compile_refs() {
-        use onig::{SearchOptions, Regex, Region};
         let pat = MatchPattern {
             has_captures: true,
-            regex_str: String::from(r"lol \\ \2 \1 '\9' \wz"),
+            regex: Regex::new(r"lol \\ \2 \1 '\9' \wz".into()),
             scope: vec![],
             captures: None,
             operation: MatchOperation::None,
             with_prototype: None,
-            regex: AtomicLazyCell::new(),
         };
-        let r = Regex::new(r"(\\\[\]\(\))(b)(c)(d)(e)").unwrap();
-        let mut region = Region::new();
+        let r = Regex::new(r"(\\\[\]\(\))(b)(c)(d)(e)".into());
         let s = r"\[]()bcde";
-        assert!(r.match_with_options(s, 0, SearchOptions::SEARCH_OPTION_NONE, Some(&mut region)).is_some());
+        let result = r.search(s, 0, s.len());
+        assert!(result.is_some());
+        let region = result.unwrap();
 
-        let regex_res = pat.regex_with_substitutes(&region, s);
-        assert_eq!(regex_res, r"lol \\ b \\\[\]\(\) '' \wz");
-        pat.regex_with_refs(&region, s);
-    }
-
-    #[test]
-    fn caches_compiled_regex() {
-        let pat = MatchPattern {
-            has_captures: false,
-            regex_str: String::from(r"\w+"),
-            scope: vec![],
-            captures: None,
-            operation: MatchOperation::None,
-            with_prototype: None,
-            regex: AtomicLazyCell::new(),
-        };
-
-        assert!(pat.regex().is_match("test"));
-        assert!(pat.regex.filled());
+        let regex_with_refs = pat.regex_with_refs(&region, s);
+        assert_eq!(regex_with_refs.regex_str(), r"lol \\ b \\\[\]\(\) '' \wz");
     }
 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::mem;
 
 use lazycell::AtomicLazyCell;
-use onig::Regex;
+use super::regex::Regex;
 use crate::parsing::syntax_definition::ContextId;
 
 /// A syntax set holds multiple syntaxes that have been linked together.
@@ -189,7 +189,7 @@ impl SyntaxSet {
     pub fn find_syntax_by_first_line<'a>(&'a self, s: &str) -> Option<&'a SyntaxReference> {
         let cache = self.first_line_cache();
         for &(ref reg, i) in cache.regexes.iter().rev() {
-            if reg.find(s).is_some() {
+            if reg.search(s, 0, s.len()).is_some() {
                 return Some(&self.syntaxes[i]);
             }
         }
@@ -644,9 +644,8 @@ impl FirstLineCache {
         let mut regexes = Vec::new();
         for (i, syntax) in syntaxes.iter().enumerate() {
             if let Some(ref reg_str) = syntax.first_line_match {
-                if let Ok(reg) = Regex::new(reg_str) {
-                    regexes.push((reg, i));
-                }
+                let reg = Regex::new(reg_str.into());
+                regexes.push((reg, i));
             }
         }
         FirstLineCache {

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -189,7 +189,7 @@ impl SyntaxSet {
     pub fn find_syntax_by_first_line<'a>(&'a self, s: &str) -> Option<&'a SyntaxReference> {
         let cache = self.first_line_cache();
         for &(ref reg, i) in cache.regexes.iter().rev() {
-            if reg.search(s, 0, s.len()).is_some() {
+            if reg.search(s, 0, s.len(), None) {
                 return Some(&self.syntaxes[i]);
             }
         }

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -465,11 +465,7 @@ impl SyntaxDefinition {
         regex_str: &str,
         state: &mut ParserState<'_>,
     ) -> Result<CaptureMapping, ParseSyntaxError> {
-        let r = RegexRewriter {
-            bytes: regex_str.as_bytes(),
-            index: 0,
-        };
-        let valid_indexes = r.get_consuming_capture_indexes();
+        let valid_indexes = get_consuming_capture_indexes(regex_str);
         let mut captures = Vec::new();
         for (key, value) in map.iter() {
             if let (Some(key_int), Some(val_str)) = (key.as_i64(), value.as_str()) {
@@ -560,11 +556,60 @@ fn replace_posix_char_classes(regex: String) -> String {
 }
 
 
-/// Some of the regexes include `$` and expect it to match end of line. In fancy-regex, `$` means
-/// end of text by default. Adding `(?m)` activates multi-line mode which changes `$` to match
-/// end of line.
+/// Some of the regexes include `$` and expect it to match end of line.
+/// In fancy-regex, `$` means end of text by default. Adding `(?m)` activates
+/// multi-line mode which changes `$` to match end of line.
+///
+/// But it also changes `^` to match beginning of line, which with fancy-regex
+/// also matches at the end of e.g. `"test\n"`.
+///
+/// So, we rewrite `^` to `\A` to always mean beginning of text, and add `(?m)`
+/// to change the meaning of `$`.
 fn regex_for_newlines(regex: String) -> String {
-    format!("(?m){}", regex)
+    if !regex.contains(|c| c == '^' || c == '$') {
+        return regex;
+    }
+
+    let rewriter = RegexRewriterForNewlines {
+        parser: Parser::new(regex.as_bytes()),
+    };
+    rewriter.rewrite()
+}
+
+struct RegexRewriterForNewlines<'a> {
+    parser: Parser<'a>,
+}
+
+impl<'a> RegexRewriterForNewlines<'a> {
+    fn rewrite(mut self) -> String {
+        let mut result = Vec::new();
+        result.extend_from_slice(br"(?m)");
+        while let Some(c) = self.parser.peek() {
+            match c {
+                b'^' => {
+                    self.parser.next();
+                    result.extend_from_slice(br"\A");
+                }
+                b'\\' => {
+                    self.parser.next();
+                    result.push(c);
+                    if let Some(c2) = self.parser.peek() {
+                        self.parser.next();
+                        result.push(c2);
+                    }
+                }
+                b'[' => {
+                    let (mut content, _) = self.parser.parse_character_class();
+                    result.append(&mut content);
+                }
+                _ => {
+                    self.parser.next();
+                    result.push(c);
+                }
+            }
+        }
+        String::from_utf8(result).unwrap()
+    }
 }
 
 /// Rewrite a regex that matches `\n` to one that matches `$` (end of line) instead.
@@ -584,30 +629,28 @@ fn regex_for_no_newlines(regex: String) -> String {
     // handle properly.
     let regex = regex.replace("(?:\\n)?", "(?:$|)");
 
-    let rewriter = RegexRewriter {
-        bytes: regex.as_bytes(),
-        index: 0,
+    let rewriter = RegexRewriterForNoNewlines {
+        parser: Parser::new(regex.as_bytes()),
     };
     rewriter.rewrite()
 }
 
-struct RegexRewriter<'a> {
-    bytes: &'a [u8],
-    index: usize,
+struct RegexRewriterForNoNewlines<'a> {
+    parser: Parser<'a>,
 }
 
-impl<'a> RegexRewriter<'a> {
+impl<'a> RegexRewriterForNoNewlines<'a> {
     fn rewrite(mut self) -> String {
         let mut result = Vec::new();
-        while let Some(c) = self.peek() {
+        while let Some(c) = self.parser.peek() {
             match c {
                 b'\\' => {
-                    self.next();
-                    if let Some(c2) = self.peek() {
-                        self.next();
+                    self.parser.next();
+                    if let Some(c2) = self.parser.peek() {
+                        self.parser.next();
                         // Replacing `\n` with `$` in `\n?` or `\n+` would make parsing later fail
                         // with "target of repeat operator is invalid"
-                        let c3 = self.peek();
+                        let c3 = self.parser.peek();
                         if c2 == b'n' && c3 != Some(b'?') && c3 != Some(b'+') && c3 != Some(b'*') {
                             result.extend_from_slice(b"$");
                         } else {
@@ -619,8 +662,8 @@ impl<'a> RegexRewriter<'a> {
                     }
                 }
                 b'[' => {
-                    let (mut content, matches_newline) = self.parse_character_class();
-                    if matches_newline && self.peek() != Some(b'?') {
+                    let (mut content, matches_newline) = self.parser.parse_character_class();
+                    if matches_newline && self.parser.peek() != Some(b'?') {
                         result.extend_from_slice(b"(?:");
                         result.append(&mut content);
                         result.extend_from_slice(br"|$)");
@@ -629,14 +672,27 @@ impl<'a> RegexRewriter<'a> {
                     }
                 }
                 _ => {
-                    self.next();
+                    self.parser.next();
                     result.push(c);
                 }
             }
         }
         String::from_utf8(result).unwrap()
     }
+}
 
+fn get_consuming_capture_indexes(regex: &str) -> Vec<usize> {
+    let parser = ConsumingCaptureIndexParser {
+        parser: Parser::new(regex.as_bytes()),
+    };
+    parser.get_consuming_capture_indexes()
+}
+
+struct ConsumingCaptureIndexParser<'a> {
+    parser: Parser<'a>,
+}
+
+impl<'a> ConsumingCaptureIndexParser<'a> {
     /// find capture groups which are not inside lookarounds.
     /// If, in a YAML syntax definition, a scope stack is applied
     /// to a capture group inside a lookaround,
@@ -651,20 +707,20 @@ impl<'a> RegexRewriter<'a> {
         stack.push(in_lookaround);
         result.push(cap_num);
 
-        while let Some(c) = self.peek() {
+        while let Some(c) = self.parser.peek() {
             match c {
                 b'\\' => {
-                    self.next();
-                    self.next();
+                    self.parser.next();
+                    self.parser.next();
                 }
                 b'[' => {
-                    self.parse_character_class();
+                    self.parser.parse_character_class();
                 }
                 b'(' => {
-                    self.next();
+                    self.parser.next();
                     // add the current lookaround state to the stack so we can just pop at a closing paren
                     stack.push(in_lookaround);
-                    if let Some(c2) = self.peek() {
+                    if let Some(c2) = self.parser.peek() {
                         if c2 != b'?' {
                             // simple numbered capture group
                             cap_num += 1;
@@ -674,22 +730,22 @@ impl<'a> RegexRewriter<'a> {
                                 result.push(cap_num);
                             }
                         } else {
-                            self.next();
-                            if let Some(c3) = self.peek() {
-                                self.next();
+                            self.parser.next();
+                            if let Some(c3) = self.parser.peek() {
+                                self.parser.next();
                                 if c3 == b'=' || c3 == b'!' {
                                     // lookahead
                                     in_lookaround = true;
                                 } else if c3 == b'<' {
-                                    if let Some(c4) = self.peek() {
+                                    if let Some(c4) = self.parser.peek() {
                                         if c4 == b'=' || c4 == b'!' {
-                                            self.next();
+                                            self.parser.next();
                                             // lookbehind
                                             in_lookaround = true;
                                         }
                                     }
                                 } else if c3 == b'P' {
-                                    if let Some(c4) = self.peek() {
+                                    if let Some(c4) = self.parser.peek() {
                                         if c4 == b'<' {
                                             // named capture group
                                             cap_num += 1;
@@ -709,14 +765,36 @@ impl<'a> RegexRewriter<'a> {
                     if let Some(value) = stack.pop() {
                         in_lookaround = value;
                     }
-                    self.next();
+                    self.parser.next();
                 }
                 _ => {
-                    self.next();
+                    self.parser.next();
                 }
             }
         }
         result
+    }
+}
+
+struct Parser<'a> {
+    bytes: &'a [u8],
+    index: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(bytes: &[u8]) -> Parser {
+        Parser {
+            bytes,
+            index: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.index).map(|&b| b)
+    }
+
+    fn next(&mut self) {
+        self.index += 1;
     }
 
     fn parse_character_class(&mut self) -> (Vec<u8>, bool) {
@@ -743,15 +821,13 @@ impl<'a> RegexRewriter<'a> {
             match c {
                 b'\\' => {
                     self.next();
+                    content.push(c);
                     if let Some(c2) = self.peek() {
                         self.next();
                         if c2 == b'n' && !negated && nesting == 0 {
                             matches_newline = true;
                         }
-                        content.push(c);
                         content.push(c2);
-                    } else {
-                        content.push(c);
                     }
                 }
                 b'[' => {
@@ -775,14 +851,6 @@ impl<'a> RegexRewriter<'a> {
         }
 
         (content, matches_newline)
-    }
-
-    fn peek(&self) -> Option<u8> {
-        self.bytes.get(self.index).cloned()
-    }
-
-    fn next(&mut self) {
-        self.index += 1;
     }
 }
 
@@ -1064,6 +1132,26 @@ mod tests {
     }
 
     #[test]
+    fn can_rewrite_regex_for_newlines() {
+        fn rewrite(s: &str) -> String {
+            regex_for_newlines(s.to_string())
+        }
+
+        assert_eq!(&rewrite(r"a"), r"a");
+        assert_eq!(&rewrite(r"\b"), r"\b");
+        assert_eq!(&rewrite(r"(a)"), r"(a)");
+        assert_eq!(&rewrite(r"[a]"), r"[a]");
+        assert_eq!(&rewrite(r"[^a]"), r"(?m)[^a]");
+        assert_eq!(&rewrite(r"[]a]"), r"[]a]");
+        assert_eq!(&rewrite(r"[[a]]"), r"[[a]]");
+
+        assert_eq!(&rewrite(r"^"), r"(?m)\A");
+        assert_eq!(&rewrite(r"$"), r"(?m)$");
+        assert_eq!(&rewrite(r"^ab$"), r"(?m)\Aab$");
+        assert_eq!(&rewrite(r"\^ab\$"), r"(?m)\^ab\$");
+    }
+
+    #[test]
     fn can_rewrite_regex_for_no_newlines() {
         fn rewrite(s: &str) -> String {
             regex_for_no_newlines(s.to_string())
@@ -1100,12 +1188,8 @@ mod tests {
     #[test]
     fn can_get_valid_captures_from_regex() {
         let regex = "hello(test)(?=(world))(foo(?P<named>bar))";
-        let r = RegexRewriter {
-            bytes: regex.as_bytes(),
-            index: 0,
-        };
         println!("{:?}", regex);
-        let valid_indexes = r.get_consuming_capture_indexes();
+        let valid_indexes = get_consuming_capture_indexes(regex);
         println!("{:?}", valid_indexes);
         assert_eq!(valid_indexes, [0, 1, 3, 4]);
     }
@@ -1113,12 +1197,8 @@ mod tests {
     #[test]
     fn can_get_valid_captures_from_regex2() {
         let regex = "hello(test)[(?=tricked](foo(bar))";
-        let r = RegexRewriter {
-            bytes: regex.as_bytes(),
-            index: 0,
-        };
         println!("{:?}", regex);
-        let valid_indexes = r.get_consuming_capture_indexes();
+        let valid_indexes = get_consuming_capture_indexes(regex);
         println!("{:?}", valid_indexes);
         assert_eq!(valid_indexes, [0, 1, 2, 3]);
     }
@@ -1126,12 +1206,8 @@ mod tests {
     #[test]
     fn can_get_valid_captures_from_nested_regex() {
         let regex = "hello(test)(?=(world(?!(te(?<=(st))))))(foo(bar))";
-        let r = RegexRewriter {
-            bytes: regex.as_bytes(),
-            index: 0,
-        };
         println!("{:?}", regex);
-        let valid_indexes = r.get_consuming_capture_indexes();
+        let valid_indexes = get_consuming_capture_indexes(regex);
         println!("{:?}", valid_indexes);
         assert_eq!(valid_indexes, [0, 1, 5, 6]);
     }


### PR DESCRIPTION
Even with onig as an unused feature, it still causes the build to fail on windows.

Conditionally excludes onig dependency on windows.
Use fancy-regex by default on windows.

Use onig-regex by default on not-windows.
fancy-regex is a feature for not-windows.