### PR TITLE
Use matches!-macro where clippy says we can

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -353,10 +353,9 @@ impl ParseState {
                         min_start = match_start;
 
                         let consuming = match_end > start;
-                        pop_would_loop = check_pop_loop && !consuming && match match_pat.operation {
-                            MatchOperation::Pop => true,
-                            _ => false,
-                        };
+                        pop_would_loop = check_pop_loop
+                            && !consuming
+                            && matches!(match_pat.operation, MatchOperation::Pop);
 
                         best_match = Some(RegexMatch {
                             regions: match_region,
@@ -521,10 +520,7 @@ impl ParseState {
             // - the interaction with meta scopes means that the token has the meta scopes of both the current scope and the new scope.
             MatchOperation::Push(ref context_refs) |
             MatchOperation::Set(ref context_refs) => {
-                let is_set = match *match_op {
-                    MatchOperation::Set(_) => true,
-                    _ => false
-                };
+                let is_set = matches!(*match_op, MatchOperation::Set(_));
                 // a match pattern that "set"s keeps the meta_content_scope and meta_scope from the previous context
                 if initial {
                     if is_set && cur_context.clear_scopes != None {

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -181,11 +181,7 @@ mod regex_impl {
             // If there's an error during search, treat it as non-matching.
             // For example, in case of catastrophic backtracking, onig should
             // fail with a "retry-limit-in-match over" error eventually.
-            if let Ok(Some(_)) = matched {
-                true
-            } else {
-                false
-            }
+            matches!(matched, Ok(Some(_)))
         }
     }
 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -607,11 +607,7 @@ impl SyntaxSetBuilder {
             for context_index in 0..all_contexts.len() {
                 let context = &all_contexts[context_index];
                 if !context.uses_backrefs && context.patterns.iter().any(|pattern| {
-                    match pattern {
-                        Pattern::Include(ContextReference::Direct(id))
-                            if all_contexts[id.index()].uses_backrefs => true,
-                        _ => false,
-                    }
+                    matches!(pattern, Pattern::Include(ContextReference::Direct(id)) if all_contexts[id.index()].uses_backrefs)
                 }) {
                     let mut context = &mut all_contexts[context_index];
                     context.uses_backrefs = true;


### PR DESCRIPTION
Use the exact code that clippy suggests, plus `cargo fmt` the new code.

The lints warnings look like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --deny clippy::match_like_matches_macro             
    Checking syntect v4.6.0 (/home/martin/src/syntect)
error: match expression looks like `matches!` macro
   --> src/parsing/parser.rs:356:74
    |
356 |                           pop_would_loop = check_pop_loop && !consuming && match match_pat.operation {
    |  __________________________________________________________________________^
357 | |                             MatchOperation::Pop => true,
358 | |                             _ => false,
359 | |                         };
    | |_________________________^ help: try this: `matches!(match_pat.operation, MatchOperation::Pop)`
    |
    = note: requested on the command line with `-D clippy::match-like-matches-macro`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

error: match expression looks like `matches!` macro
   --> src/parsing/parser.rs:524:30
    |
524 |                   let is_set = match *match_op {
    |  ______________________________^
525 | |                     MatchOperation::Set(_) => true,
526 | |                     _ => false
527 | |                 };
    | |_________________^ help: try this: `matches!(*match_op, MatchOperation::Set(_))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

error: match expression looks like `matches!` macro
   --> src/parsing/syntax_set.rs:610:21
    |
610 | /                     match pattern {
611 | |                         Pattern::Include(ContextReference::Direct(id))
612 | |                             if all_contexts[id.index()].uses_backrefs => true,
613 | |                         _ => false,
614 | |                     }
    | |_____________________^ help: try this: `matches!(pattern, Pattern::Include(ContextReference::Direct(id)) if all_contexts[id.index()].uses_backrefs)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

error: if let .. else expression looks like `matches!` macro
   --> src/parsing/regex.rs:184:13
    |
184 | /             if let Ok(Some(_)) = matched {
185 | |                 true
186 | |             } else {
187 | |                 false
188 | |             }
    | |_____________^ help: try this: `matches!(matched, Ok(Some(_)))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
```