### PR TITLE
Make clippy happy again with Scope::is_empty()

### DIFF
--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -242,7 +242,7 @@ impl Scope {
         8 - self.missing_atoms()
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
The `Scope::is_empty()` was added only to [make clippy
happy](https://github.com/trishume/syntect/commit/73c09c38cfb990af57d35c1c964b6d65e47494cb).

Now clippy is sad again. So let's make clippy happy again.

Due to rustc auto-deference logic, it should be compile-time
backwards compatible to change to `self` like the other methods have, instead of
having `&self`.

The lint warning looks like this:

```
warning: struct `Scope` has a public `len` method, but the `is_empty` method has an unexpected signature
   --> src/parsing/scope.rs:241:5
    |
241 |     pub fn len(self) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::len_without_is_empty)]` on by default
note: `is_empty` defined here
   --> src/parsing/scope.rs:245:5
    |
245 |     pub fn is_empty(&self) -> bool {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected signature: `(self) -> bool`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty
```