### PR TITLE
Fix all clippy::wildcard_in_or_patterns warnings

### DIFF
--- a/src/highlighting/theme_load.rs
+++ b/src/highlighting/theme_load.rs
@@ -262,9 +262,7 @@ impl ParseSettings for ThemeSettings {
                 "activeGuide" => settings.active_guide = Color::parse_settings(value).ok(),
                 "stackGuide" => settings.stack_guide = Color::parse_settings(value).ok(),
                 "shadow" => settings.shadow = Color::parse_settings(value).ok(),
-                "shadowWidth"| // ignored
-                "invisibles" | // ignored
-                _ => (),
+                _ => (), // E.g. "shadowWidth" and "invisibles" are ignored
             }
         }
         Ok(settings)


### PR DESCRIPTION
The lint warning looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::wildcard_in_or_patterns                    
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: wildcard pattern covers any other pattern as it will match anyway
   --> src/highlighting/theme_load.rs:265:17
    |
265 | /                 "shadowWidth"| // ignored
266 | |                 "invisibles" | // ignored
267 | |                 _ => (),
    | |_________________^
    |
    = note: requested on the command line with `-W clippy::wildcard-in-or-patterns`
    = help: consider handling `_` separately
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_in_or_patterns
```