### PR TITLE
Fix all non_fmt_panic compilation warnings

### DIFF
--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -39,7 +39,7 @@ fn main() {
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m }
-        Err(f) => { panic!(f.to_string()) }
+        Err(f) => { panic!("{}", f.to_string()) }
     };
 
     let no_newlines = matches.opt_present("no-newlines");

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -274,7 +274,7 @@ fn main() {
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => { m }
-        Err(f) => { panic!(f.to_string()) }
+        Err(f) => { panic!("{}", f.to_string()) }
     };
 
     let tests_path = if matches.free.len() < 1 {


### PR DESCRIPTION
They look like this:

    warning: panic message is not a string literal
    --> examples/syntest.rs:277:28
        |
    277 |         Err(f) => { panic!(f.to_string()) }
        |                            ^^^^^^^^^^^^^
        |
        = note: `#[warn(non_fmt_panic)]` on by default
        = note: this is no longer accepted in Rust 2021
    help: add a "{}" format string to Display the message
        |
    277 |         Err(f) => { panic!("{}", f.to_string()) }
        |                            ^^^^^
    help: or use std::panic::panic_any instead
        |
    277 |         Err(f) => { std::panic::panic_any(f.to_string()) }
        |                     ^^^^^^^^^^^^^^^^^^^^^