### PR TITLE
Rustfmt *; add doc links

### DIFF
--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -1,11 +1,11 @@
-use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use syntect::parsing::{SyntaxSet, SyntaxReference, ScopeStack};
-use syntect::highlighting::{ThemeSet, Theme};
-use syntect::easy::HighlightLines;
-use syntect::html::highlighted_html_for_string;
-use std::str::FromStr;
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use std::fs::File;
 use std::io::Read;
+use std::str::FromStr;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme, ThemeSet};
+use syntect::html::highlighted_html_for_string;
+use syntect::parsing::{ScopeStack, SyntaxReference, SyntaxSet};
 
 fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> usize {
     let mut h = HighlightLines::new(syntax, theme);
@@ -37,19 +37,14 @@ fn highlight_file(b: &mut Bencher, file: &str) {
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
-    b.iter(|| {
-        do_highlight(&s, &ss, syntax, &ts.themes["base16-ocean.dark"])
-    });
+    b.iter(|| do_highlight(&s, &ss, syntax, &ts.themes["base16-ocean.dark"]));
 }
-
 
 fn stack_matching(b: &mut Bencher) {
     let s = "source.js meta.group.js meta.group.js meta.block.js meta.function-call.method.js meta.group.js meta.object-literal.js meta.block.js meta.function-call.method.js meta.group.js variable.other.readwrite.js";
     let stack = ScopeStack::from_str(s).unwrap();
     let selector = ScopeStack::from_str("source meta.function-call.method").unwrap();
-    b.iter(|| {
-        selector.does_match(stack.as_slice())
-    });
+    b.iter(|| selector.does_match(stack.as_slice()));
 }
 
 fn highlight_html(b: &mut Bencher) {
@@ -62,9 +57,7 @@ fn highlight_html(b: &mut Bencher) {
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
-    b.iter(|| {
-        highlighted_html_for_string(&s, &ss, syntax, &ts.themes["base16-ocean.dark"])
-    });
+    b.iter(|| highlighted_html_for_string(&s, &ss, syntax, &ts.themes["base16-ocean.dark"]));
 }
 
 fn highlighting_benchmark(c: &mut Criterion) {

--- a/benches/loading.rs
+++ b/benches/loading.rs
@@ -1,24 +1,17 @@
-use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use syntect::highlighting::ThemeSet;
-
+use syntect::parsing::{SyntaxSet, SyntaxSetBuilder};
 
 fn bench_load_internal_dump(b: &mut Bencher) {
-    b.iter(|| {
-        SyntaxSet::load_defaults_newlines()
-    });
+    b.iter(|| SyntaxSet::load_defaults_newlines());
 }
 
 fn bench_load_internal_themes(b: &mut Bencher) {
-    b.iter(|| {
-        ThemeSet::load_defaults()
-    });
+    b.iter(|| ThemeSet::load_defaults());
 }
 
 fn bench_load_theme(b: &mut Bencher) {
-    b.iter(|| {
-        ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme")
-    });
+    b.iter(|| ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme"));
 }
 
 fn bench_add_from_folder(b: &mut Bencher) {

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,4 +1,4 @@
-use criterion::{Bencher, Criterion, criterion_group, criterion_main};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use std::fs::File;
 use std::io::Read;
 use std::time::Duration;

--- a/examples/gendata.rs
+++ b/examples/gendata.rs
@@ -5,29 +5,32 @@
 //!
 //! An example of how this script is used to generate the pack files included
 //! with syntect can be found under `make packs` in the Makefile.
-use syntect::parsing::SyntaxSetBuilder;
-use syntect::highlighting::ThemeSet;
-use syntect::dumps::*;
 use std::env;
+use syntect::dumps::*;
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSetBuilder;
 
 fn usage_and_exit() -> ! {
-    println!("USAGE: gendata synpack source-dir \
+    println!(
+        "USAGE: gendata synpack source-dir \
               newlines.packdump nonewlines.packdump \
               [metadata.packdump] [metadata extra-source-dir]\n       \
-              gendata themepack source-dir themepack.themedump");
+              gendata themepack source-dir themepack.themedump"
+    );
     ::std::process::exit(2);
 }
 
 fn main() {
     let mut a = env::args().skip(1);
     match (a.next(), a.next(), a.next(), a.next(), a.next(), a.next()) {
-        (Some(ref cmd),
-         Some(ref package_dir),
-         Some(ref packpath_newlines),
-         Some(ref packpath_nonewlines),
-         ref _option_metapath,
-         ref _option_metasource,
-         ) if cmd == "synpack" => {
+        (
+            Some(ref cmd),
+            Some(ref package_dir),
+            Some(ref packpath_newlines),
+            Some(ref packpath_nonewlines),
+            ref _option_metapath,
+            ref _option_metasource,
+        ) if cmd == "synpack" => {
             let mut builder = SyntaxSetBuilder::new();
             builder.add_plain_text_syntax();
             builder.add_from_folder(package_dir, true).unwrap();
@@ -36,12 +39,16 @@ fn main() {
 
             let mut builder_nonewlines = SyntaxSetBuilder::new();
             builder_nonewlines.add_plain_text_syntax();
-            builder_nonewlines.add_from_folder(package_dir, false).unwrap();
+            builder_nonewlines
+                .add_from_folder(package_dir, false)
+                .unwrap();
 
             #[cfg(feature = "metadata")]
             {
                 if let Some(metasource) = _option_metasource {
-                    builder_nonewlines.add_from_folder(metasource, false).unwrap();
+                    builder_nonewlines
+                        .add_from_folder(metasource, false)
+                        .unwrap();
                 }
             }
 
@@ -54,7 +61,6 @@ fn main() {
                     dump_to_file(&ss_nonewlines.metadata(), metapath).unwrap();
                 }
             }
-
         }
         (Some(ref s), Some(ref theme_dir), Some(ref packpath), ..) if s == "themepack" => {
             let ts = ThemeSet::load_from_folder(theme_dir).unwrap();

--- a/examples/latex-demo.rs
+++ b/examples/latex-demo.rs
@@ -1,7 +1,7 @@
 use syntect::easy::HighlightLines;
+use syntect::highlighting::{Style, ThemeSet};
 use syntect::parsing::SyntaxSet;
-use syntect::highlighting::{ThemeSet,Style};
-use syntect::util::{as_latex_escaped,LinesWithEndings};
+use syntect::util::{as_latex_escaped, LinesWithEndings};
 
 fn main() {
     // Load these once at the start of your program
@@ -12,7 +12,8 @@ fn main() {
     let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}\n";
 
     let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
-    for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
+    for line in LinesWithEndings::from(s) {
+        // LinesWithEndings enables use of newlines mode
         let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
         let escaped = as_latex_escaped(&ranges[..]);
         println!("\n{:?}", line);

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -1,13 +1,13 @@
 //! Highlights the files given on the command line, in parallel.
 //! Prints the highlighted output to stdout.
 
-use syntect::parsing::SyntaxSet;
-use syntect::highlighting::{ThemeSet, Style};
-use syntect::easy::HighlightFile;
 use rayon::prelude::*;
+use syntect::easy::HighlightFile;
+use syntect::highlighting::{Style, ThemeSet};
+use syntect::parsing::SyntaxSet;
 
 use std::fs::File;
-use std::io::{BufReader, BufRead};
+use std::io::{BufRead, BufReader};
 
 fn main() {
     let files: Vec<String> = std::env::args().skip(1).collect();
@@ -21,7 +21,8 @@ fn main() {
     let theme_set = ThemeSet::load_defaults();
 
     // We first collect the contents of the files...
-    let contents: Vec<Vec<String>> = files.par_iter()
+    let contents: Vec<Vec<String>> = files
+        .par_iter()
         .map(|filename| {
             let mut lines = Vec::new();
             // We use `String::new()` and `read_line()` instead of `BufRead::lines()`
@@ -37,7 +38,8 @@ fn main() {
         .collect();
 
     // ...so that the highlighted regions have valid lifetimes...
-    let regions: Vec<Vec<(Style, &str)>> = files.par_iter()
+    let regions: Vec<Vec<(Style, &str)>> = files
+        .par_iter()
         .zip(&contents)
         .map(|(filename, contents)| {
             let mut regions = Vec::new();
@@ -56,6 +58,9 @@ fn main() {
 
     // ...and then print them all out.
     for file_regions in regions {
-        print!("{}", syntect::util::as_24_bit_terminal_escaped(&file_regions[..], true));
+        print!(
+            "{}",
+            syntect::util::as_24_bit_terminal_escaped(&file_regions[..], true)
+        );
     }
 }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -2,11 +2,11 @@ use getopts::Options;
 use std::borrow::Cow;
 use std::io::BufRead;
 use std::path::Path;
-use syntect::parsing::SyntaxSet;
-use syntect::highlighting::{Theme, ThemeSet, Style};
-use syntect::util::as_24_bit_terminal_escaped;
+use syntect::dumps::{dump_to_file, from_dump_file};
 use syntect::easy::HighlightFile;
-use syntect::dumps::{from_dump_file, dump_to_file};
+use syntect::highlighting::{Style, Theme, ThemeSet};
+use syntect::parsing::SyntaxSet;
+use syntect::util::as_24_bit_terminal_escaped;
 
 fn load_theme(tm_file: &String, enable_caching: bool) -> Theme {
     let tm_path = Path::new(tm_file);
@@ -30,16 +30,33 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let mut opts = Options::new();
     opts.optflag("l", "list-file-types", "Lists supported file types");
-    opts.optflag("L", "list-embedded-themes", "Lists themes present in the executable");
+    opts.optflag(
+        "L",
+        "list-embedded-themes",
+        "Lists themes present in the executable",
+    );
     opts.optopt("t", "theme-file", "THEME_FILE", "Theme file to use. May be a path, or an embedded theme. Embedded themes will take precendence. Default: base16-ocean.dark");
-    opts.optopt("s", "extra-syntaxes", "SYNTAX_FOLDER", "Additional folder to search for .sublime-syntax files in.");
-    opts.optflag("e", "no-default-syntaxes", "Doesn't load default syntaxes, intended for use with --extra-syntaxes.");
-    opts.optflag("n", "no-newlines", "Uses the no newlines versions of syntaxes and dumps.");
+    opts.optopt(
+        "s",
+        "extra-syntaxes",
+        "SYNTAX_FOLDER",
+        "Additional folder to search for .sublime-syntax files in.",
+    );
+    opts.optflag(
+        "e",
+        "no-default-syntaxes",
+        "Doesn't load default syntaxes, intended for use with --extra-syntaxes.",
+    );
+    opts.optflag(
+        "n",
+        "no-newlines",
+        "Uses the no newlines versions of syntaxes and dumps.",
+    );
     opts.optflag("c", "cache-theme", "Cache the parsed theme file.");
 
     let matches = match opts.parse(&args[1..]) {
-        Ok(m) => { m }
-        Err(f) => { panic!(f.to_string()) }
+        Ok(m) => m,
+        Err(f) => panic!(f.to_string()),
     };
 
     let no_newlines = matches.opt_present("no-newlines");
@@ -65,25 +82,27 @@ fn main() {
         for sd in ss.syntaxes() {
             println!("- {} (.{})", sd.name, sd.file_extensions.join(", ."));
         }
-
     } else if matches.opt_present("list-embedded-themes") {
         println!("Embedded themes:");
 
         for t in ts.themes.keys() {
             println!("- {}", t);
         }
-
     } else if matches.free.len() == 0 {
         let brief = format!("USAGE: {} [options] FILES", args[0]);
         println!("{}", opts.usage(&brief));
-
     } else {
-        let theme_file : String = matches.opt_str("theme-file")
+        let theme_file: String = matches
+            .opt_str("theme-file")
             .unwrap_or("base16-ocean.dark".to_string());
 
-        let theme = ts.themes.get(&theme_file)
+        let theme = ts
+            .themes
+            .get(&theme_file)
             .map(|t| Cow::Borrowed(t))
-            .unwrap_or_else(|| Cow::Owned(load_theme(&theme_file, matches.opt_present("cache-theme"))));
+            .unwrap_or_else(|| {
+                Cow::Owned(load_theme(&theme_file, matches.opt_present("cache-theme")))
+            });
 
         for src in &matches.free[..] {
             if matches.free.len() > 1 {
@@ -103,7 +122,8 @@ fn main() {
                 }
 
                 {
-                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
+                    let regions: Vec<(Style, &str)> =
+                        highlighter.highlight_lines.highlight(&line, &ss);
                     print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
                 }
                 line.clear();

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -11,7 +11,7 @@
 //! mode.
 use syntect::highlighting::ThemeSet;
 use syntect::html::css_for_theme_with_class_style;
-use syntect::html::{ClassedHTMLGenerator, ClassStyle};
+use syntect::html::{ClassStyle, ClassedHTMLGenerator};
 use syntect::parsing::SyntaxSet;
 
 use std::fs::File;
@@ -23,7 +23,7 @@ fn main() -> Result<(), std::io::Error> {
     // generate html
     let ss = SyntaxSet::load_defaults_newlines();
 
-    let html_file =  File::create(Path::new("synhtml-css-classes.html"))?;
+    let html_file = File::create(Path::new("synhtml-css-classes.html"))?;
     let mut html = BufWriter::new(&html_file);
 
     // write html header
@@ -31,7 +31,10 @@ fn main() -> Result<(), std::io::Error> {
     writeln!(html, "<html>")?;
     writeln!(html, "  <head>")?;
     writeln!(html, "    <title>synhtml-css-classes.rs</title>")?;
-    writeln!(html, "    <link rel=\"stylesheet\" href=\"synhtml-css-classes.css\">")?;
+    writeln!(
+        html,
+        "    <link rel=\"stylesheet\" href=\"synhtml-css-classes.css\">"
+    )?;
     writeln!(html, "  </head>")?;
     writeln!(html, "  <body>")?;
 
@@ -42,7 +45,8 @@ fn main() {
 }";
 
     let sr_rs = ss.find_syntax_by_extension("rs").unwrap();
-    let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_rs, &ss, ClassStyle::Spaced);
+    let mut rs_html_generator =
+        ClassedHTMLGenerator::new_with_class_style(&sr_rs, &ss, ClassStyle::Spaced);
     for line in code_rs.lines() {
         rs_html_generator.parse_html_for_line(&line);
     }
@@ -60,7 +64,8 @@ int main() {
 }";
 
     let sr_cpp = ss.find_syntax_by_extension("cpp").unwrap();
-    let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_cpp, &ss, ClassStyle::Spaced);
+    let mut cpp_html_generator =
+        ClassedHTMLGenerator::new_with_class_style(&sr_cpp, &ss, ClassStyle::Spaced);
     for line in code_cpp.lines() {
         cpp_html_generator.parse_html_for_line(&line);
     }

--- a/examples/synhtml.rs
+++ b/examples/synhtml.rs
@@ -1,8 +1,8 @@
 //! Prints highlighted HTML for a file to stdout.
 //! Basically just wraps a body around `highlighted_html_for_file`
-use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{Color, ThemeSet};
 use syntect::html::highlighted_html_for_file;
+use syntect::parsing::SyntaxSet;
 
 fn main() {
     let ss = SyntaxSet::load_defaults_newlines();
@@ -19,10 +19,16 @@ fn main() {
             font-size:13px;
             font-family: Consolas, \"Liberation Mono\", Menlo, Courier, monospace;
         }";
-    println!("<head><title>{}</title><style>{}</style></head>", &args[1], style);
+    println!(
+        "<head><title>{}</title><style>{}</style></head>",
+        &args[1], style
+    );
     let theme = &ts.themes["base16-ocean.dark"];
     let c = theme.settings.background.unwrap_or(Color::WHITE);
-    println!("<body style=\"background-color:#{:02x}{:02x}{:02x};\">\n", c.r, c.g, c.b);
+    println!(
+        "<body style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
+        c.r, c.g, c.b
+    );
     let html = highlighted_html_for_file(&args[1], &ss, theme).unwrap();
     println!("{}", html);
     println!("</body>");

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -6,15 +6,15 @@
 //! Another thing it does that other line count programs can't always
 //! do is properly count comments in embedded syntaxes. For example
 //! JS, CSS and Ruby comments embedded in ERB files.
-use syntect::parsing::{SyntaxSet, ParseState, ScopeStackOp, ScopeStack};
+use syntect::easy::ScopeRegionIterator;
 use syntect::highlighting::{ScopeSelector, ScopeSelectors};
-use syntect::easy::{ScopeRegionIterator};
+use syntect::parsing::{ParseState, ScopeStack, ScopeStackOp, SyntaxSet};
 
-use std::path::Path;
-use std::io::{BufRead, BufReader};
 use std::fs::File;
-use walkdir::{DirEntry, WalkDir};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::str::FromStr;
+use walkdir::{DirEntry, WalkDir};
 
 #[derive(Debug)]
 struct Selectors {
@@ -28,9 +28,15 @@ impl Default for Selectors {
     fn default() -> Selectors {
         Selectors {
             comment: ScopeSelector::from_str("comment - comment.block.attribute").unwrap(),
-            doc_comment: ScopeSelectors::from_str("comment.line.documentation, comment.block.documentation").unwrap(),
+            doc_comment: ScopeSelectors::from_str(
+                "comment.line.documentation, comment.block.documentation",
+            )
+            .unwrap(),
             function: ScopeSelector::from_str("entity.name.function").unwrap(),
-            types: ScopeSelectors::from_str("entity.name.class, entity.name.struct, entity.name.enum, entity.name.type").unwrap(),
+            types: ScopeSelectors::from_str(
+                "entity.name.class, entity.name.struct, entity.name.enum, entity.name.type",
+            )
+            .unwrap(),
         }
     }
 }
@@ -57,28 +63,58 @@ fn print_stats(stats: &Stats) {
     println!("File count:                           {:>6}", stats.files);
     println!("Total characters:                     {:>6}", stats.chars);
     println!("");
-    println!("Function count:                       {:>6}", stats.functions);
+    println!(
+        "Function count:                       {:>6}",
+        stats.functions
+    );
     println!("Type count (structs, enums, classes): {:>6}", stats.types);
     println!("");
-    println!("Code lines (traditional SLOC):        {:>6}", stats.code_lines);
+    println!(
+        "Code lines (traditional SLOC):        {:>6}",
+        stats.code_lines
+    );
     println!("Total lines (w/ comments & blanks):   {:>6}", stats.lines);
-    println!("Comment lines (comment but no code):  {:>6}", stats.comment_lines);
-    println!("Blank lines (lines-blank-comment):    {:>6}", stats.lines-stats.code_lines-stats.comment_lines);
+    println!(
+        "Comment lines (comment but no code):  {:>6}",
+        stats.comment_lines
+    );
+    println!(
+        "Blank lines (lines-blank-comment):    {:>6}",
+        stats.lines - stats.code_lines - stats.comment_lines
+    );
     println!("");
-    println!("Lines with a documentation comment:   {:>6}", stats.doc_comment_lines);
-    println!("Total words written in doc comments:  {:>6}", stats.doc_comment_words);
-    println!("Total words written in all comments:  {:>6}", stats.comment_words);
-    println!("Characters of comment:                {:>6}", stats.comment_chars);
+    println!(
+        "Lines with a documentation comment:   {:>6}",
+        stats.doc_comment_lines
+    );
+    println!(
+        "Total words written in doc comments:  {:>6}",
+        stats.doc_comment_words
+    );
+    println!(
+        "Total words written in all comments:  {:>6}",
+        stats.comment_words
+    );
+    println!(
+        "Characters of comment:                {:>6}",
+        stats.comment_chars
+    );
 }
 
 fn is_ignored(entry: &DirEntry) -> bool {
-    entry.file_name()
-         .to_str()
-         .map(|s| s.starts_with(".") && s.len() > 1 || s.ends_with(".md"))
-         .unwrap_or(false)
+    entry
+        .file_name()
+        .to_str()
+        .map(|s| s.starts_with(".") && s.len() > 1 || s.ends_with(".md"))
+        .unwrap_or(false)
 }
 
-fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack, stats: &mut Stats) {
+fn count_line(
+    ops: &[(usize, ScopeStackOp)],
+    line: &str,
+    stack: &mut ScopeStack,
+    stats: &mut Stats,
+) {
     stats.lines += 1;
 
     let mut line_has_comment = false;
@@ -86,12 +122,29 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
     let mut line_has_code = false;
     for (s, op) in ScopeRegionIterator::new(&ops, line) {
         stack.apply(op);
-        if s.is_empty() { // in this case we don't care about blank tokens
+        if s.is_empty() {
+            // in this case we don't care about blank tokens
             continue;
         }
-        if stats.selectors.comment.does_match(stack.as_slice()).is_some() {
-            let words = s.split_whitespace().filter(|w| w.chars().all(|c| c.is_alphanumeric() || c == '.' || c == '\'')).count();
-            if stats.selectors.doc_comment.does_match(stack.as_slice()).is_some() {
+        if stats
+            .selectors
+            .comment
+            .does_match(stack.as_slice())
+            .is_some()
+        {
+            let words = s
+                .split_whitespace()
+                .filter(|w| {
+                    w.chars()
+                        .all(|c| c.is_alphanumeric() || c == '.' || c == '\'')
+                })
+                .count();
+            if stats
+                .selectors
+                .doc_comment
+                .does_match(stack.as_slice())
+                .is_some()
+            {
                 line_has_doc_comment = true;
                 stats.doc_comment_words += words;
             }
@@ -101,7 +154,12 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
         } else if !s.chars().all(|c| c.is_whitespace()) {
             line_has_code = true;
         }
-        if stats.selectors.function.does_match(stack.as_slice()).is_some() {
+        if stats
+            .selectors
+            .function
+            .does_match(stack.as_slice())
+            .is_some()
+        {
             stats.functions += 1;
         }
         if stats.selectors.types.does_match(stack.as_slice()).is_some() {
@@ -122,7 +180,7 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
 fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let syntax = match ss.find_syntax_for_file(path).unwrap_or(None) {
         Some(syntax) => syntax,
-        None => return
+        None => return,
     };
     stats.files += 1;
     let mut state = ParseState::new(syntax);
@@ -145,11 +203,7 @@ fn main() {
     let ss = SyntaxSet::load_defaults_newlines(); // note we load the version with newlines
 
     let args: Vec<String> = std::env::args().collect();
-    let path = if args.len() < 2 {
-        "."
-    } else {
-        &args[1]
-    };
+    let path = if args.len() < 2 { "." } else { &args[1] };
 
     println!("################## Files ###################");
     let mut stats = Stats::default();

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -9,13 +9,15 @@ use std::io::{self, BufReader};
 use std::path::Path;
 // use util::debug_print_ops;
 
-/// Simple way to go directly from lines of text to colored
-/// tokens.
+/// Simple way to go directly from lines of text to colored tokens.
 ///
-/// Depending on how you load the syntaxes (see the `SyntaxSet` docs)
-/// you can either pass this strings with trailing `\n`s or without.
+/// Depending on how you load the syntaxes (see the [`SyntaxSet`] docs), this can either take
+/// strings with trailing `\n`s or without.
+///
+/// [`SyntaxSet`]: ../parsing/struct.SyntaxSet.html
 ///
 /// # Examples
+///
 /// Prints colored lines of a string to the terminal
 ///
 /// ```
@@ -70,9 +72,12 @@ impl<'a> HighlightLines<'a> {
     }
 }
 
-/// Convenience struct containing everything you need to highlight a file.
-/// Use the `reader` to get the lines of the file and the `highlight_lines` to highlight them.
-/// See the `new` method docs for more information.
+/// Convenience struct containing everything you need to highlight a file
+///
+/// Use the `reader` to get the lines of the file and the `highlight_lines` to highlight them. See
+/// the [`new`] method docs for more information.
+///
+/// [`new`]: #method.new
 pub struct HighlightFile<'a> {
     pub reader: BufReader<File>,
     pub highlight_lines: HighlightLines<'a>,
@@ -80,9 +85,14 @@ pub struct HighlightFile<'a> {
 
 impl<'a> HighlightFile<'a> {
     /// Constructs a file reader and a line highlighter to get you reading files as fast as possible.
-    /// Auto-detects the syntax from the extension and constructs a `HighlightLines` with the correct syntax and theme.
+    ///
+    /// This auto-detects the syntax from the extension and constructs a [`HighlightLines`] with the
+    /// correct syntax and theme.
+    ///
+    /// [`HighlightLines`]: struct.HighlightLines.html
     ///
     /// # Examples
+    ///
     /// Using the `newlines` mode is a bit involved but yields more robust and glitch-free highlighting,
     /// as well as being slightly faster since it can re-use a line buffer.
     ///
@@ -150,13 +160,16 @@ impl<'a> HighlightFile<'a> {
 
 /// Iterator over the regions of a line which a given the operation from the parser applies.
 ///
-/// To use just keep your own `ScopeStack` and then `ScopeStack.apply(op)` the operation that is yielded
-/// at the top of your `for` loop over this iterator. Now you have a substring of the line and the scope stack
-/// for that token.
+/// To use, just keep your own [`ScopeStack`] and then `ScopeStack.apply(op)` the operation that is
+/// yielded at the top of your `for` loop over this iterator. Now you have a substring of the line
+/// and the scope stack for that token.
 ///
 /// See the `synstats.rs` example for an example of using this iterator.
 ///
-/// **Note:** This will often return empty regions, just `continue` after applying the op if you don't want them.
+/// **Note:** This will often return empty regions, just `continue` after applying the op if you
+/// don't want them.
+///
+/// [`ScopeStack`]: ../parsing/struct.ScopeStack.html
 #[derive(Debug)]
 pub struct ScopeRegionIterator<'a> {
     ops: &'a [(usize, ScopeStackOp)],
@@ -177,6 +190,7 @@ impl<'a> ScopeRegionIterator<'a> {
 }
 
 static NOOP_OP: ScopeStackOp = ScopeStackOp::Noop;
+
 impl<'a> Iterator for ScopeRegionIterator<'a> {
     type Item = (&'a str, &'a ScopeStackOp);
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/highlighting/Readme.md
+++ b/src/highlighting/Readme.md
@@ -1,5 +1,9 @@
 # Attribution
 
-Much of the code in this module/folder is heavily based on and largely copy-pasted from the the [sublimate](https://github.com/defuz/sublimate) project by [Ivan Ivashchenko a.k.a @defuz](https://github.com/defuz). The project was released under the MIT license.
+Much of the code in this module/folder is heavily based on and largely copy-pasted from the the
+[sublimate](https://github.com/defuz/sublimate) project by
+[Ivan Ivashchenko a.k.a @defuz](https://github.com/defuz). The project was released under the MIT license.
 
-I needed to copy-paste the code here because it required some adaptations to work with the other parts of syntect. One example modification is using my bit-packed `Scope` type instead of the original string-based one.
+I needed to copy-paste the code here because it required some adaptations to work with the other
+parts of syntect. One example modification is using my bit-packed `Scope` type instead of the
+original string-based one.

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -9,9 +9,9 @@ mod style;
 mod theme;
 mod theme_set;
 
+pub use self::highlighter::*;
 pub use self::selector::*;
 pub use self::settings::SettingsError;
 pub use self::style::*;
 pub use self::theme::*;
-pub use self::highlighter::*;
 pub use self::theme_set::*;

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -1,7 +1,11 @@
 //! Everything having to do with turning parsed text into styled text.
-//! You might want to check out `Theme` for its handy text-editor related
-//! settings like selection color, `ThemeSet` for loading themes,
-//! as well as things starting with `Highlight` for how to highlight text.
+//!
+//! You might want to check out [`Theme`] for its handy text-editor related settings like selection
+//! color, [`ThemeSet`] for loading themes, as well as things starting with `Highlight` for how to
+//! highlight text.
+//!
+//! [`Theme`]: struct.Theme.html
+//! [`ThemeSet`]: struct.ThemeSet.html
 mod highlighter;
 mod selector;
 pub(crate) mod settings;

--- a/src/highlighting/selector.rs
+++ b/src/highlighting/selector.rs
@@ -1,28 +1,35 @@
-/// Code based on https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs
-/// released under the MIT license by @defuz
+// Code based on [https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs](https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs)
+// released under the MIT license by @defuz
 use crate::parsing::{MatchPower, ParseScopeError, Scope, ScopeStack};
 use std::str::FromStr;
 
-/// A single selector consisting of a stack to match and a possible stack to exclude from being matched.
-/// You probably want `ScopeSelectors` which is this but with union support.
+/// A single selector consisting of a stack to match and a possible stack to
+/// exclude from being matched.
+///
+/// You probably want [`ScopeSelectors`] which is this but with union support.
+///
+/// [`ScopeSelectors`]: struct.ScopeSelectors.html
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ScopeSelector {
-    path: ScopeStack,
-    excludes: Vec<ScopeStack>,
+    pub path: ScopeStack,
+    pub excludes: Vec<ScopeStack>,
 }
 
 /// A selector set that matches anything matched by any of its component selectors.
-/// See [The TextMate Docs](https://manual.macromates.com/en/scope_selectors) for how these
-/// work.
+///
+/// See [The TextMate Docs](https://manual.macromates.com/en/scope_selectors) for how these work.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ScopeSelectors {
-    /// the selectors, if any of them match, this matches
+    /// The selectors, if any of them match, that this matches
     pub selectors: Vec<ScopeSelector>,
 }
 
 impl ScopeSelector {
     /// Checks if this selector matches a given scope stack.
-    /// See `ScopeSelectors#does_match` for more info.
+    ///
+    /// See [`ScopeSelectors::does_match`] for more info.
+    ///
+    /// [`ScopeSelectors::does_match`]: struct.ScopeSelectors.html#method.does_match
     pub fn does_match(&self, stack: &[Scope]) -> Option<MatchPower> {
         // if there are any exclusions, and any one of them matches, then this selector doesn't match
         if self
@@ -48,7 +55,7 @@ impl ScopeSelector {
         Some(self.path.as_slice()[0])
     }
 
-    /// extract all selectors for generating css
+    /// Extract all selectors for generating CSS
     pub fn extract_scopes(&self) -> Vec<Scope> {
         self.path.scopes.clone()
     }
@@ -76,10 +83,10 @@ impl FromStr for ScopeSelector {
 }
 
 impl ScopeSelectors {
-    /// checks if any of these selectors match the given scope stack
-    /// if so it returns a match score, higher match scores are stronger
-    /// matches. Scores are ordered according to the rules found
-    /// at https://manual.macromates.com/en/scope_selectors
+    /// Checks if any of the given selectors match the given scope stack
+    ///
+    /// If so, it returns a match score. Higher match scores indicate stronger matches. Scores are
+    /// ordered according to the rules found at [https://manual.macromates.com/en/scope_selectors](https://manual.macromates.com/en/scope_selectors).
     ///
     /// # Examples
     ///

--- a/src/highlighting/settings.rs
+++ b/src/highlighting/settings.rs
@@ -1,7 +1,7 @@
+use plist::Error as PlistError;
 /// Code based on https://github.com/defuz/sublimate/blob/master/src/core/settings.rs
 /// released under the MIT license by @defuz
 use std::io::{Read, Seek};
-use plist::{Error as PlistError};
 
 pub use serde_json::Value as Settings;
 pub use serde_json::Value::Array as SettingsArray;

--- a/src/highlighting/settings.rs
+++ b/src/highlighting/settings.rs
@@ -1,6 +1,6 @@
-use plist::Error as PlistError;
-/// Code based on https://github.com/defuz/sublimate/blob/master/src/core/settings.rs
+/// Code based on [https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs](https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs)
 /// released under the MIT license by @defuz
+use plist::Error as PlistError;
 use std::io::{Read, Seek};
 
 pub use serde_json::Value as Settings;

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -1,33 +1,39 @@
-// Code based on https://github.com/defuz/sublimate/blob/master/src/core/syntax/style.rs
+// Code based on [https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs](https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs)
 // released under the MIT license by @defuz
 use bitflags::bitflags;
 
-/// The foreground, background and font style
+/// Foreground and background colors, with font style
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Style {
-    /// Foreground color.
+    /// Foreground color
     pub foreground: Color,
-    /// Background color.
+    /// Background color
     pub background: Color,
-    /// Style of the font.
+    /// Style of the font
     pub font_style: FontStyle,
 }
 
-/// A change to a `Style` applied incrementally by a theme rule.
+/// A change to a [`Style`] applied incrementally by a theme rule
+///
+/// Fields left empty (as `None`) will not modify the corresponding field on a `Style`
+///
+/// [`Style`]: struct.Style.html
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StyleModifier {
-    /// Foreground color.
+    /// Foreground color
     pub foreground: Option<Color>,
-    /// Background color.
+    /// Background color
     pub background: Option<Color>,
-    /// Style of the font.
+    /// Style of the font
     pub font_style: Option<FontStyle>,
 }
 
-/// RGBA color, these numbers come directly from the theme so
-/// for now you might have to do your own color space conversion if you are outputting
-/// a different color space from the theme. This can be a problem because some Sublime
-/// themes use sRGB and some don't. This is specified in an attribute syntect doesn't parse yet.
+/// RGBA color, directly from the theme
+///
+/// Because these numbers come directly from the theme, you might have to do your own color space
+/// conversion if you're outputting a different color space from the theme. This can be a problem
+/// because some Sublime themes use sRGB and some don't. This is specified in an attribute syntect
+/// doesn't parse yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Color {
     /// Red component
@@ -36,12 +42,12 @@ pub struct Color {
     pub g: u8,
     /// Blue component
     pub b: u8,
-    /// Alpha component
+    /// Alpha (transparency) component
     pub a: u8,
 }
 
 bitflags! {
-    /// This can be a combination of `BOLD`, `UNDERLINE` and `ITALIC`
+    /// The color-independent styling of a font - i.e. bold, italicized, and/or underlined
     #[derive(Serialize, Deserialize)]
     pub struct FontStyle: u8 {
         /// Bold font style
@@ -54,7 +60,7 @@ bitflags! {
 }
 
 impl Color {
-    /// Black color (`#000000`)
+    /// The color black (`#000000`)
     pub const BLACK: Color = Color {
         r: 0x00,
         g: 0x00,
@@ -62,7 +68,7 @@ impl Color {
         a: 0xFF,
     };
 
-    /// White color (`#FFFFFF`)
+    /// The color white (`#FFFFFF`)
     pub const WHITE: Color = Color {
         r: 0xFF,
         g: 0xFF,
@@ -94,6 +100,7 @@ impl Default for Style {
 
 impl StyleModifier {
     /// Applies the other modifier to this one, creating a new modifier.
+    ///
     /// Values in `other` are preferred.
     pub fn apply(&self, other: StyleModifier) -> StyleModifier {
         StyleModifier {

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -53,7 +53,6 @@ bitflags! {
     }
 }
 
-
 impl Color {
     /// Black color (`#000000`)
     pub const BLACK: Color = Color {

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -1,5 +1,6 @@
-/// Code based on https://github.com/defuz/sublimate/blob/master/src/core/syntax/theme.rs
-/// released under the MIT license by @defuz
+// Code based on https://github.com/defuz/sublimate/blob/master/src/core/syntax/theme.rs
+// released under the MIT license by @defuz
+
 use std::str::FromStr;
 
 use super::selector::*;
@@ -10,18 +11,23 @@ use crate::parsing::ParseScopeError;
 use self::ParseThemeError::*;
 
 /// A theme parsed from a `.tmTheme` file.
-/// Contains fields useful for a theme list as well as `settings` for styling your editor.
+///
+/// This contains additional fields useful for a theme list as well as `settings` for styling your editor.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Theme {
     pub name: Option<String>,
     pub author: Option<String>,
+    /// External settings for the editor using this theme
     pub settings: ThemeSettings,
+    /// The styling rules for the viewed text
     pub scopes: Vec<ThemeItem>,
 }
 
-/// Various properties meant to be used to style a text editor.
-/// Basically all the styles that aren't directly applied to text like selection color.
-/// Use this to make your editor UI match the highlighted text.
+/// Properties for styling the UI of a text editor
+///
+/// This essentially consists of the styles that aren't directly applied to the text being viewed.
+/// `ThemeSettings` are intended to be used to make the UI of the editor match the styling of the
+/// text itself.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ThemeSettings {
     /// The default color for text.
@@ -59,14 +65,14 @@ pub struct ThemeSettings {
     /// Only applied when the `match_brackets` setting is set to `true`.
     pub brackets_background: Option<Color>,
     /// Controls certain options when the caret is next to a bracket.
-    /// Only applied when the match_brackets setting is set to `true`.
+    /// Only applied when the `match_brackets` setting is set to `true`.
     pub brackets_options: Option<UnderlineOption>,
 
     /// Color of tags when the caret is next to a tag.
     /// Only used when the `match_tags` setting is set to `true`.
     pub tags_foreground: Option<Color>,
     /// Controls certain options when the caret is next to a tag.
-    /// Only applied when the match_tags setting is set to `true`.
+    /// Only applied when the `match_tags` setting is set to `true`.
     pub tags_options: Option<UnderlineOption>,
 
     /// The border color for "other" matches.
@@ -90,6 +96,7 @@ pub struct ThemeSettings {
     ///
     /// This property is not part of the recognized tmTheme format. It may be
     /// removed in a future release.
+    #[deprecated]
     pub selection_background: Option<Color>,
 
     /// Color of the selection regions border.
@@ -115,6 +122,7 @@ pub struct ThemeSettings {
     /// Deprecated!
     /// This setting does not exist in any available documentation.
     /// Use is discouraged, and it may be removed in a future release.
+    #[deprecated]
     pub highlight_foreground: Option<Color>,
 
     /// The color of the shadow used when a text area can be horizontally scrolled.
@@ -127,6 +135,7 @@ pub struct ThemeSettings {
 pub struct ThemeItem {
     /// Target scope name.
     pub scope: ScopeSelectors,
+    /// The style to use for this component
     pub style: StyleModifier,
 }
 

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -2,9 +2,9 @@
 /// released under the MIT license by @defuz
 use std::str::FromStr;
 
+use super::selector::*;
 use super::settings::{ParseSettings, Settings};
 use super::style::*;
-use super::selector::*;
 use crate::parsing::ParseScopeError;
 
 use self::ParseThemeError::*;
@@ -206,8 +206,7 @@ impl FromStr for FontStyle {
                 "bold" => FontStyle::BOLD,
                 "underline" => FontStyle::UNDERLINE,
                 "italic" => FontStyle::ITALIC,
-                "normal" |
-                "regular" => FontStyle::empty(),
+                "normal" | "regular" => FontStyle::empty(),
                 s => return Err(IncorrectFontStyle(s.to_owned())),
             })
         }
@@ -239,30 +238,24 @@ impl FromStr for Color {
             d.push(char.to_digit(16).ok_or(IncorrectColor)? as u8);
         }
         Ok(match d.len() {
-            3 => {
-                Color {
-                    r: d[0],
-                    g: d[1],
-                    b: d[2],
-                    a: 255,
-                }
-            }
-            6 => {
-                Color {
-                    r: d[0] * 16 + d[1],
-                    g: d[2] * 16 + d[3],
-                    b: d[4] * 16 + d[5],
-                    a: 255,
-                }
-            }
-            8 => {
-                Color {
-                    r: d[0] * 16 + d[1],
-                    g: d[2] * 16 + d[3],
-                    b: d[4] * 16 + d[5],
-                    a: d[6] * 16 + d[7],
-                }
-            }
+            3 => Color {
+                r: d[0],
+                g: d[1],
+                b: d[2],
+                a: 255,
+            },
+            6 => Color {
+                r: d[0] * 16 + d[1],
+                g: d[2] * 16 + d[3],
+                b: d[4] * 16 + d[5],
+                a: 255,
+            },
+            8 => Color {
+                r: d[0] * 16 + d[1],
+                g: d[2] * 16 + d[3],
+                b: d[4] * 16 + d[5],
+                a: d[6] * 16 + d[7],
+            },
             _ => return Err(IncorrectColor),
         })
     }
@@ -327,10 +320,7 @@ impl ParseSettings for ThemeItem {
             Some(settings) => StyleModifier::parse_settings(settings)?,
             None => return Err(IncorrectSettings),
         };
-        Ok(ThemeItem {
-            scope,
-            style,
-        })
+        Ok(ThemeItem { scope, style })
     }
 }
 
@@ -434,12 +424,10 @@ impl ParseSettings for Theme {
         };
         let mut iter = items.into_iter();
         let settings = match iter.next() {
-            Some(Settings::Object(mut obj)) => {
-                match obj.remove("settings") {
-                    Some(settings) => ThemeSettings::parse_settings(settings)?,
-                    None => return Err(UndefinedSettings),
-                }
-            }
+            Some(Settings::Object(mut obj)) => match obj.remove("settings") {
+                Some(settings) => ThemeSettings::parse_settings(settings)?,
+                None => return Err(UndefinedSettings),
+            },
             _ => return Err(UndefinedSettings),
         };
         let mut scopes = Vec::new();

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -9,6 +9,7 @@ use walkdir::WalkDir;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ThemeSet {
+    // This is a `BTreeMap` because they're faster than hashmaps on small sets
     pub themes: BTreeMap<String, Theme>,
 }
 
@@ -19,7 +20,9 @@ impl ThemeSet {
         ThemeSet::default()
     }
 
-    /// Returns all the themes found in a folder, good for enumerating before loading one with get_theme
+    /// Returns all the themes found in a folder
+    ///
+    /// This is god for enumerating before loading one with [`get_theme`](#method.get_theme)
     pub fn discover_theme_paths<P: AsRef<Path>>(folder: P) -> Result<Vec<PathBuf>, LoadingError> {
         let mut themes = Vec::new();
         for entry in WalkDir::new(folder) {

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -1,11 +1,11 @@
-use super::theme::Theme;
-use super::settings::*;
 use super::super::LoadingError;
+use super::settings::*;
+use super::theme::Theme;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
-use std::io::{BufReader, BufRead, Seek};
-use walkdir::WalkDir;
 use std::fs::File;
+use std::io::{BufRead, BufReader, Seek};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ThemeSet {
@@ -55,8 +55,10 @@ impl ThemeSet {
         let paths = Self::discover_theme_paths(folder)?;
         for p in &paths {
             let theme = Self::get_theme(p)?;
-            let basename =
-                p.file_stem().and_then(|x| x.to_str()).ok_or(LoadingError::BadPath)?;
+            let basename = p
+                .file_stem()
+                .and_then(|x| x.to_str())
+                .ok_or(LoadingError::BadPath)?;
             self.themes.insert(basename.to_owned(), theme);
         }
 
@@ -64,10 +66,9 @@ impl ThemeSet {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::highlighting::{ThemeSet, Color};
+    use crate::highlighting::{Color, ThemeSet};
     #[test]
     fn can_parse_common_themes() {
         let themes = ThemeSet::load_from_folder("testdata").unwrap();
@@ -78,20 +79,24 @@ mod tests {
 
         let theme = ThemeSet::get_theme("testdata/spacegray/base16-ocean.dark.tmTheme").unwrap();
         assert_eq!(theme.name.unwrap(), "Base16 Ocean Dark");
-        assert_eq!(theme.settings.selection.unwrap(),
-                   Color {
-                       r: 0x4f,
-                       g: 0x5b,
-                       b: 0x66,
-                       a: 0xff,
-                   });
-        assert_eq!(theme.scopes[0].style.foreground.unwrap(),
-                   Color {
-                       r: 0xc0,
-                       g: 0xc5,
-                       b: 0xce,
-                       a: 0xFF,
-                   });
+        assert_eq!(
+            theme.settings.selection.unwrap(),
+            Color {
+                r: 0x4f,
+                g: 0x5b,
+                b: 0x66,
+                a: 0xff,
+            }
+        );
+        assert_eq!(
+            theme.scopes[0].style.foreground.unwrap(),
+            Color {
+                r: 0xc0,
+                g: 0xc5,
+                b: 0xce,
+                a: 0xFF,
+            }
+        );
         // assert!(false);
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,10 +1,13 @@
 //! Rendering highlighted code as HTML+CSS
-use std::fmt::Write;
-use crate::parsing::{ScopeStackOp, BasicScopeStackOp, Scope, ScopeStack, SyntaxReference, ParseState, SyntaxSet, SCOPE_REPO};
-use crate::easy::{HighlightLines, HighlightFile};
-use crate::highlighting::{Color, FontStyle, Style, Theme};
-use crate::util::LinesWithEndings;
+use crate::easy::{HighlightFile, HighlightLines};
 use crate::escape::Escape;
+use crate::highlighting::{Color, FontStyle, Style, Theme};
+use crate::parsing::{
+    BasicScopeStackOp, ParseState, Scope, ScopeStack, ScopeStackOp, SyntaxReference, SyntaxSet,
+    SCOPE_REPO,
+};
+use crate::util::LinesWithEndings;
+use std::fmt::Write;
 
 use std::io::{self, BufRead};
 use std::path::Path;
@@ -46,12 +49,19 @@ pub struct ClassedHTMLGenerator<'a> {
 }
 
 impl<'a> ClassedHTMLGenerator<'a> {
-    #[deprecated(since="4.2.0", note="Please use `new_with_class_style` instead")]
-    pub fn new(syntax_reference: &'a SyntaxReference, syntax_set: &'a SyntaxSet) -> ClassedHTMLGenerator<'a> {
+    #[deprecated(since = "4.2.0", note = "Please use `new_with_class_style` instead")]
+    pub fn new(
+        syntax_reference: &'a SyntaxReference,
+        syntax_set: &'a SyntaxSet,
+    ) -> ClassedHTMLGenerator<'a> {
         Self::new_with_class_style(syntax_reference, syntax_set, ClassStyle::Spaced)
     }
 
-    pub fn new_with_class_style(syntax_reference: &'a SyntaxReference, syntax_set: &'a SyntaxSet, style: ClassStyle) -> ClassedHTMLGenerator<'a> {
+    pub fn new_with_class_style(
+        syntax_reference: &'a SyntaxReference,
+        syntax_set: &'a SyntaxSet,
+        style: ClassStyle,
+    ) -> ClassedHTMLGenerator<'a> {
         let parse_state = ParseState::new(syntax_reference);
         let open_spans = 0;
         let html = String::new();
@@ -67,11 +77,8 @@ impl<'a> ClassedHTMLGenerator<'a> {
     /// Parse the line of code and update the internal HTML buffer with tagged HTML
     pub fn parse_html_for_line(&mut self, line: &str) {
         let parsed_line = self.parse_state.parse_line(line, &self.syntax_set);
-        let (formatted_line, delta) = tokens_to_classed_spans(
-            line,
-            parsed_line.as_slice(),
-            self.style,
-        );
+        let (formatted_line, delta) =
+            tokens_to_classed_spans(line, parsed_line.as_slice(), self.style);
         self.open_spans += delta;
         self.html.push_str(formatted_line.as_str());
         // retain newline
@@ -87,7 +94,10 @@ impl<'a> ClassedHTMLGenerator<'a> {
     }
 }
 
-#[deprecated(since="4.2.0", note="Please use `css_for_theme_with_class_style` instead.")]
+#[deprecated(
+    since = "4.2.0",
+    note = "Please use `css_for_theme_with_class_style` instead."
+)]
 pub fn css_for_theme(theme: &Theme) -> String {
     css_for_theme_with_class_style(theme, ClassStyle::Spaced)
 }
@@ -105,33 +115,41 @@ pub fn css_for_theme_with_class_style(theme: &Theme, style: ClassStyle) -> Strin
     match style {
         ClassStyle::Spaced => {
             css.push_str(".code {\n");
-        },
+        }
         ClassStyle::SpacedPrefixed { prefix } => {
             css.push_str(&format!(".{}code {{\n", prefix));
-        },
+        }
     };
     if let Some(fgc) = theme.settings.foreground {
-        css.push_str(&format!(" color: #{:02x}{:02x}{:02x};\n", fgc.r, fgc.g, fgc.b));
+        css.push_str(&format!(
+            " color: #{:02x}{:02x}{:02x};\n",
+            fgc.r, fgc.g, fgc.b
+        ));
     }
     if let Some(bgc) = theme.settings.background {
-        css.push_str(&format!(" background-color: #{:02x}{:02x}{:02x};\n", bgc.r, bgc.g, bgc.b));
+        css.push_str(&format!(
+            " background-color: #{:02x}{:02x}{:02x};\n",
+            bgc.r, bgc.g, bgc.b
+        ));
     }
     css.push_str("}\n\n");
 
     for i in &theme.scopes {
-
         for scope_selector in &i.scope.selectors {
             let scopes = scope_selector.extract_scopes();
             for k in &scopes {
                 scope_to_selector(&mut css, *k, style);
                 css.push_str(" {\n");
 
-                if let Some(fg) =  i.style.foreground {
+                if let Some(fg) = i.style.foreground {
                     css.push_str(&format!(" color: #{:02x}{:02x}{:02x};\n", fg.r, fg.g, fg.b));
                 }
 
                 if let Some(bg) = i.style.background {
-                    css.push_str(&format!(" background-color: #{:02x}{:02x}{:02x};\n", bg.r, bg.g, bg.b));
+                    css.push_str(&format!(
+                        " background-color: #{:02x}{:02x}{:02x};\n",
+                        bg.r, bg.g, bg.b
+                    ));
                 }
 
                 if let Some(fs) = i.style.font_style {
@@ -172,9 +190,7 @@ pub enum ClassStyle {
     /// file an issue; the HTML generator can also be forked
     /// separately from the rest of syntect, as it only uses the
     /// public API.)
-    SpacedPrefixed {
-        prefix: &'static str,
-    },
+    SpacedPrefixed { prefix: &'static str },
 }
 
 fn scope_to_classes(s: &mut String, scope: Scope, style: ClassStyle) {
@@ -186,11 +202,10 @@ fn scope_to_classes(s: &mut String, scope: Scope, style: ClassStyle) {
             s.push_str(" ")
         }
         match style {
-            ClassStyle::Spaced => {
-            },
+            ClassStyle::Spaced => {}
             ClassStyle::SpacedPrefixed { prefix } => {
                 s.push_str(&prefix);
-            },
+            }
         }
         s.push_str(atom_s);
     }
@@ -203,11 +218,10 @@ fn scope_to_selector(s: &mut String, scope: Scope, style: ClassStyle) {
         let atom_s = repo.atom_str(atom);
         s.push_str(".");
         match style {
-            ClassStyle::Spaced => {
-            },
+            ClassStyle::Spaced => {}
             ClassStyle::SpacedPrefixed { prefix } => {
                 s.push_str(&prefix);
-            },
+            }
         }
         s.push_str(atom_s);
     }
@@ -219,13 +233,22 @@ fn scope_to_selector(s: &mut String, scope: Scope, style: ClassStyle) {
 ///
 /// Note that the `syntax` passed in must be from a `SyntaxSet` compiled for newline characters.
 /// This is easy to get with `SyntaxSet::load_defaults_newlines()`. (Note: this was different before v3.0)
-pub fn highlighted_html_for_string(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> String {
+pub fn highlighted_html_for_string(
+    s: &str,
+    ss: &SyntaxSet,
+    syntax: &SyntaxReference,
+    theme: &Theme,
+) -> String {
     let mut highlighter = HighlightLines::new(syntax, theme);
     let (mut output, bg) = start_highlighted_html_snippet(theme);
 
     for line in LinesWithEndings::from(s) {
         let regions = highlighter.highlight(line, ss);
-        append_highlighted_html_for_styled_line(&regions[..], IncludeBackground::IfDifferent(bg), &mut output);
+        append_highlighted_html_for_styled_line(
+            &regions[..],
+            IncludeBackground::IfDifferent(bg),
+            &mut output,
+        );
     }
     output.push_str("</pre>\n");
     output
@@ -237,10 +260,11 @@ pub fn highlighted_html_for_string(s: &str, ss: &SyntaxSet, syntax: &SyntaxRefer
 ///
 /// Note that the `syntax` passed in must be from a `SyntaxSet` compiled for newline characters.
 /// This is easy to get with `SyntaxSet::load_defaults_newlines()`. (Note: this was different before v3.0)
-pub fn highlighted_html_for_file<P: AsRef<Path>>(path: P,
-                                                 ss: &SyntaxSet,
-                                                 theme: &Theme)
-                                                 -> io::Result<String> {
+pub fn highlighted_html_for_file<P: AsRef<Path>>(
+    path: P,
+    ss: &SyntaxSet,
+    theme: &Theme,
+) -> io::Result<String> {
     let mut highlighter = HighlightFile::new(path, ss, theme)?;
     let (mut output, bg) = start_highlighted_html_snippet(theme);
 
@@ -248,7 +272,11 @@ pub fn highlighted_html_for_file<P: AsRef<Path>>(path: P,
     while highlighter.reader.read_line(&mut line)? > 0 {
         {
             let regions = highlighter.highlight_lines.highlight(&line, ss);
-            append_highlighted_html_for_styled_line(&regions[..], IncludeBackground::IfDifferent(bg), &mut output);
+            append_highlighted_html_for_styled_line(
+                &regions[..],
+                IncludeBackground::IfDifferent(bg),
+                &mut output,
+            );
         }
         line.clear();
     }
@@ -271,10 +299,11 @@ pub fn highlighted_html_for_file<P: AsRef<Path>>(path: P,
 /// Returns the HTML string and the number of `<span>` tags opened
 /// (negative for closed). So that you can emit the correct number of closing
 /// tags at the end.
-pub fn tokens_to_classed_spans(line: &str,
-                           ops: &[(usize, ScopeStackOp)],
-                           style: ClassStyle)
-                           -> (String, isize) {
+pub fn tokens_to_classed_spans(
+    line: &str,
+    ops: &[(usize, ScopeStackOp)],
+    style: ClassStyle,
+) -> (String, isize) {
     let mut s = String::with_capacity(line.len() + ops.len() * 8); // a guess
     let mut cur_index = 0;
     let mut stack = ScopeStack::new();
@@ -290,26 +319,23 @@ pub fn tokens_to_classed_spans(line: &str,
             write!(s, "{}", Escape(&line[cur_index..i])).unwrap();
             cur_index = i
         }
-        stack.apply_with_hook(op, |basic_op, _| {
-            match basic_op {
-                BasicScopeStackOp::Push(scope) => {
-                    span_start = s.len();
-                    span_empty = true;
-                    s.push_str("<span class=\"");
-                    scope_to_classes(&mut s, scope, style);
-                    s.push_str("\">");
-                    span_delta += 1;
+        stack.apply_with_hook(op, |basic_op, _| match basic_op {
+            BasicScopeStackOp::Push(scope) => {
+                span_start = s.len();
+                span_empty = true;
+                s.push_str("<span class=\"");
+                scope_to_classes(&mut s, scope, style);
+                s.push_str("\">");
+                span_delta += 1;
+            }
+            BasicScopeStackOp::Pop => {
+                if span_empty == false {
+                    s.push_str("</span>");
+                } else {
+                    s.truncate(span_start);
                 }
-                BasicScopeStackOp::Pop => {
-                    if span_empty == false {
-                        s.push_str("</span>");
-                    }
-                    else {
-                        s.truncate(span_start);
-                    }
-                    span_delta -= 1;
-                    span_empty = false;
-                }
+                span_delta -= 1;
+                span_empty = false;
             }
         });
     }
@@ -317,11 +343,12 @@ pub fn tokens_to_classed_spans(line: &str,
     (s, span_delta)
 }
 
-#[deprecated(since="3.1.0", note="please use `tokens_to_classed_spans` instead")]
-pub fn tokens_to_classed_html(line: &str,
-                              ops: &[(usize, ScopeStackOp)],
-                              style: ClassStyle)
-                              -> String {
+#[deprecated(since = "3.1.0", note = "please use `tokens_to_classed_spans` instead")]
+pub fn tokens_to_classed_html(
+    line: &str,
+    ops: &[(usize, ScopeStackOp)],
+    style: ClassStyle,
+) -> String {
     tokens_to_classed_spans(line, ops, style).0
 }
 
@@ -338,9 +365,9 @@ pub enum IncludeBackground {
 
 fn write_css_color(s: &mut String, c: Color) {
     if c.a != 0xFF {
-        write!(s,"#{:02x}{:02x}{:02x}{:02x}",c.r,c.g,c.b,c.a).unwrap();
+        write!(s, "#{:02x}{:02x}{:02x}{:02x}", c.r, c.g, c.b, c.a).unwrap();
     } else {
-        write!(s,"#{:02x}{:02x}{:02x}",c.r,c.g,c.b).unwrap();
+        write!(s, "#{:02x}{:02x}{:02x}", c.r, c.g, c.b).unwrap();
     }
 }
 
@@ -376,12 +403,15 @@ pub fn styled_line_to_highlighted_html(v: &[(Style, &str)], bg: IncludeBackgroun
 
 /// Like `styled_line_to_highlighted_html` but appends to a `String` for increased efficiency.
 /// In fact `styled_line_to_highlighted_html` is just a wrapper around this function.
-pub fn append_highlighted_html_for_styled_line(v: &[(Style, &str)], bg: IncludeBackground, mut s: &mut String) {
+pub fn append_highlighted_html_for_styled_line(
+    v: &[(Style, &str)],
+    bg: IncludeBackground,
+    mut s: &mut String,
+) {
     let mut prev_style: Option<&Style> = None;
     for &(ref style, text) in v.iter() {
         let unify_style = if let Some(ps) = prev_style {
-            style == ps ||
-                (style.background == ps.background && text.trim().is_empty())
+            style == ps || (style.background == ps.background && text.trim().is_empty())
         } else {
             false
         };
@@ -434,18 +464,24 @@ pub fn append_highlighted_html_for_styled_line(v: &[(Style, &str)], bg: IncludeB
 /// helper for that :-)
 pub fn start_highlighted_html_snippet(t: &Theme) -> (String, Color) {
     let c = t.settings.background.unwrap_or(Color::WHITE);
-    (format!("<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
-            c.r,
-            c.g,
-            c.b), c)
+    (
+        format!(
+            "<pre style=\"background-color:#{:02x}{:02x}{:02x};\">\n",
+            c.r, c.g, c.b
+        ),
+        c,
+    )
 }
 
-#[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(
+    feature = "assets",
+    any(feature = "dump-load", feature = "dump-load-rs")
+))]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsing::{SyntaxSet, ParseState, ScopeStack, SyntaxSetBuilder};
-    use crate::highlighting::{ThemeSet, Style, Highlighter, HighlightIterator, HighlightState};
+    use crate::highlighting::{HighlightIterator, HighlightState, Highlighter, Style, ThemeSet};
+    use crate::parsing::{ParseState, ScopeStack, SyntaxSet, SyntaxSetBuilder};
     #[test]
     fn tokens() {
         let ss = SyntaxSet::load_defaults_newlines();
@@ -481,17 +517,21 @@ mod tests {
         let html = highlighted_html_for_string(s, &ss, syntax, &ts.themes["base16-ocean.dark"]);
         // println!("{}", html);
         assert_eq!(html, include_str!("../testdata/test3.html"));
-        let html2 = highlighted_html_for_file("testdata/highlight_test.erb",
-                                                 &ss,
-                                                 &ts.themes["base16-ocean.dark"])
-            .unwrap();
+        let html2 = highlighted_html_for_file(
+            "testdata/highlight_test.erb",
+            &ss,
+            &ts.themes["base16-ocean.dark"],
+        )
+        .unwrap();
         assert_eq!(html2, html);
 
         // YAML is a tricky syntax and InspiredGitHub is a fancy theme, this is basically an integration test
-        let html3 = highlighted_html_for_file("testdata/Packages/Rust/Cargo.sublime-syntax",
-                                                 &ss,
-                                                 &ts.themes["InspiredGitHub"])
-            .unwrap();
+        let html3 = highlighted_html_for_file(
+            "testdata/Packages/Rust/Cargo.sublime-syntax",
+            &ss,
+            &ts.themes["InspiredGitHub"],
+        )
+        .unwrap();
         println!("{}", html3);
         assert_eq!(html3, include_str!("../testdata/test4.html"));
     }
@@ -504,10 +544,12 @@ mod tests {
         builder.add_from_folder("testdata", true).unwrap();
         let ss = builder.build();
         let ts = ThemeSet::load_defaults();
-        let html = highlighted_html_for_file("testdata/testing-syntax.testsyntax",
-                                                &ss,
-                                                &ts.themes["base16-ocean.dark"])
-            .unwrap();
+        let html = highlighted_html_for_file(
+            "testdata/testing-syntax.testsyntax",
+            &ss,
+            &ts.themes["base16-ocean.dark"],
+        )
+        .unwrap();
         println!("{}", html);
         assert_eq!(html, include_str!("../testdata/test5.html"));
     }
@@ -517,7 +559,8 @@ mod tests {
         let current_code = "x + y".to_string();
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let syntax = syntax_set.find_syntax_by_name("R").unwrap();
-        let mut html_generator = ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+        let mut html_generator =
+            ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
         for line in current_code.lines() {
             html_generator.parse_html_for_line(&line);
         }
@@ -530,7 +573,11 @@ mod tests {
         let current_code = "x + y".to_string();
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let syntax = syntax_set.find_syntax_by_name("R").unwrap();
-        let mut html_generator = ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::SpacedPrefixed { prefix: "foo-" });
+        let mut html_generator = ClassedHTMLGenerator::new_with_class_style(
+            &syntax,
+            &syntax_set,
+            ClassStyle::SpacedPrefixed { prefix: "foo-" },
+        );
         for line in current_code.lines() {
             html_generator.parse_html_for_line(&line);
         }
@@ -546,7 +593,8 @@ fn main() {
 }";
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let syntax = syntax_set.find_syntax_by_extension("rs").unwrap();
-        let mut html_generator = ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+        let mut html_generator =
+            ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
         for line in code.lines() {
             html_generator.parse_html_for_line(&line);
         }

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,4 +1,5 @@
 //! Rendering highlighted code as HTML+CSS
+
 use crate::easy::{HighlightFile, HighlightLines};
 use crate::escape::Escape;
 use crate::highlighting::{Color, FontStyle, Style, Theme};
@@ -13,13 +14,17 @@ use std::io::{self, BufRead};
 use std::path::Path;
 
 /// Output HTML for a line of code with `<span>` elements using class names
-/// As this has to keep track of open and closed `<span>` tags, it is a `struct`
-/// with additional state.
 ///
-/// There is a `finalize()` function that has to be called in the end in order
+/// Because this has to keep track of open and closed `<span>` tags, it is a `struct` with
+/// additional state.
+///
+/// There is a [`finalize()`] method that must be called in the end in order
 /// to close all open `<span>` tags.
 ///
 /// The lines returned don't include a newline at the end.
+///
+/// [`finalize()`]: #method.finalize
+///
 /// # Example
 ///
 /// ```
@@ -102,8 +107,7 @@ pub fn css_for_theme(theme: &Theme) -> String {
     css_for_theme_with_class_style(theme, ClassStyle::Spaced)
 }
 
-/// Create a complete CSS for a given theme. Can be used inline, or written to
-/// a CSS file.
+/// Create a complete CSS for a given theme. Can be used inline, or written to a CSS file.
 pub fn css_for_theme_with_class_style(theme: &Theme, style: ClassStyle) -> String {
     let mut css = String::new();
 
@@ -457,7 +461,9 @@ pub fn append_highlighted_html_for_styled_line(
 /// `highlighted_html_for_string`.
 ///
 /// If you don't care about the background color you can just prefix the lines from
-/// `styled_line_to_highlighted_html` with a `<pre>`. This is meant to be used with `IncludeBackground::IfDifferent`.
+/// `styled_line_to_highlighted_html` with a `<pre>`. This is meant to be used with
+/// `IncludeBackground::IfDifferent`.
+///
 /// As of `v3.0` this method also returns the background color to be passed to `IfDifferent`.
 ///
 /// You're responsible for creating the string `</pre>` to close this, I'm not gonna provide a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,12 @@ extern crate serde_derive;
 #[macro_use]
 extern crate pretty_assertions;
 
-#[cfg(any(feature = "dump-load-rs", feature = "dump-load", feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(any(
+    feature = "dump-load-rs",
+    feature = "dump-load",
+    feature = "dump-create",
+    feature = "dump-create-rs"
+))]
 pub mod dumps;
 #[cfg(feature = "parsing")]
 pub mod easy;
@@ -35,15 +40,15 @@ pub mod html;
 pub mod parsing;
 pub mod util;
 
-use std::io::Error as IoError;
 use std::error::Error;
 use std::fmt;
+use std::io::Error as IoError;
 
-#[cfg(feature = "metadata")]
-use serde_json::Error as JsonError;
+use crate::highlighting::{ParseThemeError, SettingsError};
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 use crate::parsing::ParseSyntaxError;
-use crate::highlighting::{ParseThemeError, SettingsError};
+#[cfg(feature = "metadata")]
+use serde_json::Error as JsonError;
 
 /// Common error type used by syntax and theme loading
 #[derive(Debug)]
@@ -113,7 +118,7 @@ impl fmt::Display for LoadingError {
                 } else {
                     error.fmt(f)
                 }
-            },
+            }
             #[cfg(feature = "metadata")]
             ParseMetadata(_) => write!(f, "Failed to parse JSON"),
             ParseTheme(_) => write!(f, "Invalid syntax theme"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,21 @@
 //! Much more info about syntect is available on the [Github Page](https://github.com/trishume/syntect).
 //!
 //! May I suggest that you start by reading the `Readme.md` file in the main repo.
-//! Once you're done with that you can look at the docs for `parsing::SyntaxSet`
-//! and for the `easy` module.
+//! Once you're done with that you can look at the docs for [`parsing::SyntaxSet`]
+//! and for the [`easy`] module.
 //!
-//! Almost everything in syntect is divided up into either the `parsing` module
-//! for turning text into text annotated with scopes, and the `highlighting` module
+//! Almost everything in syntect is divided up into either the [`parsing`] module
+//! for turning text into text annotated with scopes, and the [`highlighting`] module
 //! for turning annotated text into styled/colored text.
 //!
-//! Some docs have example code but a good place to look is the `syncat` example as well as the source code
-//! for the `easy` module in `easy.rs` as that shows how to plug the various parts together for common use cases.
+//! Some docs have example code but a good place to look is the `syncat` example as
+//! well as the source code for the [`easy`] module in `easy.rs` as that shows how to
+//! plug the various parts together for common use cases.
+//!
+//! [`parsing::SyntaxSet`]: parsing/struct.SyntaxSet.html
+//! [`easy`]: easy/index.html
+//! [`parsing`]: parsing/index.html
+//! [`highlighting`]: highlighting/index.html
 
 #![doc(html_root_url = "https://docs.rs/syntect/4.4.0")]
 

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -1,6 +1,5 @@
-//! Support for loading `.tmPreferences` metadata files. These files contain
-//! information related to indentation rules, comment markers,
-//! and other syntax-specific things.
+//! Support for loading `.tmPreferences` metadata files, with information related to indentation
+//! rules, comment markers, and other syntax-specific things.
 
 use std::collections::BTreeMap;
 use std::fs::File;
@@ -19,16 +18,20 @@ use super::scope::{MatchPower, Scope};
 
 type Dict = serde_json::Map<String, Settings>;
 
-/// A String representation of a `ScopeSelectors` instance.
+/// A String representation of a [`ScopeSelectors`] instance.
+///
+/// [`ScopeSelectors`]: ../../highlighting/struct.ScopeSelectors.html
 type SelectorString = String;
 
-/// A collection of all loaded metadata.
+/// A collection of all loaded metadata
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     pub scoped_metadata: Vec<MetadataSet>,
 }
 
-/// Metadata for a particular `ScopeSelector`.
+/// Metadata for a particular [`ScopeSelector`]
+///
+/// [`ScopeSelector`]: ../../highlighting/struct.ScopeSelector.html
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetadataSet {
     /// The raw string representation of this selector. We keep this around
@@ -94,14 +97,20 @@ const KEYS_WE_USE: &[&str] = &[
 ];
 
 impl LoadMetadata {
-    /// Adds the provided `RawMetadataEntry`. When creating the final `Metadata`
-    /// object, all `RawMetadataEntry` items are sorted by path, and items that
-    /// share a scope selector are merged; last writer wins.
+    /// Adds the provided `RawMetadataEntry`
+    ///
+    /// When creating the final [`Metadata`] object, all [`RawMetadataEntry`] items are sorted by
+    /// path, and items that share a scope selector are merged; last writer wins.
+    ///
+    /// [`Metadata`]: struct.Metadata.html
+    /// [`RawMetadataEntry`]: struct.RawMetadataEntry.html
     pub fn add_raw(&mut self, raw: RawMetadataEntry) {
         self.loaded.push(raw);
     }
 
-    /// Generates a `MetadataSet` from a single file
+    /// Generates a [`MetadataSet`] from a single file
+    ///
+    /// [`MetadataSet`]: struct.MetadataSet.html
     #[cfg(test)]
     pub(crate) fn quick_load(path: &str) -> Result<MetadataSet, LoadingError> {
         let mut loaded = Self::default();
@@ -181,8 +190,10 @@ fn append_vars(obj: &mut Dict, vars: Settings, scope: &str) {
 }
 
 impl Metadata {
-    /// For a given stack of scopes, returns a [`ScopedMetadata`] object
-    /// which provides convenient access to metadata items which match the stack.
+    /// For a given stack of scopes, returns a [`ScopedMetadata`] object which provides convenient
+    /// access to metadata items which match the stack.
+    ///
+    /// [`ScopedMetadata`]: struct.ScopedMetadata.html
     pub fn metadata_for_scope(&self, scope: &[Scope]) -> ScopedMetadata<'_> {
         let mut metadata_matches = self
             .scoped_metadata
@@ -281,8 +292,8 @@ impl MetadataSet {
     }
 }
 
-/// A collection of `MetadataSet`s which match a given scope selector,
-/// sorted in order of the strength of the match.
+/// A collection of [`MetadataSet`]s which match a given scope selector, sorted by the strength of
+/// the match
 ///
 /// # Examples
 ///
@@ -324,6 +335,8 @@ impl MetadataSet {
 /// // and the other match is used when it does not.
 /// assert!(scoped.decrease_indent("one decrease"));
 /// ```
+///
+/// [`MetadataSet`]: struct.MetadataSet.html
 #[derive(Debug, Clone)]
 pub struct ScopedMetadata<'a> {
     pub items: Vec<(MatchPower, &'a MetadataSet)>,

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -3,19 +3,19 @@
 //! and other syntax-specific things.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json;
 
-use super::regex::Regex;
-use super::scope::{MatchPower, Scope};
-use super::super::LoadingError;
 use super::super::highlighting::settings::*;
 use super::super::highlighting::ScopeSelectors;
+use super::super::LoadingError;
+use super::regex::Regex;
+use super::scope::{MatchPower, Scope};
 
 type Dict = serde_json::Map<String, Settings>;
 
@@ -119,13 +119,20 @@ impl From<LoadMetadata> for Metadata {
 
         let mut scoped_metadata: BTreeMap<SelectorString, Dict> = BTreeMap::new();
 
-        for RawMetadataEntry { scope, settings, path } in loaded {
-            let scoped_settings = scoped_metadata.entry(scope.clone())
-                .or_insert_with(|| {
-                    let mut d = Dict::new();
-                    d.insert("source_file_path".to_string(), path.to_string_lossy().into());
-                    d
-                });
+        for RawMetadataEntry {
+            scope,
+            settings,
+            path,
+        } in loaded
+        {
+            let scoped_settings = scoped_metadata.entry(scope.clone()).or_insert_with(|| {
+                let mut d = Dict::new();
+                d.insert(
+                    "source_file_path".to_string(),
+                    path.to_string_lossy().into(),
+                );
+                d
+            });
 
             for (key, value) in settings {
                 if !KEYS_WE_USE.contains(&key.as_str()) {
@@ -140,11 +147,9 @@ impl From<LoadMetadata> for Metadata {
             }
         }
 
-        let scoped_metadata = scoped_metadata.into_iter()
-            .map(|r|
-                 MetadataSet::from_raw(r)
-                     .map_err(|e| eprintln!("{}", e))
-                 )
+        let scoped_metadata = scoped_metadata
+            .into_iter()
+            .map(|r| MetadataSet::from_raw(r).map_err(|e| eprintln!("{}", e)))
             .flatten()
             .collect();
         Metadata { scoped_metadata }
@@ -153,20 +158,25 @@ impl From<LoadMetadata> for Metadata {
 
 fn append_vars(obj: &mut Dict, vars: Settings, scope: &str) {
     #[derive(Deserialize)]
-    struct KeyPair { name: String, value: Settings }
+    struct KeyPair {
+        name: String,
+        value: Settings,
+    }
     #[derive(Deserialize)]
     struct ShellVars(Vec<KeyPair>);
 
-    let shell_vars = obj.entry(String::from("shellVariables"))
+    let shell_vars = obj
+        .entry(String::from("shellVariables"))
         .or_insert_with(|| Dict::new().into())
-        .as_object_mut().unwrap();
+        .as_object_mut()
+        .unwrap();
     match serde_json::from_value::<ShellVars>(vars) {
-	Ok(vars) => {
-	    for KeyPair { name, value } in vars.0 {
-		shell_vars.insert(name, value);
-	    }
-	}
-	Err(e) => eprintln!("malformed shell variables for scope {}, {:}", scope, e),
+        Ok(vars) => {
+            for KeyPair { name, value } in vars.0 {
+                shell_vars.insert(name, value);
+            }
+        }
+        Err(e) => eprintln!("malformed shell variables for scope {}, {:}", scope, e),
     }
 }
 
@@ -174,19 +184,27 @@ impl Metadata {
     /// For a given stack of scopes, returns a [`ScopedMetadata`] object
     /// which provides convenient access to metadata items which match the stack.
     pub fn metadata_for_scope(&self, scope: &[Scope]) -> ScopedMetadata<'_> {
-        let mut metadata_matches = self.scoped_metadata
+        let mut metadata_matches = self
+            .scoped_metadata
             .iter()
             .filter_map(|meta_set| {
-                meta_set.selector.does_match(scope)
+                meta_set
+                    .selector
+                    .does_match(scope)
                     .map(|score| (score, meta_set))
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         metadata_matches.sort_unstable_by(|a, b| b.0.cmp(&a.0));
-        ScopedMetadata { items: metadata_matches }
+        ScopedMetadata {
+            items: metadata_matches,
+        }
     }
 
     pub(crate) fn merged_with_raw(self, raw: LoadMetadata) -> Metadata {
-        let Metadata { mut scoped_metadata } = self;
+        let Metadata {
+            mut scoped_metadata,
+        } = self;
         let mut final_items: BTreeMap<String, MetadataSet> = scoped_metadata
             .drain(..)
             .map(|ms| (ms.selector_string.clone(), ms))
@@ -196,16 +214,13 @@ impl Metadata {
             final_items.insert(item.selector_string.clone(), item);
         }
 
-        let scoped_metadata: Vec<MetadataSet> = final_items.into_iter()
-            .map(|(_k, v)| v)
-            .collect();
+        let scoped_metadata: Vec<MetadataSet> = final_items.into_iter().map(|(_k, v)| v).collect();
 
         Metadata { scoped_metadata }
     }
 }
 
 impl MetadataSet {
-
     const COMMENT_KEYS: &'static [(&'static str, &'static str)] = &[
         ("TM_COMMENT_START", "TM_COMMENT_END"),
         ("TM_COMMENT_START_2", "TM_COMMENT_END_2"),
@@ -215,38 +230,48 @@ impl MetadataSet {
     pub fn from_raw(tuple: (SelectorString, Dict)) -> Result<MetadataSet, String> {
         let (selector_string, mut settings) = tuple;
         // we just use this for more useful debug messages
-        let path = settings.remove("source_file_path").map(|v| v.to_string())
+        let path = settings
+            .remove("source_file_path")
+            .map(|v| v.to_string())
             .unwrap_or_else(|| String::from("(path missing)"));
 
+        if !KEYS_WE_USE.iter().any(|key| settings.contains_key(*key)) {
+            return Err(format!("skipping {}", path));
+        }
 
-       if !KEYS_WE_USE.iter().any(|key| settings.contains_key(*key)) {
-           return Err(format!("skipping {}", path));
-       }
+        let line_comment = settings
+            .get("shellVariables")
+            .and_then(|v| v.as_object())
+            .and_then(MetadataSet::get_line_comment_marker);
+        let block_comment = settings
+            .get("shellVariables")
+            .and_then(|v| v.as_object())
+            .and_then(MetadataSet::get_block_comment_markers);
 
-       let line_comment = settings.get("shellVariables").and_then(|v| v.as_object())
-           .and_then(MetadataSet::get_line_comment_marker);
-       let block_comment = settings.get("shellVariables").and_then(|v| v.as_object())
-           .and_then(MetadataSet::get_block_comment_markers);
-
-
-        let mut items: MetadataItems = serde_json::from_value(settings.into())
-            .map_err(|e| format!("{}: {:?}", path, e))?;
+        let mut items: MetadataItems =
+            serde_json::from_value(settings.into()).map_err(|e| format!("{}: {:?}", path, e))?;
         items.line_comment = line_comment;
         items.block_comment = block_comment;
 
-        let selector = ScopeSelectors::from_str(&selector_string)
-            .map_err(|e| format!("{}, {:?}", path, e))?;
-        Ok(MetadataSet { selector_string, selector, items })
+        let selector =
+            ScopeSelectors::from_str(&selector_string).map_err(|e| format!("{}, {:?}", path, e))?;
+        Ok(MetadataSet {
+            selector_string,
+            selector,
+            items,
+        })
     }
 
     fn get_line_comment_marker(vars: &Dict) -> Option<String> {
-        MetadataSet::COMMENT_KEYS.iter()
+        MetadataSet::COMMENT_KEYS
+            .iter()
             .find(|(b, e)| vars.contains_key(*b) && !vars.contains_key(*e))
             .and_then(|(b, _e)| vars.get(*b).map(|v| v.as_str().unwrap().to_string()))
     }
 
     fn get_block_comment_markers(vars: &Dict) -> Option<(String, String)> {
-        MetadataSet::COMMENT_KEYS.iter()
+        MetadataSet::COMMENT_KEYS
+            .iter()
             .find(|(b, e)| vars.contains_key(*b) && vars.contains_key(*e))
             .map(|(b, e)| {
                 let b_str = vars.get(*b).unwrap().as_str().unwrap().to_string();
@@ -305,46 +330,83 @@ pub struct ScopedMetadata<'a> {
 }
 
 impl<'a> ScopedMetadata<'a> {
-
     pub fn unindented_line(&self, line: &str) -> bool {
-        self.best_match(|ind| ind.unindented_line_pattern.as_ref().map(|p| p.is_match(line)))
-            .unwrap_or(false)
+        self.best_match(|ind| {
+            ind.unindented_line_pattern
+                .as_ref()
+                .map(|p| p.is_match(line))
+        })
+        .unwrap_or(false)
     }
 
     pub fn decrease_indent(&self, line: &str) -> bool {
-        self.best_match(|ind| ind.decrease_indent_pattern.as_ref().map(|p| p.is_match(line)))
-            .unwrap_or(false)
+        self.best_match(|ind| {
+            ind.decrease_indent_pattern
+                .as_ref()
+                .map(|p| p.is_match(line))
+        })
+        .unwrap_or(false)
     }
 
     pub fn increase_indent(&self, line: &str) -> bool {
-        self.best_match(|ind| ind.increase_indent_pattern.as_ref().map(|p| p.is_match(line)))
-            .unwrap_or(false)
+        self.best_match(|ind| {
+            ind.increase_indent_pattern
+                .as_ref()
+                .map(|p| p.is_match(line))
+        })
+        .unwrap_or(false)
     }
 
     pub fn bracket_increase(&self, line: &str) -> bool {
-        self.best_match(|ind| ind.bracket_indent_next_line_pattern.as_ref().map(|p| p.is_match(line)))
-            .unwrap_or(false)
+        self.best_match(|ind| {
+            ind.bracket_indent_next_line_pattern
+                .as_ref()
+                .map(|p| p.is_match(line))
+        })
+        .unwrap_or(false)
     }
 
     pub fn disable_indent_next_line(&self, line: &str) -> bool {
-        self.best_match(|ind| ind.disable_indent_next_line_pattern.as_ref().map(|p| p.is_match(line)))
-            .unwrap_or(false)
+        self.best_match(|ind| {
+            ind.disable_indent_next_line_pattern
+                .as_ref()
+                .map(|p| p.is_match(line))
+        })
+        .unwrap_or(false)
     }
 
     pub fn line_comment(&self) -> Option<&str> {
-        let idx = self.items.iter().position(|m| m.1.items.line_comment.is_some())?;
-        self.items[idx].1.items.line_comment.as_ref().map(|s| s.as_str())
+        let idx = self
+            .items
+            .iter()
+            .position(|m| m.1.items.line_comment.is_some())?;
+        self.items[idx]
+            .1
+            .items
+            .line_comment
+            .as_ref()
+            .map(|s| s.as_str())
     }
 
     pub fn block_comment(&self) -> Option<(&str, &str)> {
-        let idx = self.items.iter().position(|m| m.1.items.block_comment.is_some())?;
-        self.items[idx].1.items.block_comment.as_ref().map(|(a, b)| (a.as_str(), b.as_str()))
+        let idx = self
+            .items
+            .iter()
+            .position(|m| m.1.items.block_comment.is_some())?;
+        self.items[idx]
+            .1
+            .items
+            .block_comment
+            .as_ref()
+            .map(|(a, b)| (a.as_str(), b.as_str()))
     }
 
     fn best_match<T, F>(&self, f: F) -> Option<T>
-        where F: FnMut(&MetadataItems) -> Option<T>
+    where
+        F: FnMut(&MetadataItems) -> Option<T>,
     {
-        self.items.iter()
+        self.items
+            .iter()
             .map(|(_, meta_set)| &meta_set.items)
             .flat_map(f)
             .next()
@@ -364,7 +426,9 @@ impl RawMetadataEntry {
         // we stash the path because we use it to determine parse order
         // when generating the final metadata object; to_string_lossy
         // is adequate for this purpose.
-        contents.as_object_mut().and_then(|obj| obj.insert("path".into(), path.to_string_lossy().into()));
+        contents
+            .as_object_mut()
+            .and_then(|obj| obj.insert("path".into(), path.to_string_lossy().into()));
         Ok(serde_json::from_value(contents)?)
     }
 }
@@ -376,32 +440,50 @@ struct MetaSetSerializable {
 }
 
 impl Serialize for MetadataSet {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-
-        let MetadataSet { selector_string, items, .. } = self.clone();
-        let inner = MetaSetSerializable { selector_string, items: Some(items) };
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let MetadataSet {
+            selector_string,
+            items,
+            ..
+        } = self.clone();
+        let inner = MetaSetSerializable {
+            selector_string,
+            items: Some(items),
+        };
         inner.serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for MetadataSet {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         use serde::de::Error;
         let inner = MetaSetSerializable::deserialize(deserializer)?;
-        let MetaSetSerializable { selector_string, items } = inner;
+        let MetaSetSerializable {
+            selector_string,
+            items,
+        } = inner;
         let selector = ScopeSelectors::from_str(&selector_string)
             .map_err(|e| Error::custom(format!("{:?}", e)))?;
         let items = items.ok_or_else(|| Error::custom(format!("no metadata items")))?;
-        Ok(MetadataSet { selector_string, selector, items })
+        Ok(MetadataSet {
+            selector_string,
+            selector,
+            items,
+        })
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use super::*;
     use crate::parsing::SyntaxSet;
+    use std::path::Path;
 
     #[test]
     fn load_raw() {
@@ -456,12 +538,36 @@ mod tests {
     fn load_shell_vars() {
         let path = "testdata/Packages/AppleScript/Comments.tmPreferences";
         let metadata = LoadMetadata::quick_load(path).unwrap();
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_START").is_some());
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_END").is_none());
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_START_2").is_some());
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_START_3").is_some());
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_END_3").is_some());
-        assert!(metadata.items.shell_variables.get("TM_COMMENT_DISABLE_INDENT_3").is_some());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_START")
+            .is_some());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_END")
+            .is_none());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_START_2")
+            .is_some());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_START_3")
+            .is_some());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_END_3")
+            .is_some());
+        assert!(metadata
+            .items
+            .shell_variables
+            .get("TM_COMMENT_DISABLE_INDENT_3")
+            .is_some());
         assert!(metadata.items.line_comment.is_some());
         assert!(metadata.items.block_comment.is_some());
         assert!(metadata.items.increase_indent_pattern.is_none());
@@ -481,6 +587,5 @@ mod tests {
         assert_eq!(indent_ctx.decrease_indent("struct This {"), false);
         assert_eq!(indent_ctx.decrease_indent("struct This {}"), false);
         assert_eq!(indent_ctx.increase_indent("struct This {}"), false);
-
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -11,20 +11,20 @@ mod syntax_set;
 #[cfg(all(feature = "parsing", feature = "yaml-load"))]
 mod yaml_load;
 
-mod scope;
 #[cfg(any(feature = "parsing", feature = "yaml-load", feature = "metadata"))]
 mod regex;
+mod scope;
 
-#[cfg(feature = "parsing")]
-pub use self::syntax_definition::SyntaxDefinition;
-#[cfg(all(feature = "parsing", feature = "yaml-load"))]
-pub use self::yaml_load::*;
-#[cfg(feature = "parsing")]
-pub use self::syntax_set::*;
-#[cfg(feature = "parsing")]
-pub use self::parser::*;
 #[cfg(feature = "metadata")]
 pub use self::metadata::*;
+#[cfg(feature = "parsing")]
+pub use self::parser::*;
+#[cfg(feature = "parsing")]
+pub use self::syntax_definition::SyntaxDefinition;
+#[cfg(feature = "parsing")]
+pub use self::syntax_set::*;
+#[cfg(all(feature = "parsing", feature = "yaml-load"))]
+pub use self::yaml_load::*;
 
 #[cfg(any(feature = "parsing", feature = "yaml-load", feature = "metadata"))]
 pub use self::regex::*;

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,5 +1,9 @@
 //! Everything about parsing text into text annotated with scopes.
-//! The most important struct here is `SyntaxSet`, check out the docs for that.
+//!
+//! The most important struct here is [`SyntaxSet`], check out the docs for that.
+//!
+//! [`SyntaxSet`]: struct.SyntaxSet.html
+
 #[cfg(feature = "metadata")]
 pub mod metadata;
 #[cfg(feature = "parsing")]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -9,21 +9,24 @@ use std::i32;
 use std::usize;
 
 /// Keeps the current parser state (the internal syntax interpreter stack) between lines of parsing.
+///
 /// If you are parsing an entire file you create one of these at the start and use it
 /// all the way to the end.
 ///
 /// # Caching
 ///
 /// One reason this is exposed is that since it implements `Clone` you can actually cache
-/// these (probably along with a `HighlightState`) and only re-start parsing from the point of a change.
-/// See the docs for `HighlightState` for more in-depth discussion of caching.
+/// these (probably along with a [`HighlightState`]) and only re-start parsing from the point of a change.
+/// See the docs for [`HighlightState`] for more in-depth discussion of caching.
 ///
 /// This state doesn't keep track of the current scope stack and parsing only returns changes to this stack
 /// so if you want to construct scope stacks you'll need to keep track of that as well.
-/// Note that `HighlightState` contains exactly this as a public field that you can use.
+/// Note that [`HighlightState`] contains exactly this as a public field that you can use.
 ///
 /// **Note:** Caching is for advanced users who have tons of time to maximize performance or want to do so eventually.
 /// It is not recommended that you try caching the first time you implement highlighting.
+///
+/// [`HighlightState`]: ../highlighting/struct.HighlightState.html
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ParseState {
     stack: Vec<StateLevel>,
@@ -49,7 +52,7 @@ struct RegexMatch<'a> {
     would_loop: bool,
 }
 
-/// maps the pattern to the start index, which is -1 if not found.
+/// Maps the pattern to the start index, which is -1 if not found.
 type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefault<FnvHasher>>;
 
 // To understand the implementation of this, here's an introduction to how
@@ -145,8 +148,8 @@ type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefau
 // again. This time, the "\w+" wins because it comes first.
 
 impl ParseState {
-    /// Create a state from a syntax, keeps its own reference counted
-    /// pointer to the main context of the syntax.
+    /// Creates a state from a syntax definition, keeping its own reference-counted point to the
+    /// main context of the syntax
     pub fn new(syntax: &SyntaxReference) -> ParseState {
         let start_state = StateLevel {
             context: syntax.contexts["__start"],
@@ -165,17 +168,20 @@ impl ParseState {
     /// Sublime Text avoids this by just not highlighting lines that are too long (thousands of characters).
     ///
     /// For efficiency reasons this returns only the changes to the current scope at each point in the line.
-    /// You can use `ScopeStack#apply` on each operation in succession to get the stack for a given point.
+    /// You can use [`ScopeStack::apply`] on each operation in succession to get the stack for a given point.
     /// Look at the code in `highlighter.rs` for an example of doing this for highlighting purposes.
     ///
     /// The returned vector is in order both by index to apply at (the `usize`) and also by order to apply them at a
     /// given index (e.g popping old scopes before pushing new scopes).
     ///
-    /// The `SyntaxSet` has to be the one that contained the syntax that was
-    /// used to construct this `ParseState`, or an extended version of it.
-    /// Otherwise the parsing would return the wrong result or even panic. The
-    /// reason for this is that contexts within the `SyntaxSet` are referenced
-    /// via indexes.
+    /// The [`SyntaxSet`] has to be the one that contained the syntax that was used to construct
+    /// this [`ParseState`], or an extended version of it. Otherwise the parsing would return the
+    /// wrong result or even panic. The reason for this is that contexts within the [`SyntaxSet`]
+    /// are referenced via indexes.
+    ///
+    /// [`ScopeStack::apply`]: struct.ScopeStack.html#method.apply
+    /// [`SyntaxSet`]: struct.SyntaxSet.html
+    /// [`ParseState`]: struct.ParseState.html
     pub fn parse_line(&mut self, line: &str, syntax_set: &SyntaxSet) -> Vec<(usize, ScopeStackOp)> {
         assert!(
             !self.stack.is_empty(),

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -49,8 +49,10 @@ impl Regex {
     /// Search for the pattern in the given text from begin/end positions.
     ///
     /// If a region is passed, it is used for storing match group positions. The argument allows
-    /// the `Region` to be reused between searches, which makes a significant performance
+    /// the [`Region`] to be reused between searches, which makes a significant performance
     /// difference.
+    ///
+    /// [`Region`]: struct.Region.html
     pub fn search(
         &self,
         text: &str,

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -1,15 +1,15 @@
 // see DESIGN.md
+use std::cmp::{min, Ordering};
 use std::collections::HashMap;
-use std::u16;
-use std::sync::Mutex;
 use std::fmt;
-use std::str::FromStr;
-use std::u64;
-use std::cmp::{Ordering, min};
 use std::mem;
+use std::str::FromStr;
+use std::sync::Mutex;
+use std::u16;
+use std::u64;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Multiplier on the power of 2 for MatchPower.
 /// Only useful if you compute your own MatchPower scores.
@@ -136,7 +136,11 @@ impl ScopeRepository {
         if s.is_empty() {
             return Ok(Scope { a: 0, b: 0 });
         }
-        let parts: Vec<usize> = s.trim_end_matches('.').split('.').map(|a| self.atom_to_index(a)).collect();
+        let parts: Vec<usize> = s
+            .trim_end_matches('.')
+            .split('.')
+            .map(|a| self.atom_to_index(a))
+            .collect();
         if parts.len() > 8 {
             return Err(ParseScopeError::TooManyAtoms);
         }
@@ -297,15 +301,20 @@ impl fmt::Debug for Scope {
 }
 
 impl Serialize for Scope {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         let s = self.build_string();
         serializer.serialize_str(&s)
     }
 }
 
 impl<'de> Deserialize<'de> for Scope {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         struct ScopeVisitor;
 
         impl<'de> Visitor<'de> for ScopeVisitor {
@@ -315,7 +324,10 @@ impl<'de> Deserialize<'de> for Scope {
                 formatter.write_str("a string")
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Scope, E> where E: Error {
+            fn visit_str<E>(self, v: &str) -> Result<Scope, E>
+            where
+                E: Error,
+            {
                 Scope::new(v).map_err(|e| Error::custom(format!("Invalid scope: {:?}", e)))
             }
         }
@@ -339,7 +351,7 @@ impl ScopeStack {
     pub fn new() -> ScopeStack {
         ScopeStack {
             clear_stack: Vec::new(),
-            scopes: Vec::new()
+            scopes: Vec::new(),
         }
     }
 
@@ -348,7 +360,7 @@ impl ScopeStack {
     pub fn from_vec(v: Vec<Scope>) -> ScopeStack {
         ScopeStack {
             clear_stack: Vec::new(),
-            scopes: v
+            scopes: v,
         }
     }
 
@@ -366,7 +378,7 @@ impl ScopeStack {
     /// use this to create a stack from a `Vec` of changes
     /// given by the parser.
     pub fn apply(&mut self, op: &ScopeStackOp) {
-        self.apply_with_hook(op, |_,_|{})
+        self.apply_with_hook(op, |_, _| {})
     }
 
     /// Modifies this stack according to the operation given and calls the hook for each basic operation.
@@ -374,7 +386,8 @@ impl ScopeStack {
     /// Use this to do things only when the scope stack changes.
     #[inline]
     pub fn apply_with_hook<F>(&mut self, op: &ScopeStackOp, mut hook: F)
-        where F: FnMut(BasicScopeStackOp, &[Scope])
+    where
+        F: FnMut(BasicScopeStackOp, &[Scope]),
     {
         match *op {
             ScopeStackOp::Push(scope) => {
@@ -406,17 +419,15 @@ impl ScopeStack {
                     hook(BasicScopeStackOp::Pop, self.as_slice());
                 }
             }
-            ScopeStackOp::Restore => {
-                match self.clear_stack.pop() {
-                    Some(ref mut to_push) => {
-                        for s in to_push {
-                            self.scopes.push(*s);
-                            hook(BasicScopeStackOp::Push(*s), self.as_slice());
-                        }
+            ScopeStackOp::Restore => match self.clear_stack.pop() {
+                Some(ref mut to_push) => {
+                    for s in to_push {
+                        self.scopes.push(*s);
+                        hook(BasicScopeStackOp::Push(*s), self.as_slice());
                     }
-                    None => panic!("tried to restore cleared scopes, but none were cleared"),
                 }
-            }
+                None => panic!("tried to restore cleared scopes, but none were cleared"),
+            },
             ScopeStackOp::Noop => (),
         }
     }
@@ -529,10 +540,14 @@ mod tests {
     #[test]
     fn repo_works() {
         let mut repo = ScopeRepository::new();
-        assert_eq!(repo.build("source.php").unwrap(),
-                   repo.build("source.php").unwrap());
-        assert_eq!(repo.build("source.php.wow.hi.bob.troll.clock.5").unwrap(),
-                   repo.build("source.php.wow.hi.bob.troll.clock.5").unwrap());
+        assert_eq!(
+            repo.build("source.php").unwrap(),
+            repo.build("source.php").unwrap()
+        );
+        assert_eq!(
+            repo.build("source.php.wow.hi.bob.troll.clock.5").unwrap(),
+            repo.build("source.php.wow.hi.bob.troll.clock.5").unwrap()
+        );
         assert_eq!(repo.build("").unwrap(), repo.build("").unwrap());
         let s1 = repo.build("").unwrap();
         assert_eq!(repo.to_string(s1), "");
@@ -540,14 +555,18 @@ mod tests {
         assert_eq!(repo.to_string(s2), "source.php.wow");
         assert!(repo.build("source.php").unwrap() != repo.build("source.perl").unwrap());
         assert!(repo.build("source.php").unwrap() != repo.build("source.php.wagon").unwrap());
-        assert_eq!(repo.build("comment.line.").unwrap(),
-                   repo.build("comment.line").unwrap());
+        assert_eq!(
+            repo.build("comment.line.").unwrap(),
+            repo.build("comment.line").unwrap()
+        );
     }
     #[test]
     fn global_repo_works() {
         use std::str::FromStr;
-        assert_eq!(Scope::new("source.php").unwrap(),
-                   Scope::new("source.php").unwrap());
+        assert_eq!(
+            Scope::new("source.php").unwrap(),
+            Scope::new("source.php").unwrap()
+        );
         assert!(Scope::from_str("1.2.3.4.5.6.7.8").is_ok());
         assert!(Scope::from_str("1.2.3.4.5.6.7.8.9").is_err());
     }
@@ -578,37 +597,53 @@ mod tests {
     #[test]
     fn matching_works() {
         use std::str::FromStr;
-        assert_eq!(ScopeStack::from_str("string")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("string.quoted").unwrap().as_slice()),
-                   Some(MatchPower(0o1u64 as f64)));
-        assert_eq!(ScopeStack::from_str("source")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("string.quoted").unwrap().as_slice()),
-                   None);
-        assert_eq!(ScopeStack::from_str("a.b e.f")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   Some(MatchPower(0o202u64 as f64)));
-        assert_eq!(ScopeStack::from_str("c e.f")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   Some(MatchPower(0o210u64 as f64)));
-        assert_eq!(ScopeStack::from_str("c.d e.f")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   Some(MatchPower(0o220u64 as f64)));
-        assert_eq!(ScopeStack::from_str("a.b c e.f")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   Some(MatchPower(0o212u64 as f64)));
-        assert_eq!(ScopeStack::from_str("a c.d")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   Some(MatchPower(0o021u64 as f64)));
-        assert_eq!(ScopeStack::from_str("a c.d.e")
-                       .unwrap()
-                       .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
-                   None);
+        assert_eq!(
+            ScopeStack::from_str("string")
+                .unwrap()
+                .does_match(ScopeStack::from_str("string.quoted").unwrap().as_slice()),
+            Some(MatchPower(0o1u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("source")
+                .unwrap()
+                .does_match(ScopeStack::from_str("string.quoted").unwrap().as_slice()),
+            None
+        );
+        assert_eq!(
+            ScopeStack::from_str("a.b e.f")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            Some(MatchPower(0o202u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("c e.f")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            Some(MatchPower(0o210u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("c.d e.f")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            Some(MatchPower(0o220u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("a.b c e.f")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            Some(MatchPower(0o212u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("a c.d")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            Some(MatchPower(0o021u64 as f64))
+        );
+        assert_eq!(
+            ScopeStack::from_str("a c.d.e")
+                .unwrap()
+                .does_match(ScopeStack::from_str("a.b c.d e.f.g").unwrap().as_slice()),
+            None
+        );
     }
 }

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -11,30 +11,36 @@ use std::u64;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Multiplier on the power of 2 for MatchPower.
-/// Only useful if you compute your own MatchPower scores.
+/// Multiplier on the power of 2 for MatchPower. This is only useful if you compute your own
+/// [`MatchPower`] scores
+///
+/// [`MatchPower`]: struct.MatchPower.html
 pub const ATOM_LEN_BITS: u16 = 3;
 
 lazy_static! {
     /// The global scope repo, exposed in case you want to minimize locking and unlocking.
-    /// Shouldn't be necessary for you to use. See the `ScopeRepository` docs.
+    ///
+    /// Ths shouldn't be necessary for you to use. See the [`ScopeRepository`] docs.
+    ///
+    /// [`ScopeRepository`]: struct.ScopeRepository.html
     pub static ref SCOPE_REPO: Mutex<ScopeRepository> = Mutex::new(ScopeRepository::new());
 }
 
-/// A hierarchy of atoms with semi-standardized names
-/// used to accord semantic information to a specific piece of text.
-/// Generally written with the atoms separated by dots.
-/// By convention atoms are all lowercase alphanumeric.
+/// A hierarchy of atoms with semi-standardized names used to accord semantic information to a
+/// specific piece of text.
+///
+/// These are generally written with the atoms separated by dots, and - by convention - atoms are
+/// all lowercase alphanumeric.
 ///
 /// Example scopes: `text.plain`, `punctuation.definition.string.begin.ruby`,
 /// `meta.function.parameters.rust`
 ///
-/// `syntect` uses an optimized format for storing these that allows super fast comparison
-/// and determining if one scope is a prefix of another. It also always takes 16 bytes of space.
-/// It accomplishes this by using a global repository to store string values and using bit-packed
-/// 16 bit numbers to represent and compare atoms. Like "atoms" or "symbols" in other languages.
-/// This means that while comparing and prefix are fast, extracting a string is relatively slower
-/// but ideally should be very rare.
+/// `syntect` uses an optimized format for storing these that allows super fast comparison and
+/// determining if one scope is a prefix of another. It also always takes 16 bytes of space. It
+/// accomplishes this by using a global repository to store string values and using bit-packed 16
+/// bit numbers to represent and compare atoms. Like "atoms" or "symbols" in other languages. This
+/// means that while comparing and prefix are fast, extracting a string is relatively slower but
+/// ideally should be very rare.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Copy, Default, Hash)]
 pub struct Scope {
     a: u64,
@@ -52,25 +58,34 @@ pub enum ParseScopeError {
     TooManyAtoms,
 }
 
-/// The structure used to keep track of the mapping between scope atom numbers
-/// and their string names. It is only exposed in case you want to lock
-/// `SCOPE_REPO` and then allocate a whole bunch of scopes at once
-/// without thrashing the lock. It is recommended you just use `Scope::new()`
+/// The structure used to keep track of the mapping between scope atom numbers and their string
+/// names
 ///
-/// Only `Scope`s created by the same repository have valid comparison results.
+/// It is only exposed in case you want to lock [`SCOPE_REPO`] and then allocate a bunch of scopes
+/// at once without thrashing the lock. In general, you should just use [`Scope::new()`].
+///
+/// Only [`Scope`]s created by the same repository have valid comparison results.
+///
+/// [`SCOPE_REPO`]: struct.SCOPE_REPO.html
+/// [`Scope::new()`]: struct.Scope.html#method.new
+/// [`Scope`]: struct.Scope.html
 #[derive(Debug)]
 pub struct ScopeRepository {
     atoms: Vec<String>,
     atom_index_map: HashMap<String, usize>,
 }
 
-/// A stack/sequence of scopes. This is used both to represent hierarchies for a given
-/// token of text, as well as in `ScopeSelectors`. Press `ctrl+shift+p` in Sublime Text
-/// to see the scope stack at a given point.
-/// Also see [the TextMate docs](https://manual.macromates.com/en/scope_selectors).
+/// A stack/sequence of scopes for representing hierarchies for a given token of text
+///
+/// This is also used within [`ScopeSelectors`].
+///
+/// In Sublime Text, the scope stack at a given point can be seen by pressing `ctrl+shift+p`. Also
+/// see [the TextMate docs](https://manual.macromates.com/en/scope_selectors).
 ///
 /// Example for a JS string inside a script tag in a Rails `ERB` file:
 /// `text.html.ruby text.html.basic source.js.embedded.html string.quoted.double.js`
+///
+/// [`ScopeSelectors`]: ../highlighting/struct.ScopeSelectors.html
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ScopeStack {
     clear_stack: Vec<Vec<Scope>>,
@@ -83,21 +98,28 @@ pub enum ClearAmount {
     All,
 }
 
-/// A change to a scope stack. Generally `Noop` is only used internally and you don't have
-/// to worry about ever getting one back from a public function.
-/// Use `ScopeStack#apply` to apply this change.
+/// A change to a scope stack
+///
+/// Generally, `Noop` is only used internally and you won't need to worry about getting one back
+/// from calling a public function.
+///
+/// The change from a `ScopeStackOp` can be applied via [`ScopeStack::apply`].
+///
+/// [`ScopeStack::apply`]: struct.ScopeStack.html#method.apply
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScopeStackOp {
     Push(Scope),
     Pop(usize),
-    /// used for the clear_scopes feature
+    /// Used for the `clear_scopes` feature
     Clear(ClearAmount),
-    /// restores cleared scopes
+    /// Restores cleared scopes
     Restore,
     Noop,
 }
 
-/// Used for `ScopeStack::apply_with_hook`
+/// Used for [`ScopeStack::apply_with_hook`]
+///
+/// [`ScopeStack::apply_with_hook`]: struct.ScopeStack.html#method.apply_with_hook
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BasicScopeStackOp {
     Push(Scope),
@@ -176,23 +198,27 @@ impl ScopeRepository {
         index
     }
 
-    /// Return the string for an atom number returned by `Scope#atom_at`
+    /// Return the string for an atom number returned by [`Scope::atom_at`]
+    ///
+    /// [`Scope::atom_at`]: struct.Scope.html#method.atom_at
     pub fn atom_str(&self, atom_number: u16) -> &str {
         &self.atoms[(atom_number - 1) as usize]
     }
 }
 
 impl Scope {
-    /// Parses a `Scope` from a series of atoms separated by
-    /// `.` characters. Example: `Scope::new("meta.rails.controller")`
+    /// Parses a `Scope` from a series of atoms separated by dot (`.`) characters
+    ///
+    /// Example: `Scope::new("meta.rails.controller")`
     pub fn new(s: &str) -> Result<Scope, ParseScopeError> {
         let mut repo = SCOPE_REPO.lock().unwrap();
         repo.build(s.trim())
     }
 
     /// Gets the atom number at a given index.
-    /// I can't think of any reason you'd find this useful.
-    /// It is used internally for turning a scope back into a string.
+    ///
+    /// I can't think of any reason you'd find this useful. It is used internally for turning a
+    /// scope back into a string.
     pub fn atom_at(self, index: usize) -> u16 {
         let shifted = if index < 4 {
             self.a >> ((3 - index) * 16)
@@ -214,7 +240,7 @@ impl Scope {
         trail / 16
     }
 
-    /// return the number of atoms in the scope
+    /// Returns the number of atoms in the scope
     #[inline(always)]
     pub fn len(self) -> u32 {
         8 - self.missing_atoms()
@@ -224,15 +250,16 @@ impl Scope {
         self.len() == 0
     }
 
-    /// returns a string representation of this scope, this requires locking a
-    /// global repo and shouldn't be done frequently.
+    /// Returns a string representation of this scope
+    ///
+    /// This requires locking a global repo and shouldn't be done frequently.
     pub fn build_string(self) -> String {
         let repo = SCOPE_REPO.lock().unwrap();
         repo.to_string(self)
     }
 
-    /// Tests if this scope is a prefix of another scope.
-    /// Note that the empty scope is always a prefix.
+    /// Tests if this scope is a prefix of another scope. Note that the empty scope is always a
+    /// prefix.
     ///
     /// This operation uses bitwise operations and is very fast
     /// # Examples
@@ -336,11 +363,13 @@ impl<'de> Deserialize<'de> for Scope {
     }
 }
 
-/// Wrapper to get around the fact Rust f64 doesn't implement Ord
-/// and there is no non-NaN float type
+/// Wrapper to get around the fact Rust `f64` doesn't implement `Ord` and there is no non-NaN
+/// float type
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 pub struct MatchPower(pub f64);
+
 impl Eq for MatchPower {}
+
 impl Ord for MatchPower {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap()
@@ -356,7 +385,7 @@ impl ScopeStack {
     }
 
     /// Note: creating a ScopeStack with this doesn't contain information
-    /// on what to do when clear_scopes contexts end.
+    /// on what to do when `clear_scopes` contexts end.
     pub fn from_vec(v: Vec<Scope>) -> ScopeStack {
         ScopeStack {
             clear_stack: Vec::new(),
@@ -375,15 +404,19 @@ impl ScopeStack {
     }
 
     /// Modifies this stack according to the operation given
-    /// use this to create a stack from a `Vec` of changes
-    /// given by the parser.
+    ///
+    /// Use this to create a stack from a `Vec` of changes given by the parser.
     pub fn apply(&mut self, op: &ScopeStackOp) {
         self.apply_with_hook(op, |_, _| {})
     }
 
     /// Modifies this stack according to the operation given and calls the hook for each basic operation.
-    /// Like `apply` but calls `hook` for every basic modification (as defined by `BasicScopeStackOp`).
-    /// Use this to do things only when the scope stack changes.
+    ///
+    /// Like [`apply`] but calls `hook` for every basic modification (as defined by
+    /// [`BasicScopeStackOp`]). Use this to do things only when the scope stack changes.
+    ///
+    /// [`apply`]: #method.apply
+    /// [`BasicScopeStackOp`]: enum.BasicScopeStackOp.html
     #[inline]
     pub fn apply_with_hook<F>(&mut self, op: &ScopeStackOp, mut hook: F)
     where
@@ -441,8 +474,9 @@ impl ScopeStack {
         println!();
     }
 
-    /// Return the bottom n elements of the stack.
-    /// Equivalent to &scopes[0..n] on a Vec
+    /// Returns the bottom `n` elements of the stack.
+    ///
+    /// Equivalent to `&scopes[0..n]` on a `Vec`
     pub fn bottom_n(&self, n: usize) -> &[Scope] {
         &self.scopes[0..n]
     }
@@ -464,16 +498,16 @@ impl ScopeStack {
         self.len() == 0
     }
 
-    /// checks if this stack as a selector matches the given stack
-    /// if so it returns a match score, higher match scores are stronger
-    /// matches. Scores are ordered according to the rules found
-    /// at https://manual.macromates.com/en/scope_selectors
+    /// Checks if this stack as a selector matches the given stack, returning the match score if so
     ///
-    /// It accomplishes this ordering through some floating point math
-    /// ensuring deeper and longer matches matter.
-    /// Unfortunately it is only guaranteed to return perfectly accurate results
-    /// up to stack depths of 17, but it should be reasonably good even afterwards.
-    /// Textmate has the exact same limitation, dunno about Sublime.
+    /// Higher match scores indicate stronger matches. Scores are ordered according to the rules
+    /// found at [https://manual.macromates.com/en/scope_selectors](https://manual.macromates.com/en/scope_selectors)
+    ///
+    /// It accomplishes this ordering through some floating point math ensuring deeper and longer
+    /// matches matter. Unfortunately it is only guaranteed to return perfectly accurate results up
+    /// to stack depths of 17, but it should be reasonably good even afterwards. TextMate has the
+    /// exact same limitation, dunno about Sublime Text.
+    ///
     /// # Examples
     /// ```
     /// use syntect::parsing::{ScopeStack, MatchPower};
@@ -529,6 +563,7 @@ impl fmt::Display for ScopeStack {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn misc() {
         // use std::mem;
@@ -537,6 +572,7 @@ mod tests {
         // assert_eq!(8, mem::size_of::<Rc<Scope>>());
         // assert_eq!(Scope::new("source.php"), Scope::new("source.php"));
     }
+
     #[test]
     fn repo_works() {
         let mut repo = ScopeRepository::new();
@@ -560,6 +596,7 @@ mod tests {
             repo.build("comment.line").unwrap()
         );
     }
+
     #[test]
     fn global_repo_works() {
         use std::str::FromStr;
@@ -570,6 +607,7 @@ mod tests {
         assert!(Scope::from_str("1.2.3.4.5.6.7.8").is_ok());
         assert!(Scope::from_str("1.2.3.4.5.6.7.8.9").is_err());
     }
+
     #[test]
     fn prefixes_work() {
         assert!(Scope::new("1.2.3.4.5.6.7.8")
@@ -594,6 +632,7 @@ mod tests {
             .unwrap()
             .is_prefix_of(Scope::new("1.2.3.4.5.6.7.8").unwrap()));
     }
+
     #[test]
     fn matching_works() {
         use std::str::FromStr;

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -3,13 +3,13 @@
 //! integrated cases like text editors and I have no idea what kind of monkeying
 //! you might want to do with the data. Perhaps parsing your own syntax format
 //! into this data structure?
-use std::collections::{BTreeMap, HashMap};
-use std::hash::Hash;
-use super::scope::*;
 use super::regex::{Regex, Region};
+use super::scope::*;
+use crate::parsing::syntax_set::SyntaxSet;
 use regex_syntax::escape;
 use serde::{Serialize, Serializer};
-use crate::parsing::syntax_set::SyntaxSet;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 
 pub type CaptureMapping = Vec<(usize, Vec<Scope>)>;
 
@@ -110,7 +110,6 @@ pub enum ContextReference {
     Direct(ContextId),
 }
 
-
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum MatchOperation {
     Push(Vec<ContextReference>),
@@ -139,7 +138,7 @@ impl<'a> Iterator for MatchIter<'a> {
                 match context.patterns[index] {
                     Pattern::Match(_) => {
                         return Some((context, index));
-                    },
+                    }
                     Pattern::Include(ref ctx_ref) => {
                         let ctx_ptr = match *ctx_ref {
                             ContextReference::Direct(ref context_id) => {
@@ -199,7 +198,8 @@ impl ContextReference {
 }
 
 pub(crate) fn substitute_backrefs_in_regex<F>(regex_str: &str, substituter: F) -> String
-    where F: Fn(usize) -> Option<String>
+where
+    F: Fn(usize) -> Option<String>,
 {
     let mut reg_str = String::with_capacity(regex_str.len());
 
@@ -234,7 +234,6 @@ impl ContextId {
 }
 
 impl MatchPattern {
-
     pub fn new(
         has_captures: bool,
         regex_str: String,
@@ -268,15 +267,16 @@ impl MatchPattern {
     }
 }
 
-
 /// Serialize the provided map in natural key order, so that it's deterministic when dumping.
 pub(crate) fn ordered_map<K, V, S>(map: &HashMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
-    where S: Serializer, K: Eq + Hash + Ord + Serialize, V: Serialize
+where
+    S: Serializer,
+    K: Eq + Hash + Ord + Serialize,
+    V: Serialize,
 {
     let ordered: BTreeMap<_, _> = map.iter().collect();
     ordered.serialize(serializer)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -1,8 +1,9 @@
-//! This module contains data structures for representing syntax definitions.
-//! Everything is public because I want this library to be useful in super
-//! integrated cases like text editors and I have no idea what kind of monkeying
-//! you might want to do with the data. Perhaps parsing your own syntax format
-//! into this data structure?
+//! Data structures for representing syntax definitions
+//!
+//! Everything here is public becaues I want this library to be useful in super integrated cases
+//! like text editors and I have no idea what kind of monkeying you might want to do with the data.
+//! Perhaps parsing your own syntax format into this data structure?
+
 use super::regex::{Regex, Region};
 use super::scope::*;
 use crate::parsing::syntax_set::SyntaxSet;
@@ -19,12 +20,13 @@ pub struct ContextId {
 }
 
 /// The main data structure representing a syntax definition loaded from a
-/// `.sublime-syntax` file. You'll probably only need these as references
-/// to be passed around to parsing code.
+/// `.sublime-syntax` file
 ///
-/// Some useful public fields are the `name` field which is a human readable
-/// name to display in syntax lists, and the `hidden` field which means hide
-/// this syntax from any lists because it is for internal use.
+/// You'll probably only need these as references to be passed around to parsing code.
+///
+/// Some useful public fields are the `name` field which is a human readable name to display in
+/// syntax lists, and the `hidden` field which means hide this syntax from any lists because it is
+/// for internal use.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyntaxDefinition {
     pub name: String,
@@ -75,9 +77,9 @@ pub enum Pattern {
     Include(ContextReference),
 }
 
-/// Used to iterate over all the match patterns in a context.
-/// Basically walks the tree of patterns and include directives
-/// in the correct order.
+/// Used to iterate over all the match patterns in a context
+///
+/// Basically walks the tree of patterns and include directives in the correct order.
 #[derive(Debug)]
 pub struct MatchIter<'a> {
     syntax_set: &'a SyntaxSet,
@@ -159,8 +161,9 @@ impl<'a> Iterator for MatchIter<'a> {
 }
 
 /// Returns an iterator over all the match patterns in this context.
-/// It recursively follows include directives. Can only be run on
-/// contexts that have already been linked up.
+///
+/// It recursively follows include directives. Can only be run on contexts that have already been
+/// linked up.
 pub fn context_iter<'a>(syntax_set: &'a SyntaxSet, context: &'a Context) -> MatchIter<'a> {
     MatchIter {
         syntax_set,

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -99,9 +99,12 @@ __main:
 
 impl SyntaxDefinition {
     /// In case you want to create your own SyntaxDefinition's in memory from strings.
-    /// Generally you should use a `SyntaxSet`
+    ///
+    /// Generally you should use a [`SyntaxSet`].
     ///
     /// `fallback_name` is an optional name to use when the YAML doesn't provide a `name` key.
+    ///
+    /// [`SyntaxSet`]: ../struct.SyntaxSet.html
     pub fn load_from_str(
         s: &str,
         lines_include_newline: bool,
@@ -594,6 +597,7 @@ impl ContextNamer {
 }
 
 /// In fancy-regex, POSIX character classes only match ASCII characters.
+///
 /// Sublime's syntaxes expect them to match Unicode characters as well, so transform them to
 /// corresponding Unicode character classes.
 fn replace_posix_char_classes(regex: String) -> String {
@@ -607,6 +611,7 @@ fn replace_posix_char_classes(regex: String) -> String {
 
 /// Some of the regexes include `$` and expect it to match end of line,
 /// e.g. *before* the `\n` in `test\n`.
+///
 /// In fancy-regex, `$` means end of text by default, so that would
 /// match *after* `\n`. Using `(?m:$)` instead means it matches end of line.
 ///
@@ -742,12 +747,12 @@ struct ConsumingCaptureIndexParser<'a> {
 }
 
 impl<'a> ConsumingCaptureIndexParser<'a> {
-    /// find capture groups which are not inside lookarounds.
-    /// If, in a YAML syntax definition, a scope stack is applied
-    /// to a capture group inside a lookaround,
-    /// (i.e. "captures:\n x: scope.stack goes.here", where "x" is
-    /// the number of a capture group in a lookahead/behind), those
-    /// those scopes are not applied, so no need to even parse them.
+    /// Find capture groups which are not inside lookarounds.
+    ///
+    /// If, in a YAML syntax definition, a scope stack is applied to a capture group inside a
+    /// lookaround, (i.e. "captures:\n x: scope.stack goes.here", where "x" is the number of a
+    /// capture group in a lookahead/behind), those those scopes are not applied, so no need to
+    /// even parse them.
     fn get_consuming_capture_indexes(mut self) -> Vec<usize> {
         let mut result = Vec::new();
         let mut stack = Vec::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,22 @@
 //! Convenient helper functions for common use cases:
-//! printing to terminal, iterating lines with `\n`s, modifying ranges of highlighted output
+//! * Printing to terminal
+//! * Iterating lines with `\n`s
+//! * Modifying ranges of highlighted output
+
 use crate::highlighting::{Style, StyleModifier};
 #[cfg(feature = "parsing")]
 use crate::parsing::ScopeStackOp;
 use std::fmt::Write;
 use std::ops::Range;
 
-/// Formats the styled fragments using 24-bit color
-/// terminal escape codes. Meant for debugging and testing.
-/// It's currently fairly inefficient in its use of escape codes.
+/// Formats the styled fragments using 24-bit color terminal escape codes.
+/// Meant for debugging and testing.
 ///
-/// Note that this does not currently ever un-set the color so that
-/// the end of a line will also get highlighted with the background.
-/// This means if you might want to use `println!("\x1b[0m");` after
-/// to clear the coloring.
+/// This function is currently fairly inefficient in its use of escape codes.
+///
+/// Note that this does not currently ever un-set the color so that the end of a line will also get
+/// highlighted with the background.  This means if you might want to use `println!("\x1b[0m");`
+/// after to clear the coloring.
 ///
 /// If `bg` is true then the background is also set
 pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
@@ -199,8 +202,10 @@ impl<'a> Iterator for LinesWithEndings<'a> {
 }
 
 /// Split a highlighted line at a byte index in the line into a before and
-/// after component. It's just a helper that does the somewhat tricky logic
-/// including splitting a span if the index lies on a boundary.
+/// after component.
+///
+/// This is just a helper that does the somewhat tricky logic including splitting
+/// a span if the index lies on a boundary.
 ///
 /// This can be used to extract a chunk of the line out for special treatment
 /// like wrapping it in an HTML tag for extra styling.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,10 @@
 //! Convenient helper functions for common use cases:
 //! printing to terminal, iterating lines with `\n`s, modifying ranges of highlighted output
 use crate::highlighting::{Style, StyleModifier};
-use std::fmt::Write;
-use std::ops::Range;
 #[cfg(feature = "parsing")]
 use crate::parsing::ScopeStackOp;
+use std::fmt::Write;
+use std::ops::Range;
 
 /// Formats the styled fragments using 24-bit color
 /// terminal escape codes. Meant for debugging and testing.
@@ -20,30 +20,26 @@ pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
     let mut s: String = String::new();
     for &(ref style, text) in v.iter() {
         if bg {
-            write!(s,
-                   "\x1b[48;2;{};{};{}m",
-                   style.background.r,
-                   style.background.g,
-                   style.background.b)
-                .unwrap();
-        }
-        write!(s,
-               "\x1b[38;2;{};{};{}m{}",
-               style.foreground.r,
-               style.foreground.g,
-               style.foreground.b,
-               text)
+            write!(
+                s,
+                "\x1b[48;2;{};{};{}m",
+                style.background.r, style.background.g, style.background.b
+            )
             .unwrap();
+        }
+        write!(
+            s,
+            "\x1b[38;2;{};{};{}m{}",
+            style.foreground.r, style.foreground.g, style.foreground.b, text
+        )
+        .unwrap();
     }
     // s.push_str("\x1b[0m");
     s
 }
 
-const LATEX_REPLACE: [(&'static str, &'static str); 3] = [
-    ("\\", "\\\\"),
-    ("{", "\\{"),
-    ("}", "\\}"),
-];
+const LATEX_REPLACE: [(&'static str, &'static str); 3] =
+    [("\\", "\\\\"), ("{", "\\{"), ("}", "\\}")];
 
 /// Formats the styled fragments using LaTeX textcolor directive.
 ///
@@ -93,11 +89,13 @@ pub fn as_latex_escaped(v: &[(Style, &str)]) -> String {
     let mut prev_style: Option<Style> = None;
     let mut content: String;
     fn textcolor(style: &Style, first: bool) -> String {
-        format!("{}\\textcolor[RGB]{{{},{},{}}}{{",
+        format!(
+            "{}\\textcolor[RGB]{{{},{},{}}}{{",
             if first { "" } else { "}" },
             style.foreground.r,
             style.foreground.b,
-            style.foreground.g)
+            style.foreground.g
+        )
     }
     for &(style, text) in v.iter() {
         if let Some(ps) = prev_style {
@@ -105,7 +103,7 @@ pub fn as_latex_escaped(v: &[(Style, &str)]) -> String {
                 " " => {
                     s.push(' ');
                     continue;
-                },
+                }
                 "\n" => continue,
                 _ => (),
             }
@@ -149,7 +147,6 @@ pub fn debug_print_ops(line: &str, ops: &[(usize, ScopeStackOp)]) {
     }
 }
 
-
 /// An iterator over the lines of a string, including the line endings.
 ///
 /// This is similar to the standard library's `lines` method on `str`, except
@@ -190,7 +187,8 @@ impl<'a> Iterator for LinesWithEndings<'a> {
         if self.input.is_empty() {
             return None;
         }
-        let split = self.input
+        let split = self
+            .input
             .find('\n')
             .map(|i| i + 1)
             .unwrap_or_else(|| self.input.len());
@@ -210,14 +208,18 @@ impl<'a> Iterator for LinesWithEndings<'a> {
 /// Generic for testing purposes and fancier use cases, but intended for use with
 /// the `Vec<(Style, &str)>` returned by `highlight` methods. Look at the source
 /// code for `modify_range` for an example usage.
-pub fn split_at<'a, A: Clone>(v: &[(A, &'a str)], split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
+pub fn split_at<'a, A: Clone>(
+    v: &[(A, &'a str)],
+    split_i: usize,
+) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
     // This function works by gradually reducing the problem into smaller sub-problems from the front
     let mut rest = v;
     let mut rest_split_i = split_i;
 
     // Consume all tokens before the split
     let mut before = Vec::new();
-    for tok in rest { // Use for instead of a while to avoid bounds checks
+    for tok in rest {
+        // Use for instead of a while to avoid bounds checks
         if tok.1.len() > rest_split_i {
             break;
         }
@@ -256,11 +258,15 @@ pub fn split_at<'a, A: Clone>(v: &[(A, &'a str)], split_i: usize) -> (Vec<(A, &'
 /// let l2 = modify_range(l, 1..6, boldmod);
 /// assert_eq!(l2, &[(plain, "a"), (bold, "bc"), (bold, "def"), (plain, "ghi")]);
 /// ```
-pub fn modify_range<'a>(v: &[(Style, &'a str)], r: Range<usize>, modifier: StyleModifier) -> Vec<(Style, &'a str)> {
+pub fn modify_range<'a>(
+    v: &[(Style, &'a str)],
+    r: Range<usize>,
+    modifier: StyleModifier,
+) -> Vec<(Style, &'a str)> {
     let (mut result, in_and_after) = split_at(v, r.start);
     let (inside, mut after) = split_at(&in_and_after, r.end - r.start);
 
-    result.extend(inside.iter().map(|(style, s)| { (style.apply(modifier), *s)}));
+    result.extend(inside.iter().map(|(style, s)| (style.apply(modifier), *s)));
     result.append(&mut after);
     result
 }
@@ -291,23 +297,41 @@ mod tests {
     fn test_split_at() {
         let l: &[(u8, &str)] = &[];
         let (before, after) = split_at(l, 0); // empty
-        assert_eq!((&before[..], &after[..]), (&[][..],&[][..]));
+        assert_eq!((&before[..], &after[..]), (&[][..], &[][..]));
 
         let l = &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")];
 
         let (before, after) = split_at(l, 0); // at start
-        assert_eq!((&before[..], &after[..]), (&[][..],&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..]));
+        assert_eq!(
+            (&before[..], &after[..]),
+            (&[][..], &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..])
+        );
 
         let (before, after) = split_at(l, 4); // inside token
-        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "d")][..],&[(1u8, "ef"), (2u8, "ghi")][..]));
+        assert_eq!(
+            (&before[..], &after[..]),
+            (
+                &[(0u8, "abc"), (1u8, "d")][..],
+                &[(1u8, "ef"), (2u8, "ghi")][..]
+            )
+        );
 
         let (before, after) = split_at(l, 3); // between tokens
-        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc")][..],&[(1u8, "def"), (2u8, "ghi")][..]));
+        assert_eq!(
+            (&before[..], &after[..]),
+            (&[(0u8, "abc")][..], &[(1u8, "def"), (2u8, "ghi")][..])
+        );
 
         let (before, after) = split_at(l, 9); // just after last token
-        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
+        assert_eq!(
+            (&before[..], &after[..]),
+            (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..])
+        );
 
         let (before, after) = split_at(l, 10); // out of bounds
-        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
+        assert_eq!(
+            (&before[..], &after[..]),
+            (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..])
+        );
     }
 }


### PR DESCRIPTION
There's a lot here.

This mostly just started because I was interested in forking `syntect` for a more specialized application, and I decided that my first task was to update all of the docs so that they were easy to navigate - primarily adding links for all referenced types and functions, but also including certain opinionated stylization of doc comments.

The `rustfmt` happened because my editor typically runs it whenever a file is saved. Because it was changing many of the files I worked on, I just ran `cargo fmt` to make sure everything was formatted equally.

---

Feel free to not include this - there's a bunch of changes here and they aren't strictly speaking necessary. But I've found the docs I updated to be useful, just through a first look with
```
cargo doc --open
```

---

Update: I've done a little rewriting of history so now there's only two clear commits; the first is for running `cargo fmt` - that's all that is. The second is that visible changes I've discussed above.