### PR TITLE
MatchPower: Suppress clippy::derive_ord_xor_partial_ord

### DIFF
--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -358,6 +358,7 @@ pub struct MatchPower(pub f64);
 
 impl Eq for MatchPower {}
 
+#[allow(clippy::derive_ord_xor_partial_ord)] // The code works, so let's keep using it
 impl Ord for MatchPower {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap()


### PR DESCRIPTION
The current code works, so let's keep using it. Fixing the lint in a low-risk way is tricky.