### PR TITLE
examples and tests: Make some "obviously correct" low-risk lint fixes

### DIFF
--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -8,7 +8,7 @@ use syntect::util::as_24_bit_terminal_escaped;
 use syntect::easy::HighlightFile;
 use syntect::dumps::{from_dump_file, dump_to_file};
 
-fn load_theme(tm_file: &String, enable_caching: bool) -> Theme {
+fn load_theme(tm_file: &str, enable_caching: bool) -> Theme {
     let tm_path = Path::new(tm_file);
 
     if enable_caching {
@@ -79,7 +79,7 @@ fn main() {
 
     } else {
         let theme_file : String = matches.opt_str("theme-file")
-            .unwrap_or("base16-ocean.dark".to_string());
+            .unwrap_or_else(|| "base16-ocean.dark".to_string());
 
         let theme = ts.themes.get(&theme_file)
             .map(|t| Cow::Borrowed(t))
@@ -98,7 +98,7 @@ fn main() {
             // It also allows re-using the line buffer, which should be a tiny bit faster.
             let mut line = String::new();
             while highlighter.reader.read_line(&mut line).unwrap() > 0 {
-                if no_newlines && line.ends_with("\n") {
+                if no_newlines && line.ends_with('\n') {
                     let _ = line.pop();
                 }
 
@@ -109,7 +109,7 @@ fn main() {
                 line.clear();
 
                 if no_newlines {
-                    println!("");
+                    println!();
                 }
             }
 

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -44,9 +44,9 @@ fn main() {
 }";
 
     let sr_rs = ss.find_syntax_by_extension("rs").unwrap();
-    let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_rs, &ss, ClassStyle::Spaced);
+    let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_rs, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_rs) {
-        rs_html_generator.parse_html_for_line_which_includes_newline(&line);
+        rs_html_generator.parse_html_for_line_which_includes_newline(line);
     }
     let html_rs = rs_html_generator.finalize();
 
@@ -62,9 +62,9 @@ int main() {
 }";
 
     let sr_cpp = ss.find_syntax_by_extension("cpp").unwrap();
-    let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(&sr_cpp, &ss, ClassStyle::Spaced);
+    let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_cpp, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_cpp) {
-        cpp_html_generator.parse_html_for_line_which_includes_newline(&line);
+        cpp_html_generator.parse_html_for_line_which_includes_newline(line);
     }
     let html_cpp = cpp_html_generator.finalize();
 

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -52,19 +52,19 @@ struct Stats {
 }
 
 fn print_stats(stats: &Stats) {
-    println!("");
+    println!();
     println!("################## Stats ###################");
     println!("File count:                           {:>6}", stats.files);
     println!("Total characters:                     {:>6}", stats.chars);
-    println!("");
+    println!();
     println!("Function count:                       {:>6}", stats.functions);
     println!("Type count (structs, enums, classes): {:>6}", stats.types);
-    println!("");
+    println!();
     println!("Code lines (traditional SLOC):        {:>6}", stats.code_lines);
     println!("Total lines (w/ comments & blanks):   {:>6}", stats.lines);
     println!("Comment lines (comment but no code):  {:>6}", stats.comment_lines);
     println!("Blank lines (lines-blank-comment):    {:>6}", stats.lines-stats.code_lines-stats.comment_lines);
-    println!("");
+    println!();
     println!("Lines with a documentation comment:   {:>6}", stats.doc_comment_lines);
     println!("Total words written in doc comments:  {:>6}", stats.doc_comment_words);
     println!("Total words written in all comments:  {:>6}", stats.comment_words);
@@ -74,7 +74,7 @@ fn print_stats(stats: &Stats) {
 fn is_ignored(entry: &DirEntry) -> bool {
     entry.file_name()
          .to_str()
-         .map(|s| s.starts_with(".") && s.len() > 1 || s.ends_with(".md"))
+         .map(|s| s.starts_with('.') && s.len() > 1 || s.ends_with(".md"))
          .unwrap_or(false)
 }
 
@@ -84,7 +84,7 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
     let mut line_has_comment = false;
     let mut line_has_doc_comment = false;
     let mut line_has_code = false;
-    for (s, op) in ScopeRegionIterator::new(&ops, line) {
+    for (s, op) in ScopeRegionIterator::new(ops, line) {
         stack.apply(op);
         if s.is_empty() { // in this case we don't care about blank tokens
             continue;
@@ -133,7 +133,7 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let mut stack = ScopeStack::new();
     while reader.read_line(&mut line).unwrap() > 0 {
         {
-            let ops = state.parse_line(&line, &ss);
+            let ops = state.parse_line(&line, ss);
             stats.chars += line.len();
             count_line(&ops, &line, &mut stack, stats);
         }

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -274,13 +274,13 @@ mod tests {
         let mut stack = ScopeStack::new();
 
         for line in lines.iter() {
-            let ops = state.parse_line(&line, &ss);
+            let ops = state.parse_line(line, &ss);
             println!("{:?}", ops);
 
             let mut iterated_ops: Vec<&ScopeStackOp> = Vec::new();
-            for (_, op) in ScopeRegionIterator::new(&ops, &line) {
+            for (_, op) in ScopeRegionIterator::new(&ops, line) {
                 stack.apply(op);
-                iterated_ops.push(&op);
+                iterated_ops.push(op);
                 println!("{:?}", op);
             }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -42,9 +42,9 @@ use std::path::Path;
 ///
 /// let syntax_set = SyntaxSet::load_defaults_newlines();
 /// let syntax = syntax_set.find_syntax_by_name("R").unwrap();
-/// let mut html_generator = ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+/// let mut html_generator = ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
 /// for line in LinesWithEndings::from(current_code) {
-///     html_generator.parse_html_for_line_which_includes_newline(&line);
+///     html_generator.parse_html_for_line_which_includes_newline(line);
 /// }
 /// let output_html = html_generator.finalize();
 /// ```
@@ -614,9 +614,9 @@ mod tests {
         let syntax = syntax_set.find_syntax_by_name("JSON").unwrap();
 
         let mut html_generator =
-            ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+            ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(&line);
+            html_generator.parse_html_for_line_which_includes_newline(line);
         }
         html_generator.finalize();
     }
@@ -628,9 +628,9 @@ mod tests {
         let syntax = syntax_set.find_syntax_by_name("R").unwrap();
 
         let mut html_generator =
-            ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+            ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(&line);
+            html_generator.parse_html_for_line_which_includes_newline(line);
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"source r\">x <span class=\"keyword operator arithmetic r\">+</span> y\n</span>");
@@ -642,12 +642,12 @@ mod tests {
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let syntax = syntax_set.find_syntax_by_name("R").unwrap();
         let mut html_generator = ClassedHTMLGenerator::new_with_class_style(
-            &syntax,
+            syntax,
             &syntax_set,
             ClassStyle::SpacedPrefixed { prefix: "foo-" },
         );
         for line in LinesWithEndings::from(current_code) {
-            html_generator.parse_html_for_line_which_includes_newline(&line);
+            html_generator.parse_html_for_line_which_includes_newline(line);
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"foo-source foo-r\">x <span class=\"foo-keyword foo-operator foo-arithmetic foo-r\">+</span> y\n</span>");
@@ -663,9 +663,9 @@ fn main() {
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let syntax = syntax_set.find_syntax_by_extension("rs").unwrap();
         let mut html_generator =
-            ClassedHTMLGenerator::new_with_class_style(&syntax, &syntax_set, ClassStyle::Spaced);
+            ClassedHTMLGenerator::new_with_class_style(syntax, &syntax_set, ClassStyle::Spaced);
         for line in LinesWithEndings::from(code) {
-            html_generator.parse_html_for_line_which_includes_newline(&line);
+            html_generator.parse_html_for_line_which_includes_newline(line);
         }
         let html = html_generator.finalize();
         assert_eq!(html, "<span class=\"source rust\"><span class=\"comment line double-slash rust\"><span class=\"punctuation definition comment rust\">//</span> Rust source\n</span><span class=\"meta function rust\"><span class=\"meta function rust\"><span class=\"storage type function rust\">fn</span> </span><span class=\"entity name function rust\">main</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters begin rust\">(</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters end rust\">)</span></span></span></span><span class=\"meta function rust\"> </span><span class=\"meta function rust\"><span class=\"meta block rust\"><span class=\"punctuation section block begin rust\">{</span>\n    <span class=\"support macro rust\">println!</span><span class=\"meta group rust\"><span class=\"punctuation section group begin rust\">(</span></span><span class=\"meta group rust\"><span class=\"string quoted double rust\"><span class=\"punctuation definition string begin rust\">&quot;</span>Hello World!<span class=\"punctuation definition string end rust\">&quot;</span></span></span><span class=\"meta group rust\"><span class=\"punctuation section group end rust\">)</span></span><span class=\"punctuation terminator rust\">;</span>\n</span><span class=\"meta block rust\"><span class=\"punctuation section block end rust\">}</span></span></span>\n</span>");

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -871,7 +871,7 @@ mod tests {
             "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
             "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
         ];
-        expect_scope_stacks(&line, &expect, TEST_SYNTAX);
+        expect_scope_stacks(line, &expect, TEST_SYNTAX);
     }
 
     #[test]
@@ -882,7 +882,7 @@ mod tests {
             "<example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
             "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
         ];
-        expect_scope_stacks(&line, &expect, TEST_SYNTAX);
+        expect_scope_stacks(line, &expect, TEST_SYNTAX);
     }
 
     #[test]
@@ -894,7 +894,7 @@ mod tests {
             "<source.test>, <example.meta-scope.after-clear-scopes.example>, <example.pops-clear-scopes.example>",
             "<source.test>, <string.quoted.single.example>, <constant.character.escape.example>",
         ];
-        expect_scope_stacks(&line, &expect, TEST_SYNTAX);
+        expect_scope_stacks(line, &expect, TEST_SYNTAX);
     }
 
     #[test]
@@ -903,7 +903,7 @@ mod tests {
         let expect = [
             "<source.test>, <constant.numeric.test>",
         ];
-        expect_scope_stacks(&line, &expect, TEST_SYNTAX);
+        expect_scope_stacks(line, &expect, TEST_SYNTAX);
     }
 
     #[test]
@@ -916,7 +916,7 @@ mod tests {
             "<source.test>, <test>, <string.unquoted.test>",
             "<source.test>, <test>, <keyword.control.test>",
         ];
-        expect_scope_stacks(&line, &expect, TEST_SYNTAX);
+        expect_scope_stacks(line, &expect, TEST_SYNTAX);
     }
 
     #[test]
@@ -937,7 +937,7 @@ contexts:
 
         let line = "foo!";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -955,7 +955,7 @@ contexts:
 
         let line = "foo";
         let expect = ["<source.test>, <foo.end>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
 
         let line = "foofoofoo";
         let expect = [
@@ -963,7 +963,7 @@ contexts:
             "<source.test>, <foo.any>",
             "<source.test>, <foo.end>",
         ];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -983,7 +983,7 @@ contexts:
             "<top-level.test>",
         ];
 
-        expect_scope_stacks_with_syntax(&line1, &expect1, syntax.clone());
+        expect_scope_stacks_with_syntax(line1, &expect1, syntax.clone());
 
         let line2 = ">abctest</style>foobar";
         let expect2 = [
@@ -991,7 +991,7 @@ contexts:
             "<source.css.embedded.html>, <test.embedded>",
             "<top-level.test>",
         ];
-        expect_scope_stacks_with_syntax(&line2, &expect2, syntax.clone());
+        expect_scope_stacks_with_syntax(line2, &expect2, syntax);
     }
 
     #[test]
@@ -1017,7 +1017,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.matched>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1046,7 +1046,7 @@ contexts:
 
         let line = "test";
         let expect = ["<source.test>, <test.matched>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1074,7 +1074,7 @@ contexts:
 
         let line = "test";
         let expect = ["<source.test>, <test.matched>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1103,7 +1103,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.matched>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1125,7 +1125,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.matched>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1153,7 +1153,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1188,7 +1188,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1216,7 +1216,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1248,7 +1248,7 @@ contexts:
 
         let line = "foo::bar::* xxx";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1281,7 +1281,7 @@ contexts:
 
         let line = "hello";
         let expect = ["<source.test>, <test.good>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1308,7 +1308,7 @@ contexts:
     - match: ''
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         expect_scope_stacks_with_syntax("/** * */", &["<comment.block.documentation.javadoc>, <punctuation.definition.comment.begin.javadoc>", "<comment.block.documentation.javadoc>, <text.html.javadoc>, <punctuation.definition.comment.javadoc>", "<comment.block.documentation.javadoc>, <punctuation.definition.comment.end.javadoc>"], syntax);
     }
 
@@ -1392,13 +1392,13 @@ contexts:
             "a1b2c3d4e5",
             &[
                 "<a>", "<1>", "<b>", "<2>", "<c>", "<3>", "<d>", "<4>", "<e>", "<5>"
-            ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
+            ], SyntaxDefinition::load_from_str(syntax, true, None).unwrap()
         );
         expect_scope_stacks_with_syntax(
             "5cfcecbedcdea",
             &[
                 "<5>", "<cwith>", "<f>", "<e>", "<b>", "<d>", "<cwithout>", "<a>"
-            ], SyntaxDefinition::load_from_str(&syntax, true, None).unwrap()
+            ], SyntaxDefinition::load_from_str(syntax, true, None).unwrap()
         );
     }
 
@@ -1419,7 +1419,7 @@ contexts:
             1: keyword
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         expect_scope_stacks_with_syntax("testfoo", &["<test>", /*"<ignored>",*/ "<f>", "<keyword>"], syntax);
     }
 
@@ -1448,7 +1448,7 @@ contexts:
           scope: '1'
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax_yamlstr, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax_yamlstr, true, None).unwrap();
         expect_scope_stacks_with_syntax("abc12", &["<1>", "<2>"], syntax);
     }
 
@@ -1495,11 +1495,11 @@ contexts:
       pop: true
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax_yamlstr, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax_yamlstr, true, None).unwrap();
         expect_scope_stacks_with_syntax("ab12", &["<1>", "<2>"], syntax.clone());
         expect_scope_stacks_with_syntax("abc12", &["<1>", "<digit2>"], syntax.clone());
         expect_scope_stacks_with_syntax("abcd12", &["<1>", "<digit2>"], syntax.clone());
-        expect_scope_stacks_with_syntax("abcde12", &["<digit1>", "<digit2>"], syntax.clone());
+        expect_scope_stacks_with_syntax("abcde12", &["<digit1>", "<digit2>"], syntax);
     }
 
     #[test]
@@ -1528,7 +1528,7 @@ contexts:
           pop: true
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax_yamlstr, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax_yamlstr, true, None).unwrap();
         expect_scope_stacks_with_syntax("aa", &["<a>", "<1>"], syntax.clone());
         expect_scope_stacks_with_syntax("abcdb", &["<a>", "<b>", "<c>", "<d>", "<1>"], syntax);
     }
@@ -1562,7 +1562,7 @@ contexts:
           pop: true
 "#;
 
-        let syntax = SyntaxDefinition::load_from_str(&syntax_yamlstr, true, None).unwrap();
+        let syntax = SyntaxDefinition::load_from_str(syntax_yamlstr, true, None).unwrap();
         expect_scope_stacks_with_syntax("a--", &["<a>", "<2>"], syntax.clone());
         // it seems that when ST encounters a non existing pop backreference, it just pops back to the with_prototype's original parent context - i.e. cdb is unscoped
         // TODO: it would be useful to have syntest functionality available here for easier testing and clarity
@@ -1582,7 +1582,7 @@ contexts:
 
         let line = "foo";
         let expect = ["<source.test>, <foo.newline>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1598,7 +1598,7 @@ contexts:
 
         let line = "foo";
         let expect = ["<source.test>, <foo.newline>"];
-        expect_scope_stacks(&line, &expect, syntax);
+        expect_scope_stacks(line, &expect, syntax);
     }
 
     #[test]
@@ -1621,7 +1621,7 @@ contexts:
       scope: other
 "#;
 
-        let syntax_newlines = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        let syntax_newlines = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         let syntax_set = link(syntax_newlines);
 
         let mut state = ParseState::new(&syntax_set.syntaxes()[0]);
@@ -1659,7 +1659,7 @@ contexts:
       scope: comment.line.double-slash
 "#;
 
-        let syntax_newlines = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        let syntax_newlines = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         let syntax_set = link(syntax_newlines);
 
         let mut state = ParseState::new(&syntax_set.syntaxes()[0]);
@@ -1715,7 +1715,7 @@ contexts:
                       pop: true
                 "#, true, None).unwrap();
 
-        expect_scope_stacks_with_syntax(&"aa", &["<a>", "<b>"], syntax);
+        expect_scope_stacks_with_syntax("aa", &["<a>", "<b>"], syntax);
     }
     
     #[test]
@@ -1738,18 +1738,18 @@ contexts:
                       pop: true
                 "#, true, None).unwrap();
 
-        expect_scope_stacks_with_syntax(&"aa", &["<a>", "<b>"], syntax);
+        expect_scope_stacks_with_syntax("aa", &["<a>", "<b>"], syntax);
     }
 
     fn expect_scope_stacks(line_without_newline: &str, expect: &[&str], syntax: &str) {
         println!("Parsing with newlines");
         let line_with_newline = format!("{}\n", line_without_newline);
-        let syntax_newlines = SyntaxDefinition::load_from_str(&syntax, true, None).unwrap();
+        let syntax_newlines = SyntaxDefinition::load_from_str(syntax, true, None).unwrap();
         expect_scope_stacks_with_syntax(&line_with_newline, expect, syntax_newlines);
 
         println!("Parsing without newlines");
-        let syntax_nonewlines = SyntaxDefinition::load_from_str(&syntax, false, None).unwrap();
-        expect_scope_stacks_with_syntax(&line_without_newline, expect, syntax_nonewlines);
+        let syntax_nonewlines = SyntaxDefinition::load_from_str(syntax, false, None).unwrap();
+        expect_scope_stacks_with_syntax(line_without_newline, expect, syntax_nonewlines);
     }
 
     fn expect_scope_stacks_with_syntax(line: &str, expect: &[&str], syntax: SyntaxDefinition) {

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -1013,9 +1013,9 @@ mod tests {
 
         let mut syntax = syntax_set.find_syntax_by_extension("a").unwrap();
         assert_eq!(syntax.name, "A improved");
-        syntax = syntax_set.find_syntax_by_scope(Scope::new(&"source.a").unwrap()).unwrap();
+        syntax = syntax_set.find_syntax_by_scope(Scope::new("source.a").unwrap()).unwrap();
         assert_eq!(syntax.name, "A improved");
-        syntax = syntax_set.find_syntax_by_first_line(&"syntax a").unwrap();
+        syntax = syntax_set.find_syntax_by_first_line("syntax a").unwrap();
         assert_eq!(syntax.name, "C");
 
         let mut parse_state = ParseState::new(syntax);


### PR DESCRIPTION
Same as #349, but this time in examples and tests. It's mostly fixes for https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow, but not only that.
