### PR TITLE
Suppress clippy::redundant_clone in can_clone() test

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -843,6 +843,7 @@ mod tests {
             builder.add(syntax_b());
 
             let syntax_set_original = builder.build();
+            #[allow(clippy::redundant_clone)] // We want to test .clone()
             syntax_set_original.clone()
             // Note: The original syntax set is dropped
         };


### PR DESCRIPTION
We need to .clone() to test .clone().

The warning looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::redundant_clone
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: redundant clone
   --> src/parsing/syntax_set.rs:846:32
    |
846 |             syntax_set_original.clone()
    |                                ^^^^^^^^ help: remove this
    |
    = note: requested on the command line with `-W clippy::redundant-clone`
note: this value is dropped without further use
   --> src/parsing/syntax_set.rs:846:13
    |
846 |             syntax_set_original.clone()
    |             ^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

warning: 1 warning emitted
```