### PR TITLE
Fix all clippy::needless-collect warnings

### DIFF
--- a/src/easy.rs
+++ b/src/easy.rs
@@ -284,8 +284,8 @@ mod tests {
                 println!("{:?}", op);
             }
 
-            let all_ops: Vec<&ScopeStackOp> = ops.iter().map(|t|&t.1).collect();
-            assert_eq!(all_ops.len(), iterated_ops.len() - 1); // -1 because we want to ignore the NOOP
+            let all_ops = ops.iter().map(|t| &t.1);
+            assert_eq!(all_ops.count(), iterated_ops.len() - 1); // -1 because we want to ignore the NOOP
         }
     }
 }


### PR DESCRIPTION
We only have one such warning, and it looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::needless-collect 
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: avoid using `collect()` when not needed
   --> src/easy.rs:287:71
    |
287 |             let all_ops: Vec<&ScopeStackOp> = ops.iter().map(|t|&t.1).collect();
    |                                                                       ^^^^^^^
288 |             assert_eq!(all_ops.len(), iterated_ops.len() - 1); // -1 because we want to ignore the NOOP
    |                        ------------- the iterator could be used here instead
    |
    = note: requested on the command line with `-W clippy::needless-collect`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect
help: take the original Iterator's count instead of collecting it and finding the length
    |
287 |             
288 |             assert_eq!(ops.iter().map(|t|&t.1).count(), iterated_ops.len() - 1); // -1 because we want to ignore the NOOP
    |
```

(I kept the variable for readability, and did not inline it like clippy suggeted.)