### PR TITLE
Use std::fs::read_to_string() when possible

### DIFF
--- a/benches/highlighting.rs
+++ b/benches/highlighting.rs
@@ -4,8 +4,6 @@ use syntect::highlighting::{ThemeSet, Theme};
 use syntect::easy::HighlightLines;
 use syntect::html::highlighted_html_for_string;
 use std::str::FromStr;
-use std::fs::File;
-use std::io::Read;
 
 fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> usize {
     let mut h = HighlightLines::new(syntax, theme);
@@ -33,9 +31,7 @@ fn highlight_file(b: &mut Bencher, file: &str) {
     let ts = ThemeSet::load_defaults();
 
     let syntax = ss.find_syntax_for_file(path).unwrap().unwrap();
-    let mut f = File::open(path).unwrap();
-    let mut s = String::new();
-    f.read_to_string(&mut s).unwrap();
+    let s = std::fs::read_to_string(path).unwrap();
 
     b.iter(|| {
         do_highlight(&s, &ss, syntax, &ts.themes["base16-ocean.dark"])
@@ -58,9 +54,7 @@ fn highlight_html(b: &mut Bencher) {
 
     let path = "testdata/parser.rs";
     let syntax = ss.find_syntax_for_file(path).unwrap().unwrap();
-    let mut f = File::open(path).unwrap();
-    let mut s = String::new();
-    f.read_to_string(&mut s).unwrap();
+    let s = std::fs::read_to_string(path).unwrap();
 
     b.iter(|| {
         highlighted_html_for_string(&s, &ss, syntax, &ts.themes["base16-ocean.dark"])

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,6 +1,4 @@
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
-use std::fs::File;
-use std::io::Read;
 use std::time::Duration;
 use syntect::parsing::{ParseState, SyntaxReference, SyntaxSet};
 
@@ -29,9 +27,7 @@ fn parse_file(b: &mut Bencher, file: &str) {
     let ss = SyntaxSet::load_defaults_nonewlines();
 
     let syntax = ss.find_syntax_for_file(path).unwrap().unwrap();
-    let mut f = File::open(path).unwrap();
-    let mut s = String::new();
-    f.read_to_string(&mut s).unwrap();
+    let s = std::fs::read_to_string(path).unwrap();
 
     b.iter(|| do_parse(&s, &ss, syntax));
 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -11,8 +11,6 @@ use std::collections::{HashMap, HashSet, BTreeSet};
 use std::path::Path;
 #[cfg(feature = "yaml-load")]
 use walkdir::WalkDir;
-#[cfg(feature = "yaml-load")]
-use std::io::Read;
 use std::io::{self, BufRead, BufReader};
 use std::fs::File;
 use std::mem;
@@ -91,9 +89,7 @@ pub struct SyntaxSetBuilder {
 fn load_syntax_file(p: &Path,
                     lines_include_newline: bool)
                     -> Result<SyntaxDefinition, LoadingError> {
-    let mut f = File::open(p)?;
-    let mut s = String::new();
-    f.read_to_string(&mut s)?;
+    let s = std::fs::read_to_string(p)?;
 
     SyntaxDefinition::load_from_str(
         &s,


### PR DESCRIPTION
Simplifies the code to a non-negligible extent. Note that I opted for for a fully qualified path rather than having `use` directive at the top. This not only makes the code easier to move around, but also, and more importantly, makes it simpler to use together with `cfg(feature)` directives.