### PR TITLE
Update lazycell to v1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ fancy-regex = { version = "0.7", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
-lazycell = "1.0"
+lazycell = "1.3"
 bitflags = "1.0.4"
 plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }


### PR DESCRIPTION
Related to #334

This PR updates lazycell crate to the latest.