### PR TITLE
Export the HTML escape helper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod dumps;
 #[cfg(feature = "parsing")]
 pub mod easy;
 #[cfg(feature = "html")]
-mod escape;
+pub mod escape;
 pub mod highlighting;
 #[cfg(feature = "html")]
 pub mod html;


### PR DESCRIPTION
When building custom HTML structure, this helper is useful to have
exported. Most of the remaining functions for building custom
CSS-classed HTML are already exported.

Feel free to close if you don't want this as part of the external interface. 
It's not terribly difficult to copy or reimplement, but I figured it'd be nice
if I can use the same escaping logic that's used internally. 

Closes #330 