### PR TITLE
Fix all clippy::map-clone warnings

### DIFF
--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -787,7 +787,7 @@ impl<'a> Parser<'a> {
     }
 
     fn peek(&self) -> Option<u8> {
-        self.bytes.get(self.index).map(|&b| b)
+        self.bytes.get(self.index).copied()
     }
 
     fn next(&mut self) {


### PR DESCRIPTION
This change will feel safe once you see the implementation of `.copied()`, which looks like this:

```
impl<T: Copy> Option<&T> {
    /// ...
    #[stable(feature = "copied", since = "1.35.0")]
    pub fn copied(self) -> Option<T> {
        self.map(|&t| t)
    }
}
```

The lint warning looks like this:
```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --deny clippy::map_clone      
    Checking syntect v4.6.0 (/home/martin/src/syntect)
error: you are using an explicit closure for copying elements
   --> src/parsing/yaml_load.rs:790:9
    |
790 |         self.bytes.get(self.index).map(|&b| b)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `self.bytes.get(self.index).copied()`
    |
    = note: requested on the command line with `-D clippy::map-clone`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
```