### PR TITLE
Rename `contexts` in `SyntaxReference` to `context_ids`

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -164,7 +164,7 @@ impl ParseState {
     /// main context of the syntax
     pub fn new(syntax: &SyntaxReference) -> ParseState {
         let start_state = StateLevel {
-            context: syntax.contexts["__start"],
+            context: syntax.context_ids["__start"],
             prototypes: Vec::new(),
             captures: None,
         };


### PR DESCRIPTION
We will later split up and move `contexts` from `SyntaxSet` to
`SyntaxReference`s. If we don't do this renaming, there will be a name clash.
Unless we call the new field something else of course, but that would only be
confusing.

Note that `bincode` does not serialize field names, so the existing packdumps are still valid.

For an overview of where this PR fits in the bigger picture, see this updated comment: https://github.com/trishume/syntect/pull/378#issuecomment-944592257