### PR TITLE
Fix all clippy::option-as-ref-deref warnings

### DIFF
--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -346,7 +346,7 @@ impl<'a> ScopedMetadata<'a> {
 
     pub fn line_comment(&self) -> Option<&str> {
         let idx = self.items.iter().position(|m| m.1.items.line_comment.is_some())?;
-        self.items[idx].1.items.line_comment.as_ref().map(|s| s.as_str())
+        self.items[idx].1.items.line_comment.as_deref()
     }
 
     pub fn block_comment(&self) -> Option<(&str, &str)> {


### PR DESCRIPTION
We currently just have one of these lint warnings.

`line_comment` is of type `Option<String>` and we want an `Option<&str>`.
We currently convert first to `Option<&String>` and then `map` to `.as_str()`.
But since `String` implements `Deref` like this:

    impl ops::Deref for String {
        type Target = str;

        #[inline]
        fn deref(&self) -> &str {
            unsafe { str::from_utf8_unchecked(&self.vec) }
        }
    }

we can simplify to just use `.as_deref()`, as recommended by clippy.

Here is what the lint warning looks like:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::option_as_ref_deref              
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: called `.as_ref().map(|s| s.as_str())` on an Option value. This can be done more directly by calling `self.items[idx].1.items.line_comment.as_deref()` instead
   --> src/parsing/metadata.rs:349:9
    |
349 |         self.items[idx].1.items.line_comment.as_ref().map(|s| s.as_str())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using as_deref instead: `self.items[idx].1.items.line_comment.as_deref()`
    |
    = note: requested on the command line with `-W clippy::option-as-ref-deref`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref
```