### PR TITLE
Fix last clippy lint, add clippy to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,19 @@ jobs:
       with:
         toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
         default: true
-    - run: |
-        cargo check --verbose --all-features --all-targets
+        profile: minimal
+        components: clippy
+    - name: Run cargo clippy
+      run: |
+        # Must run before `cargo check` until we use Rust 1.52
+        # See https://github.com/rust-lang/rust-clippy/issues/4612
+        cargo clippy --all-targets --all-features -- \
+          --allow clippy::unknown_clippy_lints \
+          --allow clippy::unnecessary_cast \
+          --allow clippy::block_in_if_condition_stmt
+    - name: Run cargo check
+      run: |
+        cargo check --all-features --all-targets
 
   build-and-test:
     name: Build and test

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -415,15 +415,18 @@ impl ParseState {
             }
         }
 
-        let (matched, can_cache) = if match_pat.has_captures && captures.is_some() {
-            let &(ref region, ref s) = captures.unwrap();
-            let regex = match_pat.regex_with_refs(region, s);
-            let matched = regex.search(line, start, line.len(), Some(regions));
-            (matched, false)
-        } else {
-            let regex = match_pat.regex();
-            let matched = regex.search(line, start, line.len(), Some(regions));
-            (matched, true)
+        let (matched, can_cache) = match (match_pat.has_captures, captures) {
+            (true, Some(captures)) => {
+                let &(ref region, ref s) = captures;
+                let regex = match_pat.regex_with_refs(region, s);
+                let matched = regex.search(line, start, line.len(), Some(regions));
+                (matched, false)
+            }
+            _ => {
+                let regex = match_pat.regex();
+                let matched = regex.search(line, start, line.len(), Some(regions));
+                (matched, true)
+            }
         };
 
         if matched {


### PR DESCRIPTION
The first commit fixes the last clippy lint warning.

The second commits adds clippy to CI. The CI build will fail only if serious clippy lint is found. Those that default to `deny`. "Normal" clippy warnings - those that default to `warn` - will not fail the build.

    CI: Add clippy lint step to the MSRV job
    
    --allow clippy::unknown_clippy_lints since we mention some lints in newer
    versions of Rust.
    
    --allow clippy::unnecessary_cast since that lint has been removed in newer
    versions of clippy.
    
    --allow clippy::block_in_if_condition_stmt since that lint has been removed in
    newer versions of clippy.

