### PR TITLE
Fix crash on lazy initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ fancy-regex = { version = "0.7", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
-lazycell = "1.0"
 bitflags = "1.0.4"
 plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }
@@ -33,6 +32,7 @@ fnv = { version = "1.0", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+once_cell = "1.8"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "html_reports" ] }


### PR DESCRIPTION
Fixes #334 
Closes #390 

## Problem

Crash at https://github.com/trishume/syntect/blob/540555edafc74354e49ebc195a39439334177cb6/src/parsing/regex.rs#L73-L74

Since this rarely happens in mutli-threads environment, I couldn't trace what happened. However, logically it would be:

1. Thread1 starts `.fill()` call and acquires lock
2. Thread2 starts `.fill()` call but cannot acquire lock (since Thread1 already did it)
3. `.fill()` in Thread2 immediately returns `Err(value)` (but Thread2 ignores it by `.ok()`)
4. Thread2 calls `.borrow()`. However, at this point, the `.fill()` call in Thread1 is not completed yet. So `.borrow()` in Thread2 returns `None`
5. The `.unwrap()` call crashes
6. Thread1 finishes to set value at `.fill()`

So,

```rust
cell.fill(something).ok();
cell.borrow().unwrap();
```

is not crash-free actually.

## Solution

Using [`once_cell::sync::OnceCell`](https://docs.rs/once_cell/1.8.0/once_cell/sync/struct.OnceCell.html) instead of `lazycell::ActomicLazyCell` solves this issue.

https://docs.rs/once_cell/1.8.0/once_cell/sync/struct.OnceCell.html#method.get_or_init
 
> Many threads may call get_or_init concurrently with different initializing functions, but it is guaranteed that only one function will be executed.

I also read its implementation. Initializing cell is synchronized with a queue.

https://github.com/matklad/once_cell/blob/7b2943b3828867a58690165961424230ca423403/src/imp_std.rs#L86-L107