### PR TITLE
Fix all clippy::len-zero warnings

### DIFF
--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -73,7 +73,7 @@ fn main() {
             println!("- {}", t);
         }
 
-    } else if matches.free.len() == 0 {
+    } else if matches.free.is_empty() {
         let brief = format!("USAGE: {} [options] FILES", args[0]);
         println!("{}", opts.usage(&brief));
 

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -277,7 +277,7 @@ fn main() {
         Err(f) => { panic!("{}", f.to_string()) }
     };
 
-    let tests_path = if matches.free.len() < 1 {
+    let tests_path = if matches.free.is_empty() {
         "."
     } else {
         &args[1]


### PR DESCRIPTION
The warnings look like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::len_zero
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: length comparison to zero
  --> examples/syncat.rs:76:15
   |
76 |     } else if matches.free.len() == 0 {
   |               ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `matches.free.is_empty()`
   |
   = note: requested on the command line with `-W clippy::len-zero`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: 1 warning emitted

warning: length comparison to one
   --> examples/syntest.rs:280:25
    |
280 |     let tests_path = if matches.free.len() < 1 {
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `matches.free.is_empty()`
    |
    = note: requested on the command line with `-W clippy::len-zero`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 8.59s
```