### PR TITLE
Maximize 'bitflags' versions range while keeping MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"
-bitflags = "~1.2"
+bitflags = ">= 1.0.4, < 1.3.0"
 plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }


### PR DESCRIPTION
## Short version

`syntect` currently accepts `bitflags` `1.2.0` and `1.2.1`. This PR makes `syntect` also accept `bitflags` `1.0.4` and `1.1.0`, which I have verified also works.

## Long version

#348 which limited `bitflags` to `~1.2` was made in a bit of a rush since CI on master was failing. Inspired by https://github.com/nix-rust/nix/compare/v0.22.0...v0.22.1 (https://github.com/sharkdp/bat/pull/1837) I thought it would be a good idea to maximize the range of accepted version of `bitflags`. It would be annoying to have to make a hotfix release of `syntect` just because we were too conservative in the range of acceptable `bitflags` versions.

Before `~1.2`, we had `1.0.4`, and I have confirmed that the build fails with `1.0.3`. So this PR changes to `>= 1.0.4, < 1.3.0`. We can't use `1.3.0` and higher if we want to keep MSRV. And I have confirmed that `1.3.0` and `1.0.3` does not match the new constraint:

```
% cargo update -p bitflags --precise 1.3.1
    Updating crates.io index
error: failed to select a version for the requirement `bitflags = ">=1.0.4, <1.3.0"`
candidate versions found which didn't match: 1.3.1
location searched: crates.io index
required by package `syntect v4.6.0 (/home/martin/src/syntect)`
```

Looking at https://crates.io/crates/bitflags/versions one can see that the following versions are the complete set of (non-yanked) `bitflags` versions that fulfill the new version constraint:

* 1.2.1
* 1.2.0
* 1.1.0
* 1.0.4


I have confirmed that all syntect tests passes for all those `bitflags` versions, by doing:

```
% for v in 1.2.1 1.2.0 1.1.0 1.0.4 ; do cargo update -p bitflags --precise $v && cargo test --quiet --all-features; done
    Updating bitflags v1.0.4 -> v1.2.1
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 90.98s
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.66s

    Updating bitflags v1.2.1 -> v1.2.0
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 85.04s
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.62s

    Updating bitflags v1.2.0 -> v1.1.0
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 84.13s
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 21.96s

    Updating bitflags v1.1.0 -> v1.0.4
test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 95.51s
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 22.25s
```

This works both on Rust 1.54 and Rust 1.42 (our MSRV).
