### PR TITLE
Fix all clippy::filter_next warnings

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1780,7 +1780,7 @@ contexts:
                 }
             }
         }
-        if let Some(missing) = expect.iter().filter(|e| !criteria_met.contains(&e)).next() {
+        if let Some(missing) = expect.iter().find(|e| !criteria_met.contains(e)) {
             panic!("expected scope stack '{}' missing", missing);
         }
     }


### PR DESCRIPTION
There is only one, and it looks like this:

```
% cargo clippy --all-features --all-targets -- --allow clippy::all --allow deprecated --warn clippy::filter_next
    Checking syntect v4.6.0 (/home/martin/src/syntect)
warning: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
    --> src/parsing/parser.rs:1783:32
     |
1783 |         if let Some(missing) = expect.iter().filter(|e| !criteria_met.contains(&e)).next() {
     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `expect.iter().find(|e| !criteria_met.contains(&e))`
     |
     = note: requested on the command line with `-W clippy::filter-next`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#filter_next

warning: 1 warning emitted
```

Also fix the `clippy::needless-borrow` on `e` that slipped through my PR to fix all such warnings.