### PR TITLE
Bump MSRV to 1.51 to fix build with latest plist release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.46"
+  MIN_SUPPORTED_RUST_VERSION: "1.51"
   CARGO_TERM_COLOR: always
 
 jobs:


### PR DESCRIPTION
A recent release of plist bumped MSRV to 1.51 (see
https://github.com/ebarnard/rust-plist/pull/72 and discussions therein). One easy way for us to deal with that is to also bump *our* MSRV to 1.51. I can't think of why this would be a big problem, so here is a PR that does that. It fixes this build error in MSRV CI that we currently get on the master branch (https://github.com/trishume/syntect/runs/4282657925?check_suite_focus=true):

```
error: failed to parse manifest at `/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.3.5/Cargo.toml`

Caused by:
  feature `resolver` is required

  this Cargo does not support nightly features, but if you
  switch to nightly channel you can add
  `cargo-features = ["resolver"]` to enable this feature
```
Note that the build error is in time-rs, but it is plist that pulls in that dependency.