### PR TITLE
Fix all clippy::match_ref_pats warnings

### DIFF
--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -926,8 +926,8 @@ mod tests {
         assert_eq!(defn2.contexts["string"].meta_scope,
                    vec![Scope::new("string.quoted.double.c").unwrap()]);
         let first_pattern: &Pattern = &main.patterns[0];
-        match first_pattern {
-            &Pattern::Match(ref match_pat) => {
+        match *first_pattern {
+            Pattern::Match(ref match_pat) => {
                 let m: &CaptureMapping = match_pat.captures.as_ref().expect("test failed");
                 assert_eq!(&m[0], &(1,vec![Scope::new("meta.preprocessor.c++").unwrap()]));
                 use crate::parsing::syntax_definition::ContextReference::*;
@@ -1067,8 +1067,8 @@ mod tests {
         assert_eq!(defn.scope, top_level_scope);
 
         let first_pattern: &Pattern = &defn.contexts["main"].patterns[0];
-        match first_pattern {
-            &Pattern::Match(ref match_pat) => {
+        match *first_pattern {
+            Pattern::Match(ref match_pat) => {
                 let m: &CaptureMapping = match_pat.captures.as_ref().expect("test failed");
                 assert_eq!(&m[0], &(1,vec![Scope::new("support.function.box.latex").unwrap()]));
 


### PR DESCRIPTION
The warnings looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::match_ref_pats 
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: you don't need to add `&` to all patterns
   --> src/parsing/yaml_load.rs:929:9
    |
929 | /         match first_pattern {
930 | |             &Pattern::Match(ref match_pat) => {
931 | |                 let m: &CaptureMapping = match_pat.captures.as_ref().expect("test failed");
932 | |                 assert_eq!(&m[0], &(1,vec![Scope::new("meta.preprocessor.c++").unwrap()]));
...   |
953 | |             _ => unreachable!(),
954 | |         }
    | |_________^
    |
    = note: requested on the command line with `-W clippy::match-ref-pats`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: instead of prefixing all patterns with `&`, you can dereference the expression
    |
929 |         match *first_pattern {
930 |             Pattern::Match(ref match_pat) => {
    |

warning: you don't need to add `&` to all patterns
    --> src/parsing/yaml_load.rs:1070:9
     |
1070 | /         match first_pattern {
1071 | |             &Pattern::Match(ref match_pat) => {
1072 | |                 let m: &CaptureMapping = match_pat.captures.as_ref().expect("test failed");
1073 | |                 assert_eq!(&m[0], &(1,vec![Scope::new("support.function.box.latex").unwrap()]));
...    |
1082 | |             _ => unreachable!(),
1083 | |         }
     | |_________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats
help: instead of prefixing all patterns with `&`, you can dereference the expression
     |
1070 |         match *first_pattern {
1071 |             Pattern::Match(ref match_pat) => {
     |

warning: 2 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 10.72s
```