### PR TITLE
Bump MSRV to 1.47 to build with pkg-config 0.3.21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.46"
+  MIN_SUPPORTED_RUST_VERSION: "1.47"
   CARGO_TERM_COLOR: always
 
 jobs:


### PR DESCRIPTION
pkg-config 0.3.21 was released 2 days ago and depends on `inner_deref` which was
stabalized in Rust 1.47.

Rust 1.46 fails with:

```
error[E0658]: use of unstable library feature 'inner_deref'
   --> /home/martin/.cargo/registry/src/github.com-1ecc6299db9ec823/pkg-config-0.3.21/src/lib.rs:163:53
    |
163 |                         let crate_name = crate_name.as_deref().unwrap_or("sys");
    |                                                     ^^^^^^^^
```

we could also put an upper limit on pkg-config, but that will only lead to
headaches later.