### PR TITLE
support backrefs in included contexts

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1711,6 +1711,29 @@ contexts:
 
         expect_scope_stacks_with_syntax(&"aa", &["<a>", "<b>"], syntax);
     }
+    
+    #[test]
+    fn can_include_nested_backrefs() {
+        let syntax = SyntaxDefinition::load_from_str(r#"
+                name: Backref Include Test
+                scope: source.backrefinc
+                contexts:
+                  main:
+                    - match: (a)
+                      scope: a
+                      push: context1
+                  context1:
+                    - include: context3
+                  context3:
+                    - include: context2
+                  context2:
+                    - match: \1
+                      scope: b
+                      pop: true
+                "#, true, None).unwrap();
+
+        expect_scope_stacks_with_syntax(&"aa", &["<a>", "<b>"], syntax);
+    }
 
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {
         println!("Parsing with newlines");

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1691,6 +1691,27 @@ contexts:
         expect_scope_stacks("\u{1F600}x", &["<source.test>, <test.good>"], syntax);
     }
 
+    #[test]
+    fn can_include_backrefs() {
+        let syntax = SyntaxDefinition::load_from_str(r#"
+                name: Backref Include Test
+                scope: source.backrefinc
+                contexts:
+                  main:
+                    - match: (a)
+                      scope: a
+                      push: context1
+                  context1:
+                    - include: context2
+                  context2:
+                    - match: \1
+                      scope: b
+                      pop: true
+                "#, true, None).unwrap();
+
+        expect_scope_stacks_with_syntax(&"aa", &["<a>", "<b>"], syntax);
+    }
+
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {
         println!("Parsing with newlines");
         let line_with_newline = format!("{}\n", line_without_newline);

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -499,26 +499,17 @@ impl SyntaxSetBuilder {
             for context_id in syntax.contexts.values() {
                 let index = context_id.index();
                 let context = &all_contexts[index];
-                if !context.uses_backrefs {
-                    let mut uses_backrefs = false;
-                    for pattern in &context.patterns {
-                        match *pattern {
-                            Pattern::Include(ref context_ref) => {
-                                match context_ref {
-                                    ContextReference::Direct(ref id) => {
-                                        if (&all_contexts[id.index()]).uses_backrefs {
-                                            uses_backrefs = true;
-                                            break;
-                                        }
-                                    }, _ => {},
-                                }
-                            }, _ => {},
+                let uses_backrefs = context.patterns.iter().any(|pattern| {
+                    if let Pattern::Include(ref context_ref) = *pattern {
+                        if let ContextReference::Direct(ref id) = context_ref {
+                            return (&all_contexts[id.index()]).uses_backrefs;
                         }
                     }
-                    if uses_backrefs {
-                        let mut context = &mut all_contexts[index];
-                        context.uses_backrefs = true;
-                    }
+                    false
+                });
+                if uses_backrefs {
+                    let mut context = &mut all_contexts[index];
+                    context.uses_backrefs = true;
                 }
             }
         }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -502,6 +502,13 @@ impl SyntaxSetBuilder {
             }
         }
         
+        // We need to recursively mark contexts that include contexts which
+        // use backreferences as using backreferences. In theory we could use
+        // a more efficient method here like doing a toposort or constructing
+        // a representation with reversed edges and then tracing in the
+        // opposite direction, but I benchmarked this and it adds <2% to link
+        // time on the default syntax set, and linking doesn't even happen
+        // when loading from a binary dump.
         while found_more_backref_includes {
             found_more_backref_includes = false;
             // find any contexts which include a context which uses backrefs
@@ -509,14 +516,11 @@ impl SyntaxSetBuilder {
             for context_index in 0..all_contexts.len() {
                 let context = &all_contexts[context_index];
                 if !context.uses_backrefs && context.patterns.iter().any(|pattern| {
-                    if let Pattern::Include(ref context_ref) = *pattern {
-                        if let ContextReference::Direct(ref id) = context_ref {
-                            if all_contexts[id.index()].uses_backrefs {
-                                return true;
-                            }
-                        }
+                    match pattern {
+                        Pattern::Include(ContextReference::Direct(id))
+                            if all_contexts[id.index()].uses_backrefs => true,
+                        _ => false,
                     }
-                    false
                 }) {
                     let mut context = &mut all_contexts[context_index];
                     context.uses_backrefs = true;

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -495,6 +495,32 @@ impl SyntaxSetBuilder {
                 }
                 Self::link_context(&mut context, syntax, &syntaxes);
             }
+            
+            for context_id in syntax.contexts.values() {
+                let index = context_id.index();
+                let context = &all_contexts[index];
+                if !context.uses_backrefs {
+                    let mut uses_backrefs = false;
+                    for pattern in &context.patterns {
+                        match *pattern {
+                            Pattern::Include(ref context_ref) => {
+                                match context_ref {
+                                    ContextReference::Direct(ref id) => {
+                                        if (&all_contexts[id.index()]).uses_backrefs {
+                                            uses_backrefs = true;
+                                            break;
+                                        }
+                                    }, _ => {},
+                                }
+                            }, _ => {},
+                        }
+                    }
+                    if uses_backrefs {
+                        let mut context = &mut all_contexts[index];
+                        context.uses_backrefs = true;
+                    }
+                }
+            }
         }
 
         #[cfg(feature = "metadata")]


### PR DESCRIPTION
fixes #104 - when building the syntax set, after the contexts are linked to direct references, it now checks if any included contexts use backreferences in their match patterns, and if so, marks the base context as using backreferences.