### PR TITLE
Use 'Display::fmt' instead of 'Error::description', fix warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,33 +109,21 @@ impl fmt::Display for LoadingError {
             #[cfg(feature = "yaml-load")]
             ParseSyntax(ref error, ref filename) => {
                 if let Some(ref file) = filename {
-                    write!(f, "{}: {}", file, error.description())
+                    write!(f, "{}: {}", file, error)
                 } else {
                     error.fmt(f)
                 }
             },
-            _ => write!(f, "{}", self.description()),
+            #[cfg(feature = "metadata")]
+            ParseMetadata(_) => write!(f, "Failed to parse JSON"),
+            ParseTheme(_) => write!(f, "Invalid syntax theme"),
+            ReadSettings(_) => write!(f, "Invalid syntax theme settings"),
+            BadPath => write!(f, "Invalid path"),
         }
     }
 }
 
 impl Error for LoadingError {
-    fn description(&self) -> &str {
-        use crate::LoadingError::*;
-
-        match *self {
-            WalkDir(ref error) => error.description(),
-            Io(ref error) => error.description(),
-            #[cfg(feature = "yaml-load")]
-            ParseSyntax(ref error, ..) => error.description(),
-            #[cfg(feature = "metadata")]
-            ParseMetadata(_) => "Failed to parse JSON",
-            ParseTheme(_) => "Invalid syntax theme",
-            ReadSettings(_) => "Invalid syntax theme settings",
-            BadPath => "Invalid path",
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         use crate::LoadingError::*;
 

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -191,9 +191,9 @@ impl Scope {
     /// It is used internally for turning a scope back into a string.
     pub fn atom_at(self, index: usize) -> u16 {
         let shifted = if index < 4 {
-            (self.a >> ((3 - index) * 16))
+            self.a >> ((3 - index) * 16)
         } else if index < 8 {
-            (self.b >> ((7 - index) * 16))
+            self.b >> ((7 - index) * 16)
         } else {
             panic!("atom index out of bounds {:?}", index);
         };

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -36,30 +36,21 @@ impl fmt::Display for ParseSyntaxError {
         use crate::ParseSyntaxError::*;
 
         match *self {
+            InvalidYaml(_) => write!(f, "Invalid YAML file syntax"),
+            EmptyFile => write!(f, "Empty file"),
+            MissingMandatoryKey(_) => write!(f, "Missing mandatory key in YAML file"),
             RegexCompileError(ref regex, ref error) =>
                 write!(f, "Error while compiling regex '{}': {}",
                        regex, error),
-            _ => write!(f, "{}", self.description())
+            InvalidScope(_) => write!(f, "Invalid scope"),
+            BadFileRef => write!(f, "Invalid file reference"),
+            MainMissing => write!(f, "Context 'main' is missing"),
+            TypeMismatch => write!(f, "Type mismatch"),
         }
     }
 }
 
 impl Error for ParseSyntaxError {
-    fn description(&self) -> &str {
-        use crate::ParseSyntaxError::*;
-
-        match self {
-            InvalidYaml(_) => "Invalid YAML file syntax",
-            EmptyFile => "Empty file",
-            MissingMandatoryKey(_) => "Missing mandatory key in YAML file",
-            RegexCompileError(_, error) => error.description(),
-            InvalidScope(_) => "Invalid scope",
-            BadFileRef => "Invalid file reference",
-            MainMissing => "Context 'main' is missing",
-            TypeMismatch => "Type mismatch",
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         use crate::ParseSyntaxError::*;
 


### PR DESCRIPTION
`Error::description` has been deprecated in Rust 1.42: https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.description

When compiling `syntect` with the latest compiler, error messages look like this:
```
[bat error]: /home/shark/Informatik/rust/bat/assets/syntaxes/01_Packages/PHP/PHP Source.sublime-syntax:
description() is deprecated; use Display
```

With this fix, we can see the reason for error messages again:
```
[bat error]: /home/shark/Informatik/rust/bat/assets/syntaxes/01_Packages/PHP/PHP Source.sublime-syntax:
Error while compiling regex '(?x)/\*\*(?:
  (?:\#@\+)?\s*(?m:$) (?# multi-line doc )
  |
  (?=\s+@.*\s\*/\s*(?m:$)) (?# inline doc )
)': Unknown group flag
```

I also fixed the other two remaining warnings concerning superfluous parentheses.