### PR TITLE
Add Criterion benchmark test that includes loading assets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ name = "highlighting"
 harness = false
 
 [[bench]]
+name = "load_and_highlight"
+harness = false
+
+[[bench]]
 name = "loading"
 harness = false
 

--- a/benches/highlight_utils/mod.rs
+++ b/benches/highlight_utils/mod.rs
@@ -1,0 +1,14 @@
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme};
+use syntect::parsing::{SyntaxReference, SyntaxSet};
+
+/// Common helper for benchmarking highlighting.
+pub fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, theme: &Theme) -> usize {
+    let mut h = HighlightLines::new(syntax, theme);
+    let mut count = 0;
+    for line in s.lines() {
+        let regions = h.highlight(line, syntax_set);
+        count += regions.len();
+    }
+    count
+}

--- a/benches/load_and_highlight.rs
+++ b/benches/load_and_highlight.rs
@@ -1,0 +1,40 @@
+mod highlight_utils;
+mod utils;
+
+/// Measures the time it takes to run the whole pipeline:
+///  1. Load assets
+///  2. Parse
+///  3. Highlight
+fn run(b: &mut criterion::Bencher, file: &str) {
+    let path = utils::get_test_file_path(file);
+
+    b.iter(|| {
+        let ss = syntect::parsing::SyntaxSet::load_defaults_nonewlines();
+        let ts = syntect::highlighting::ThemeSet::load_defaults();
+
+        let syntax = ss.find_syntax_for_file(path).unwrap().unwrap();
+        let s = std::fs::read_to_string(path).unwrap();
+
+        highlight_utils::do_highlight(&s, &ss, syntax, &ts.themes["base16-ocean.dark"]);
+    })
+}
+
+fn load_and_highlight_benchmark(c: &mut criterion::Criterion) {
+    let mut group = c.benchmark_group("load_and_highlight");
+    for input in &[
+        "highlight_test.erb",
+        "InspiredGitHub.tmTheme",
+        "Ruby.sublime-syntax",
+        "parser.rs"
+    ] {
+        group.bench_with_input(format!("\"{}\"", input), input, |b, s| run(b, s));
+    }
+    group.finish();
+}
+
+criterion::criterion_group! {
+    name = benches;
+    config = criterion::Criterion::default().sample_size(50);
+    targets = load_and_highlight_benchmark
+}
+criterion::criterion_main!(benches);

--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -1,0 +1,14 @@
+/// To be able to keep the same Criterion benchmark names as before (for the
+/// `the --baseline` feature of Criterion) we use one level of indirection to
+/// map file name to file path.
+pub fn get_test_file_path(file: &str) -> &str {
+    match file {
+        "highlight_test.erb" => "testdata/highlight_test.erb",
+        "InspiredGitHub.tmTheme" => "testdata/InspiredGitHub.tmtheme/InspiredGitHub.tmTheme",
+        "Ruby.sublime-syntax" => "testdata/Packages/Ruby/Ruby.sublime-syntax",
+        "jquery.js" => "testdata/jquery.js",
+        "parser.rs" => "testdata/parser.rs",
+        "scope.rs" => "src/parsing/scope.rs",
+        _ => panic!("Unknown test file {}", file),
+    }
+}


### PR DESCRIPTION
This makes it easy to measure the impact lazy-loading will have on a complete syntect "pipeline".

This commit is designed to be cherry-pickable to the v4.6.0 tag to get a Criterion `--baseline` for the lazy-loading changes.

An upcoming PR will make existing benches make use of the helper methods that this commit adds. I will wait with that until #387 is merged however, to reduce problems with conflicts.