### PR TITLE
CI: Add job to ensure MSRV compatibility, currently 1.42

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,9 +8,22 @@ on:
     branches: [ master ]
 
 env:
+  MIN_SUPPORTED_RUST_VERSION: "1.42"
   CARGO_TERM_COLOR: always
 
 jobs:
+  min_version:
+    name: Minimum supported rust version
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
+        default: true
+    - run: |
+        cargo check --verbose --all-features --all-targets
+
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a job to CI to ensure compatibility with current min supported rust version. This project currently works with Rust 1.42, but fails with Rust 1.41 with `cargo check --all-features --all-targets`.

For just `cargo check --all-features`, Rust 1.40 is enough, but doesn't hurt to use Rust 1.42 I think. Rust 1.42 is well over a year old by now.

To keep the job quick, I'm just doing a `cargo check`. A `cargo test` takes significantly longer time, and we already run `cargo test` in various configurations in the other job. It should be safe to assume that if the project code compiles with MSRV, the tests will also pass (if they pass in the main job).