### PR TITLE
src/parsing/parser.rs: Silence false positive clippy::mutable_key_type

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,3 +1,15 @@
+// Suppression of a false positive clippy lint. Upstream issue:
+//
+//   mutable_key_type false positive for raw pointers
+//   https://github.com/rust-lang/rust-clippy/issues/6745
+//
+// We use `*const MatchPattern` as key in our `SearchCache` hash map.
+// Clippy thinks this is a problem since `MatchPattern` has interior mutability
+// via `MatchPattern::regex::regex` which is an `AtomicLazyCell`.
+// But raw pointers are hashed via the pointer itself, not what is pointed to.
+// See https://github.com/rust-lang/rust/blob/1.54.0/library/core/src/hash/mod.rs#L717-L725
+#![allow(clippy::mutable_key_type)]
+
 use super::syntax_definition::*;
 use super::scope::*;
 use super::regex::Region;


### PR DESCRIPTION
I added the details in a comment, which I am also duplicating here for convenience:
```
// Suppression of a false positive clippy lint. Upstream issue:
//
//   mutable_key_type false positive for raw pointers
//   https://github.com/rust-lang/rust-clippy/issues/6745
//
// We use `*const MatchPattern` as key in our `SearchCache` hash map.
// Clippy thinks this is a problem since `MatchPattern` has interior mutability
// via `MatchPattern::regex::regex` which is an `AtomicLazyCell`.
// But raw pointers are hashed via the pointer itself, not what is pointed to.
// See https://github.com/rust-lang/rust/blob/1.54.0/library/core/src/hash/mod.rs#L717-L725
#![allow(clippy::mutable_key_type)]
```

The lint looks like this:

```
% cargo clippy --all-features -- --allow clippy::all --allow deprecated --deny clippy::mutable_key_type
    Checking syntect v4.6.0 (/home/martin/src/syntect)
error: mutable key type
   --> src/parsing/parser.rs:202:9
    |
202 |         let mut search_cache: SearchCache = HashMap::with_capacity_and_hasher(128, fnv);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-D clippy::mutable-key-type`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type

error: mutable key type
   --> src/parsing/parser.rs:224:23
    |
224 |         search_cache: &mut SearchCache,
    |                       ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type

error: mutable key type
   --> src/parsing/parser.rs:306:23
    |
306 |         search_cache: &mut SearchCache,
    |                       ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type

error: mutable key type
   --> src/parsing/parser.rs:386:29
    |
386 |               search_cache: &mut SearchCache,
    |                             ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type

error: aborting due to 4 previous errors

error: could not compile `syntect`

To learn more, run the command again with --verbose.
```