### PR TITLE
Fix all clippy::new-without-default lints

### DIFF
--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -128,6 +128,12 @@ impl Region {
     }
 }
 
+impl Default for Region {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(feature = "regex-onig")]
 mod regex_impl {
     pub use onig::Region;


### PR DESCRIPTION
Thee is just one warning for `Region`.

The warning looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --deny clippy::new_without_default
    Checking syntect v4.6.0 (/home/martin/src/syntect)
error: you should consider adding a `Default` implementation for `parsing::regex::Region`
   --> src/parsing/regex.rs:116:5
    |
116 | /     pub fn new() -> Self {
117 | |         Self {
118 | |             region: regex_impl::new_region(),
119 | |         }
120 | |     }
    | |_____^
    |
    = note: requested on the command line with `-D clippy::new-without-default`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
    |
115 | impl Default for parsing::regex::Region {
116 |     fn default() -> Self {
117 |         Self::new()
118 |     }
119 | }
    |

```