### PR TITLE
Fix handling of newlines in classed HTML

### DIFF
--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -13,6 +13,8 @@ use syntect::highlighting::ThemeSet;
 use syntect::html::css_for_theme_with_class_style;
 use syntect::html::{ClassedHTMLGenerator, ClassStyle};
 use syntect::parsing::SyntaxSet;
+use syntect::util::LinesWithEndings;
+
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -43,8 +45,8 @@ fn main() {
 
     let sr_rs = ss.find_syntax_by_extension("rs").unwrap();
     let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_rs, &ss, ClassStyle::Spaced);
-    for line in code_rs.lines() {
-        rs_html_generator.parse_html_for_line(&line);
+    for line in LinesWithEndings::from(code_rs) {
+        rs_html_generator.parse_html_for_line_which_includes_newline(&line);
     }
     let html_rs = rs_html_generator.finalize();
 
@@ -61,8 +63,8 @@ int main() {
 
     let sr_cpp = ss.find_syntax_by_extension("cpp").unwrap();
     let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_cpp, &ss, ClassStyle::Spaced);
-    for line in code_cpp.lines() {
-        cpp_html_generator.parse_html_for_line(&line);
+    for line in LinesWithEndings::from(code_cpp) {
+        cpp_html_generator.parse_html_for_line_which_includes_newline(&line);
     }
     let html_cpp = cpp_html_generator.finalize();
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -37,7 +37,7 @@ use std::path::Path;
 /// x + y
 /// "#;
 ///
-/// let syntax_set = SyntaxSet::load_defaults_nonewlines();
+/// let syntax_set = SyntaxSet::load_defaults_newlines();
 /// let syntax = syntax_set.find_syntax_by_name("R").unwrap();
 /// let mut html_generator = ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
 /// for line in LinesWithEndings::from(current_code) {


### PR DESCRIPTION
The examples used the `_newlines` syntax without providing newlines,
leading to occasional broken highlighting (#303). The function for producing
classed HTML added newlines for you so I deprecated that one and
added a new one which doesn't, so that I could change the examples to
use the `_newlines` variant in the proper way.

cc @mitnk @uwearzt @quasicomputational 