### PR TITLE
Fix all clippy::needless_question_mark warnings

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -95,13 +95,12 @@ fn load_syntax_file(p: &Path,
     let mut s = String::new();
     f.read_to_string(&mut s)?;
 
-    Ok(
-        SyntaxDefinition::load_from_str(
-            &s,
-            lines_include_newline,
-            p.file_stem().and_then(|x| x.to_str())
-        ).map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))?
+    SyntaxDefinition::load_from_str(
+        &s,
+        lines_include_newline,
+        p.file_stem().and_then(|x| x.to_str()),
     )
+    .map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))
 }
 
 impl Clone for SyntaxSet {


### PR DESCRIPTION
We only have one occurrence. It's this one:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::needless_question_mark
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: question mark operator is useless here
   --> src/parsing/syntax_set.rs:98:5
    |
98  | /     Ok(
99  | |         SyntaxDefinition::load_from_str(
100 | |             &s,
101 | |             lines_include_newline,
102 | |             p.file_stem().and_then(|x| x.to_str())
103 | |         ).map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))?
104 | |     )
    | |_____^
    |
    = note: requested on the command line with `-W clippy::needless-question-mark`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
help: try
    |
98  |     SyntaxDefinition::load_from_str(
99  |             &s,
100 |             lines_include_newline,
101 |             p.file_stem().and_then(|x| x.to_str())
102 |         ).map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))
    |

```