### PR TITLE
Don't print double newlines in load_defaults_newlines() sample code

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 for line in LinesWithEndings::from(s) {
     let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
-    println!("{}", escaped);
+    print!("{}", escaped);
 }
 ```
 

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -36,7 +36,7 @@ use std::path::Path;
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
 ///     let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
 ///     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
-///     println!("{}", escaped);
+///     print!("{}", escaped);
 /// }
 /// ```
 pub struct HighlightLines<'a> {
@@ -109,7 +109,7 @@ impl<'a> HighlightFile<'a> {
     /// while highlighter.reader.read_line(&mut line)? > 0 {
     ///     {
     ///         let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
-    ///         println!("{}", as_24_bit_terminal_escaped(&regions[..], true));
+    ///         print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
     ///     } // until NLL this scope is needed so we can clear the buffer after
     ///     line.clear(); // read_line appends so we need to clear between lines
     /// }


### PR DESCRIPTION
Since the lines themselves end with a newline character, the sample code needs
to use `print!()` instead of `println!()`, otherwise an extra newline character
is inserted for each line in the output.

Before PR:
![with-println](https://user-images.githubusercontent.com/115040/143492217-15eaf997-5832-4822-b682-9b854ba249c3.png)

After PR
![with-print](https://user-images.githubusercontent.com/115040/143492240-a2f89de6-a25e-4901-998a-8c31577a16b0.png)
:
