### PR TITLE
Make ContextId implement Hash and simplify the code

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -14,9 +14,9 @@ use crate::parsing::syntax_set::SyntaxSet;
 
 pub type CaptureMapping = Vec<(usize, Vec<Scope>)>;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ContextId {
-    index: usize,
+    pub(crate) index: usize,
 }
 
 /// The main data structure representing a syntax definition loaded from a
@@ -228,11 +228,6 @@ pub(crate) fn substitute_backrefs_in_regex<F>(regex_str: &str, substituter: F) -
 impl ContextId {
     pub fn new(index: usize) -> Self {
         ContextId { index }
-    }
-
-    #[inline(always)]
-    pub(crate) fn index(self) -> usize {
-        self.index
     }
 }
 


### PR DESCRIPTION
I thought it would be a good idea to split up https://github.com/trishume/syntect/pull/374 into smaller and self-contained parts that are easier to digest and make sense of. Here is the first such PR. It passes
 * syntect regression tests
 * bat regression tests

and I know from working with the referenced PR that the code is very sensitive, and the slightest mistake will practically always make at least one test fail. So that all tests pass gives good confidence that the code is in order.

As for the change itself; making `ContextId` implement `Hash` allows us to make the code simpler and clearer. Most importantly:

* We don't need to pass around a cryptic `HashSet<usize>`. We can instead pass
  around the semantically much clearer `HashSet<ContextId>`,

But I also take the opportunity to:

* Remove the `ContextId::index()` getter. `ContextId` shall be seen as a
  primitive that we pass around, rather than something with getters.

* Stop using `ContextId::new()`. The way we use it, it is just boilerplate.
  Long-term, we should remove it from the public API. Clients should never
  create their own `ContextId`s.