### PR TITLE
Lock bitflags at ~1.2 to keep MSRV at 1.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"
-bitflags = "1.0.4"
+bitflags = "~1.2"
 plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }


### PR DESCRIPTION
Timeline:
* 9 days ago: The MSRV CI job in [my PR](https://github.com/trishume/syntect/pull/346) was green
* 7 days ago: bitflags 1.3.0 was released, which included [this commit](https://github.com/bitflags/bitflags/pull/229) which bumps MSRV of bitflags to 1.46
* 0 days ago: Merged MSRV CI job failed on master due to building with latest bitflags

Solution: Lock bitflags to be compatible with our current MSRV of 1.42.