### PR TITLE
Fix all clippy::assertions-on-constants warnings

### DIFF
--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -99,6 +99,6 @@ mod tests {
                        b: 0xce,
                        a: 0xFF,
                    });
-        // assert!(false);
+        // unreachable!();
     }
 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -834,7 +834,7 @@ mod tests {
                    "Rust");
         // println!("{:#?}", syntax);
         assert_eq!(syntax.scope, rails_scope);
-        // assert!(false);
+        // unreachable!();
         let main_context = ps.get_context(&syntax.contexts["main"]);
         let count = syntax_definition::context_iter(&ps, main_context).count();
         assert_eq!(count, 109);

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -914,7 +914,7 @@ mod tests {
 
         let n: Vec<Scope> = Vec::new();
         println!("{:?}", defn2);
-        // assert!(false);
+        // unreachable!();
         let main = &defn2.contexts["main"];
         assert_eq!(main.meta_content_scope, vec![top_level_scope]);
         assert_eq!(main.meta_scope, n);
@@ -950,7 +950,7 @@ mod tests {
 
                 assert!(match_pat.with_prototype.is_some());
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 
@@ -1013,7 +1013,7 @@ mod tests {
         assert!(def.is_err());
         match def.unwrap_err() {
             ParseSyntaxError::MissingMandatoryKey(key) => assert_eq!(key, "escape"),
-            _ => assert!(false, "Got unexpected ParseSyntaxError"),
+            _ => unreachable!("Got unexpected ParseSyntaxError"),
         }
     }
 
@@ -1031,7 +1031,7 @@ mod tests {
         assert!(def.is_err());
         match def.unwrap_err() {
             ParseSyntaxError::RegexCompileError(ref regex, _) => assert_eq!("[a", regex),
-            _ => assert!(false, "Got unexpected ParseSyntaxError"),
+            _ => unreachable!("Got unexpected ParseSyntaxError"),
         }
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
 
                 assert!(match_pat.with_prototype.is_none());
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
     }
 


### PR DESCRIPTION
This PR fixes these lints:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated -D clippy::assertions_on_constants
    Checking syntect v4.6.0 (/home/martin/src/syntect)
error: `assert!(false)` should probably be replaced
   --> src/parsing/yaml_load.rs:953:18
    |
953 |             _ => assert!(false),
    |                  ^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-D clippy::assertions-on-constants`
    = help: use `panic!()` or `unreachable!()`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

error: `assert!(false, "Got unexpected ParseSyntaxError")` should probably be replaced
    --> src/parsing/yaml_load.rs:1016:18
     |
1016 |             _ => assert!(false, "Got unexpected ParseSyntaxError"),
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: use `panic!("Got unexpected ParseSyntaxError")` or `unreachable!("Got unexpected ParseSyntaxError")`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
     = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

error: `assert!(false, "Got unexpected ParseSyntaxError")` should probably be replaced
    --> src/parsing/yaml_load.rs:1034:18
     |
1034 |             _ => assert!(false, "Got unexpected ParseSyntaxError"),
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: use `panic!("Got unexpected ParseSyntaxError")` or `unreachable!("Got unexpected ParseSyntaxError")`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
     = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

error: `assert!(false)` should probably be replaced
    --> src/parsing/yaml_load.rs:1082:18
     |
1082 |             _ => assert!(false),
     |                  ^^^^^^^^^^^^^^
     |
     = help: use `panic!()` or `unreachable!()`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
     = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 4 previous errors

error: could not compile `syntect`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
