### PR TITLE
SyntaxSetBuilder: Allow to list added syntaxes via a syntaxes() method

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -407,6 +407,11 @@ impl SyntaxSetBuilder {
         self.syntaxes.push(syntax);
     }
 
+    /// The list of syntaxes added so far.
+    pub fn syntaxes(&self) -> &[SyntaxDefinition] {
+        &self.syntaxes[..]
+    }
+
     /// A rarely useful method that loads in a syntax with no highlighting rules for plain text
     ///
     /// Exists mainly for adding the plain text syntax to syntax set dumps, because for some reason
@@ -828,6 +833,18 @@ mod tests {
         let ops = parse_state.parse_line("a go_b b", &cloned_syntax_set);
         let expected = (7, ScopeStackOp::Push(Scope::new("b").unwrap()));
         assert_ops_contain(&ops, &expected);
+    }
+
+    #[test]
+    fn can_list_added_syntaxes() {
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(syntax_a());
+        builder.add(syntax_b());
+        let syntaxes = builder.syntaxes();
+
+        assert_eq!(syntaxes.len(), 2);
+        assert_eq!(syntaxes[0].name, "A");
+        assert_eq!(syntaxes[1].name, "B");
     }
 
     #[test]


### PR DESCRIPTION
This is analogous to the existing public `SyntaxSet::syntaxes()` method.

### Background information

I am doing some prototyping around ways to improve the startup time of bat (see https://github.com/sharkdp/bat/issues/951). And the way to improve startup time is to only load the syntaxes needed for the given input file(s). Instead of having one giant `SyntaxSet`, we need several smaller ones.

The added method enables clients such as bat to analyze dependencies between `SyntaxDefinition`s and build up many smaller, self-contained `SyntaxSet`s.

An alternative to this PR could be to move out `SyntaxSetBuilder::add_from_folder()` to some place where the logic can live and be used independently, i.e. without taking a detour through a `SyntaxSetBuilder`. That however seems to like a significantly higher hanging fruit at this point.