### PR TITLE
Silence 2 clippy warnings that we can live with

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -216,6 +216,7 @@ impl ParseState {
         res
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn parse_next_token(
         &mut self,
         line: &str,

--- a/src/util.rs
+++ b/src/util.rs
@@ -215,6 +215,7 @@ impl<'a> Iterator for LinesWithEndings<'a> {
 /// Generic for testing purposes and fancier use cases, but intended for use with
 /// the `Vec<(Style, &str)>` returned by `highlight` methods. Look at the source
 /// code for `modify_range` for an example usage.
+#[allow(clippy::type_complexity)]
 pub fn split_at<'a, A: Clone>(v: &[(A, &'a str)], split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
     // This function works by gradually reducing the problem into smaller sub-problems from the front
     let mut rest = v;


### PR DESCRIPTION
The effort to fix these warnings does not seem warranted.

The warnings look like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::too_many_arguments --warn clippy::type_complexity
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: this function has too many arguments (8/7)
   --> src/parsing/parser.rs:219:5
    |
219 | /     fn parse_next_token(
220 | |         &mut self,
221 | |         line: &str,
222 | |         syntax_set: &SyntaxSet,
...   |
227 | |         ops: &mut Vec<(usize, ScopeStackOp)>,
228 | |     ) -> bool {
    | |_____________^
    |
    = note: requested on the command line with `-W clippy::too-many-arguments`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: very complex type used. Consider factoring parts into `type` definitions
   --> src/util.rs:218:70
    |
218 | pub fn split_at<'a, A: Clone>(v: &[(A, &'a str)], split_i: usize) -> (Vec<(A, &'a str)>, Vec<(A, &'a str)>) {
    |                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-W clippy::type-complexity`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity

```