### PR TITLE
Make sure 'ParseSyntaxError' implements 'Send'

### DIFF
--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -32,7 +32,7 @@ impl Regex {
     }
 
     /// Check whether the pattern compiles as a valid regex or not.
-    pub fn try_compile(regex_str: &str) -> Option<Box<dyn Error>> {
+    pub fn try_compile(regex_str: &str) -> Option<Box<dyn Error + Send>> {
         regex_impl::Regex::new(regex_str).err()
     }
 
@@ -142,7 +142,7 @@ mod regex_impl {
     }
 
     impl Regex {
-        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error>> {
+        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error + Send>> {
             let result = onig::Regex::with_options(
                 regex_str,
                 RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
@@ -210,7 +210,7 @@ mod regex_impl {
     }
 
     impl Regex {
-        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error>> {
+        pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error + Send>> {
             let result = fancy_regex::Regex::new(regex_str);
             match result {
                 Ok(regex) => Ok(Regex { regex }),

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -18,7 +18,7 @@ pub enum ParseSyntaxError {
     /// Some keys are required for something to be a valid `.sublime-syntax`
     MissingMandatoryKey(&'static str),
     /// Invalid regex
-    RegexCompileError(String, Box<dyn Error>),
+    RegexCompileError(String, Box<dyn Error + Send>),
     /// A scope that syntect's scope implementation can't handle
     InvalidScope(ParseScopeError),
     /// A reference to another file that is invalid


### PR DESCRIPTION
Since `syntect` 4.0, `syntect::parsing::ParseSyntaxError` does not implement `Send` anymore:
* https://docs.rs/syntect/3.3.0/syntect/parsing/enum.ParseSyntaxError.html
* https://docs.rs/syntect/4.0.0/syntect/parsing/enum.ParseSyntaxError.html

due to the `Box<dyn Error>` in the `RegexCompileError` variant.

Related issue: https://github.com/sharkdp/bat/issues/650#issuecomment-605999784

This PR fixes this.