### PR TITLE
CI.yml: Stop doing 'rm -Rf examples'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,6 @@ jobs:
         rm -Rf examples
     - name: Docs
       run: |
-        # Only run doc build on stable until this is fixed: https://github.com/rust-lang/rust/issues/51661
         cargo doc
     - name: Run tests without default features
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,15 +60,12 @@ jobs:
         make assets
         make syntest
         make syntest-fancy
-        rm -Rf examples
     - name: Docs
       run: |
         cargo doc
     - name: Run tests without default features
       run: |
-        # default features are required for examples to build - so remove them from sight.
-        # Doc-tests may also use default features
-        rm -Rf examples && cargo test --lib --no-default-features
+        cargo test --lib --no-default-features
     - name: Run Xi tests
       run: |
         # Test the build configuration that Xi uses


### PR DESCRIPTION
It is not needed, CI passes anyway.