### PR TITLE
Introduce find_unlinked_contexts_in_context() helper

### DIFF
--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -397,31 +397,22 @@ impl SyntaxSet {
     ) {
         for pattern in context.patterns.iter() {
             let maybe_refs_to_check = match pattern {
-                Pattern::Match(match_pat) => {
-                    match &match_pat.operation {
-                        MatchOperation::Push(context_refs) => {
-                            Some(context_refs)
-                        },
-                        MatchOperation::Set(context_refs) => {
-                            Some(context_refs)
-                        },
-                        _ => None,
-                    }
+                Pattern::Match(match_pat) => match &match_pat.operation {
+                    MatchOperation::Push(context_refs) => Some(context_refs),
+                    MatchOperation::Set(context_refs) => Some(context_refs),
+                    _ => None,
                 },
                 _ => None,
             };
-    
             for context_ref in maybe_refs_to_check.into_iter().flatten() {
                 match context_ref {
-                    ContextReference::Direct(_) => {},
+                    ContextReference::Direct(_) => {}
                     _ => {
-                        unlinked_contexts.insert(
-                            format!(
-                                "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
-                                name, scope, &context_ref
-                            )
-                        );
-                    },
+                        unlinked_contexts.insert(format!(
+                            "Syntax '{}' with scope '{}' has unresolved context reference {:?}",
+                            name, scope, &context_ref
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Glad to hear you liked my PoC for lazy-loading syntaxes! No worries about having a busy life :)

Here comes another PR. This one is pretty simple. But it will make the upcoming work and diff for #374 easier to do and read.

The code can be further simplified and refactored, but spare time is limited, and at this point I'd prefer to prioritize getting lazy-loading production ready.

First commit splits out a helper function (ignore white space when diffing to get a nice diff), and the second commit runs cargo fmt on the new helper function.