### PR TITLE
benches: Use exact same names as in v4.6.0

### DIFF
--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -79,7 +79,7 @@ fn highlighting_benchmark(c: &mut Criterion) {
         "parser.rs",
         "scope.rs",
     ] {
-        highlight.bench_with_input(*input, input, |b, s| highlight_file(b, s));
+        highlight.bench_with_input(format!("\"{}\"", input), input, |b, s| highlight_file(b, s));
     }
     highlight.finish();
 }

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -46,7 +46,7 @@ fn parsing_benchmark(c: &mut Criterion) {
         "parser.rs",
         "scope.rs",
     ] {
-        parse.bench_with_input(*input, input, |b, s| parse_file(b, s));
+        parse.bench_with_input(format!("\"{}\"", input), input, |b, s| parse_file(b, s));
     }
     parse.finish();
 }


### PR DESCRIPTION
When doing #380 I were not insightful enough to realize that it will be useful
to have the exact same names as before. This is useful when using the
`--baseline` feature of Criterion to compare current code with old code.

After this commit, we can do this:

```bash
git checkout v4.6.0
cargo bench 'highlight/"jquery.js"' -- --save-baseline v4.6.0
git checkout origin/master
cargo bench 'highlight/"jquery.js"' -- --baseline v4.6.0
```

Without this commit, the name of the benchmark on `master` is
`'highlight/jquery.js'`, which makes criterion treat it as a different benchmark.