### PR TITLE
Increase MSRV instead of putting upper bound on bitflags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.42"
+  MIN_SUPPORTED_RUST_VERSION: "1.46"
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 lazycell = "1.0"
-bitflags = ">= 1.0.4, < 1.3.0"
+bitflags = "1.0.4"
 plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }


### PR DESCRIPTION
It is getting unreasonably much work to stay at MSRV 1.42.

bat recently bumped nix to 0.23.0 which requires bitflags 1.3.1 or later.
See https://github.com/sharkdp/bat/pull/1874. So as of now, bat can't build
with syntect master.

It will cause unnecssary headaches for bat and other downstream projects if we
stay at MSRV 1.42. So remove upper bound on bitflags and bump MSRV to 1.46
instead and only put a lower bound (same as we had before) on bitflags.