### PR TITLE
SyntaxReference: Add some docs

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -48,6 +48,9 @@ pub struct SyntaxSet {
     pub(crate) metadata: Metadata,
 }
 
+/// A linked version of a [`SyntaxDefinition`] that is only useful as part of the
+/// [`SyntaxSet`] that contains it. See docs for [`SyntaxSetBuilder::build`] for
+/// more info.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SyntaxReference {
     pub name: String,


### PR DESCRIPTION
Hi and thanks for a great project!

I'm in the process of exploring the inner workings of syntect. Here is a PR that adds some docs to `SyntaxReference` that would have sped up my learning process. Hopefully someone that comes after me will find it helpful.