### PR TITLE
MetadataItems: Use #[non_exhaustive] attribute instead manual implementation

### DIFF
--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -48,6 +48,7 @@ pub struct MetadataSet {
 /// For more information, see [Metadata Files](http://docs.sublimetext.info/en/latest/reference/metadata.html)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct MetadataItems {
     pub increase_indent_pattern: Option<Regex>,
     pub decrease_indent_pattern: Option<Regex>,
@@ -64,9 +65,6 @@ pub struct MetadataItems {
     /// The first pair of `TM_COMMENT_START` and `TM_COMMENT_END` items in
     /// `shell_variables`, if they exist.
     pub block_comment: Option<(String, String)>,
-
-    #[serde(default)]
-    __allow_adding_fields_without_major_semver_bump: (),
 }
 
 /// A type that can be deserialized from a `.tmPreferences` file.


### PR DESCRIPTION
This is the first lint fix PR that I am not entirely comfortable is the right thing to do, but I can't think of why it would be a problem, so here we go.

I did consider to suppress this lint warning and just keep the code, together with a note to not duplicate this pattern further. But I did not like how the code turned out.

So I think we should try to fix like this as clippy suggests. If you are not comfortable with this PR, you are of course very free to reject it. I will not be the slightest offended. (Which applies to all my PRs, btw.)

The fixed clippy warning looks like this:
```
warning: this seems like a manual implementation of the non-exhaustive pattern
  --> src/parsing/metadata.rs:51:1
   |
51 |   pub struct MetadataItems {
   |   ^-----------------------
   |   |
   |  _help: add the attribute: `#[non_exhaustive] pub struct MetadataItems`
   | |
52 | |     pub increase_indent_pattern: Option<Regex>,
53 | |     pub decrease_indent_pattern: Option<Regex>,
54 | |     pub bracket_indent_next_line_pattern: Option<Regex>,
...  |
69 | |     __allow_adding_fields_without_major_semver_bump: (),
70 | | }
   | |_^
   |
   = note: `#[warn(clippy::manual_non_exhaustive)]` on by default
help: remove this field
  --> src/parsing/metadata.rs:69:5
   |
69 |     __allow_adding_fields_without_major_semver_bump: (),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
```