### PR TITLE
Improve find_unlinked_contexts output to make it easier to find the "culprit"

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -384,36 +384,35 @@ impl SyntaxSet {
                     builder_contexts.insert(context_name, context);
 
                     for pattern in context.patterns.iter() {
-                        match pattern {
+                        let maybe_refs_to_check = match pattern {
                             Pattern::Match(match_pat) => {
-                                let mut maybe_refs_to_check = None;
                                 match &match_pat.operation {
                                     MatchOperation::Push(context_refs) => {
-                                        maybe_refs_to_check = Some(context_refs);
+                                        Some(context_refs)
                                     },
                                     MatchOperation::Set(context_refs) => {
-                                        maybe_refs_to_check = Some(context_refs);
+                                        Some(context_refs)
                                     },
-                                    _ => {},
-                                }
-
-                                if let Some(refs_to_check) = maybe_refs_to_check {
-                                    for context_ref in refs_to_check {
-                                        match context_ref {
-                                            ContextReference::Direct(_) => {},
-                                            _ => {
-                                                unlinked_contexts.insert(
-                                                    format!(
-                                                        "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
-                                                        name, scope, &context_ref
-                                                    )
-                                                );
-                                            },
-                                        }
-                                    }
+                                    _ => None,
                                 }
                             },
-                            _ => {},
+                            _ => None,
+                        };
+
+                        if let Some(refs_to_check) = maybe_refs_to_check {
+                            for context_ref in refs_to_check {
+                                match context_ref {
+                                    ContextReference::Direct(_) => {},
+                                    _ => {
+                                        unlinked_contexts.insert(
+                                            format!(
+                                                "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
+                                                name, scope, &context_ref
+                                            )
+                                        );
+                                    },
+                                }
+                            }
                         }
                     }
                 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -7,7 +7,7 @@ use super::metadata::{LoadMetadata, Metadata, RawMetadataEntry};
 #[cfg(feature = "yaml-load")]
 use super::super::LoadingError;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, BTreeSet};
 use std::path::Path;
 #[cfg(feature = "yaml-load")]
 use walkdir::WalkDir;
@@ -360,7 +360,7 @@ impl SyntaxSet {
         }
     }
 
-    pub fn find_unlinked_contexts(&self) -> HashSet<String> {
+    pub fn find_unlinked_contexts(&self) -> BTreeSet<String> {
         let SyntaxSet { syntaxes, contexts, .. } = self;
 
         let mut context_map = HashMap::with_capacity(contexts.len());
@@ -368,7 +368,7 @@ impl SyntaxSet {
             context_map.insert(i, context);
         }
 
-        let mut unlinked_contexts = HashSet::new();
+        let mut unlinked_contexts = BTreeSet::new();
 
         for syntax in syntaxes {
             let SyntaxReference {

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -360,7 +360,7 @@ impl SyntaxSet {
         }
     }
 
-    pub fn find_unlinked_contexts(&self) -> Vec<String> {
+    pub fn find_unlinked_contexts(&self) -> HashSet<String> {
         let SyntaxSet { syntaxes, contexts, .. } = self;
 
         let mut context_map = HashMap::with_capacity(contexts.len());
@@ -368,7 +368,7 @@ impl SyntaxSet {
             context_map.insert(i, context);
         }
 
-        let mut unlinked_contexts = Vec::new();
+        let mut unlinked_contexts = HashSet::new();
 
         for syntax in syntaxes {
             let SyntaxReference {
@@ -402,7 +402,7 @@ impl SyntaxSet {
                                         match context_ref {
                                             ContextReference::Direct(_) => {},
                                             _ => {
-                                                unlinked_contexts.push(
+                                                unlinked_contexts.insert(
                                                     format!(
                                                         "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
                                                         name, scope, &context_ref
@@ -909,7 +909,7 @@ mod tests {
             builder.build()
         };
 
-        let unlinked_contexts = syntax_set.find_unlinked_contexts();
+        let unlinked_contexts : Vec<String> = syntax_set.find_unlinked_contexts().into_iter().collect();
         assert_eq!(unlinked_contexts.len(), 1);
         assert_eq!(unlinked_contexts[0], "Syntax 'A' with scope 'source.a' has unresolved context reference ByScope { scope: <source.b>, sub_context: Some(\"main\") }");
     }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -378,7 +378,7 @@ impl SyntaxSet {
                 ..
             } = syntax;
 
-            for (context_name, context_id) in contexts {
+            for (_, context_id) in contexts {
                 if let Some(context) = context_map.remove(&context_id.index()) {
                     for pattern in context.patterns.iter() {
                         let maybe_refs_to_check = match pattern {
@@ -402,8 +402,8 @@ impl SyntaxSet {
                                 _ => {
                                     unlinked_contexts.insert(
                                         format!(
-                                            "Syntax '{}' with scope '{}' has unresolved context reference {:?} from context '{}'",
-                                            name, scope, &context_ref, context_name
+                                            "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
+                                            name, scope, &context_ref
                                         )
                                     );
                                 },
@@ -905,7 +905,7 @@ mod tests {
 
         let unlinked_contexts : Vec<String> = syntax_set.find_unlinked_contexts().into_iter().collect();
         assert_eq!(unlinked_contexts.len(), 1);
-        assert_eq!(unlinked_contexts[0], "Syntax 'A' with scope 'source.a' has unresolved context reference ByScope { scope: <source.b>, sub_context: Some(\"main\") } from context 'main'");
+        assert_eq!(unlinked_contexts[0], "Syntax 'A' with scope 'source.a' has unresolved context reference ByScope { scope: <source.b>, sub_context: Some(\"main\") }");
     }
 
     #[test]


### PR DESCRIPTION
Improve the output of the `find_unlinked_contexts` method to include the syntax name and scope from where the unlinked context reference originated, and deduplicate the results. I've changed it to return a HashSet instead of a Vec - this method has never been in a release so it shouldn't matter. But if you think keeping the Vec return type makes sense then we can change it back again :)