### PR TITLE
Fix feature semver violations in v4.7.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,4 +76,4 @@ jobs:
     - name: Run Xi tests
       run: |
         # Test the build configuration that Xi uses
-        cargo test --lib --no-default-features --features "assets dump-load-rs"
+        cargo test --lib --no-default-features --features "assets dump-load"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Run these tests in release mode since they're slow as heck otherwise
         cargo test --features default-fancy --no-default-features --release
-    - name: Ensure highlight works without 'plist-load' and 'yaml-load' features
+    - name: Ensure highlight works without 'yaml-load'
       run: |
         cargo run --example synhtml --no-default-features --features html,assets,dump-load,dump-create,regex-onig -- examples/synhtml.rs
     - name: make stuff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 4.7.1](https://github.com/trishume/syntect/compare/v4.7.0...v4.7.1) (2022-01-xx)
+
+- Remove 'plist-load' feature again due to semver violation. [#403](https://github.com/trishume/syntect/pull/403)
+
 ## [Version 4.7.0](https://github.com/trishume/syntect/compare/v4.6.0...v4.7.0) (2021-12-25)
 
 - Lazy-load syntaxes to significantly improve startup time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.0"
 bitflags = "1.0.4"
 plist = "1"
 bincode = { version = "1.0", optional = true }
-flate2 = { version = "1.0", optional = true, default-features = false }
+flate2 = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
@@ -47,27 +47,24 @@ pretty_assertions = "0.6"
 # will fail, choose one of each. If you are using both creation and loading,
 # your binary will be smaller if you choose the same one for each.
 
-# Pure Rust dump loading, slower than regular `dump-load`
-dump-load-rs = ["flate2/rust_backend", "bincode"]
-# Dump loading using flate2, which depends on the miniz C library.
-dump-load = ["flate2/default", "bincode"]
-# Dump creation using flate2, which depends on the miniz C library.
-dump-create = ["flate2/default", "bincode"]
-# Pure Rust dump creation, worse compressor so produces larger dumps than dump-create
-dump-create-rs = ["flate2/rust_backend", "bincode"]
+# Legacy alias for `dump-load`
+dump-load-rs = ["dump-load"]
+# Dump loading using flate2
+dump-load = ["flate2", "bincode"]
+# Dump creation using flate2
+dump-create = ["flate2", "bincode"]
+# Legacy alias for `dump-create`
+dump-create-rs = ["dump-create"]
 
 regex-fancy = ["fancy-regex"]
 regex-onig = ["onig"]
 
-# If you enable "parsing", you must also enable either "dump-load" or
-# "dump-load-rs", and "dump-create" or "dump-create-rs". Otherwise the code that
-# enables lazy-loading of syntaxes will not compile.
-parsing = ["regex-syntax", "fnv"]
+parsing = ["regex-syntax", "fnv", "dump-create", "dump-load"]
 
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
 metadata = ["parsing"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
-# For `assets` to do anything, it requires one of `dump-load-rs` or `dump-load` to be set.
+# For `assets` to do anything, it requires `dump-load` to be set.
 assets = []
 html = ["parsing"]
 # Support for parsing .sublime-syntax files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 bitflags = "1.0.4"
-plist = { version = "1", optional = true }
+plist = "1"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true, default-features = false }
 fnv = { version = "1.0", optional = true }
@@ -65,18 +65,16 @@ regex-onig = ["onig"]
 parsing = ["regex-syntax", "fnv"]
 
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
-metadata = ["parsing", "plist-load"]
+metadata = ["parsing"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
 # For `assets` to do anything, it requires one of `dump-load-rs` or `dump-load` to be set.
 assets = []
 html = ["parsing"]
-# Support for parsing .tmTheme files and .tmPreferences files
-plist-load = ["plist"]
 # Support for parsing .sublime-syntax files
 yaml-load = ["yaml-rust", "parsing"]
-default-onig = ["parsing", "assets", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-onig"]
+default-onig = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature
-default-fancy = ["parsing", "assets", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
+default-fancy = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
 default = ["default-onig"]
 
 # [profile.release]

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -111,7 +111,7 @@ pub fn from_uncompressed_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P)
 /// data that has been embedded in your own binary with the [`include_bytes!`]
 /// macro.
 #[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
-fn from_uncompressed_data<T: DeserializeOwned>(v: &[u8]) -> Result<T> {
+pub fn from_uncompressed_data<T: DeserializeOwned>(v: &[u8]) -> Result<T> {
     deserialize_from_reader_impl(v, false)
 }
 

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -13,35 +13,35 @@
 //! [`ThemeSet`]: ../highlighting/struct.ThemeSet.html
 //! [`dump_to_file`]: fn.dump_to_file.html
 use bincode::Result;
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 use bincode::deserialize_from;
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 use bincode::serialize_into;
 use std::fs::File;
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 use std::io::{BufRead};
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 use std::io::{BufWriter, Write};
-#[cfg(all(feature = "parsing", feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "parsing", feature = "assets", feature = "dump-load"))]
 use crate::parsing::SyntaxSet;
-#[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "assets", feature = "dump-load"))]
 use crate::highlighting::ThemeSet;
 use std::path::Path;
 #[cfg(feature = "dump-create")]
 use flate2::write::ZlibEncoder;
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 use flate2::bufread::ZlibDecoder;
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 use flate2::Compression;
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 use serde::Serialize;
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 use serde::de::DeserializeOwned;
 
 /// Dumps an object to the given writer in a compressed binary format
 ///
 /// The writer is encoded with the `bincode` crate and compressed with `flate2`.
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 pub fn dump_to_writer<T: Serialize, W: Write>(to_dump: &T, output: W) -> Result<()> {
     serialize_to_writer_impl(to_dump, output, true)
 }
@@ -49,7 +49,7 @@ pub fn dump_to_writer<T: Serialize, W: Write>(to_dump: &T, output: W) -> Result<
 /// Dumps an object to a binary array in the same format as [`dump_to_writer`]
 ///
 /// [`dump_to_writer`]: fn.dump_to_writer.html
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 pub fn dump_binary<T: Serialize>(o: &T) -> Vec<u8> {
     let mut v = Vec::new();
     dump_to_writer(o, &mut v).unwrap();
@@ -62,14 +62,14 @@ pub fn dump_binary<T: Serialize>(o: &T) -> Vec<u8> {
 /// the `bincode` crate and then compressed with the `flate2` crate.
 ///
 /// [`dump_to_writer`]: fn.dump_to_writer.html
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 pub fn dump_to_file<T: Serialize, P: AsRef<Path>>(o: &T, path: P) -> Result<()> {
     let out = BufWriter::new(File::create(path)?);
     dump_to_writer(o, out)
 }
 
 /// A helper function for decoding and decompressing data from a reader
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 pub fn from_reader<T: DeserializeOwned, R: BufRead>(input: R) -> Result<T> {
     deserialize_from_reader_impl(input, true)
 }
@@ -77,13 +77,13 @@ pub fn from_reader<T: DeserializeOwned, R: BufRead>(input: R) -> Result<T> {
 /// Returns a fully loaded object from a binary dump.
 ///
 /// This function panics if the dump is invalid.
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 pub fn from_binary<T: DeserializeOwned>(v: &[u8]) -> T {
     from_reader(v).unwrap()
 }
 
 /// Returns a fully loaded object from a binary dump file.
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 pub fn from_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let contents = std::fs::read(path)?;
     from_reader(&contents[..])
@@ -93,7 +93,7 @@ pub fn from_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T>
 /// itself shall not be compressed, because the data for its lazy-loaded
 /// syntaxes are already compressed. Compressing another time just results in
 /// bad performance.
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 pub fn dump_to_uncompressed_file<T: Serialize, P: AsRef<Path>>(o: &T, path: P) -> Result<()> {
     let out = BufWriter::new(File::create(path)?);
     serialize_to_writer_impl(o, out, false)
@@ -101,7 +101,7 @@ pub fn dump_to_uncompressed_file<T: Serialize, P: AsRef<Path>>(o: &T, path: P) -
 
 /// To be used when deserializing a [`SyntaxSet`] that was previously written to
 /// file using [dump_to_uncompressed_file].
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 pub fn from_uncompressed_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T> {
     let contents = std::fs::read(path)?;
     deserialize_from_reader_impl(&contents[..], false)
@@ -110,13 +110,13 @@ pub fn from_uncompressed_dump_file<T: DeserializeOwned, P: AsRef<Path>>(path: P)
 /// To be used when deserializing a [`SyntaxSet`] from raw data, for example
 /// data that has been embedded in your own binary with the [`include_bytes!`]
 /// macro.
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 pub fn from_uncompressed_data<T: DeserializeOwned>(v: &[u8]) -> Result<T> {
     deserialize_from_reader_impl(v, false)
 }
 
 /// Private low level helper function used to implement the public API.
-#[cfg(any(feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(feature = "dump-create")]
 fn serialize_to_writer_impl<T: Serialize, W: Write>(to_dump: &T, output: W, use_compression: bool) -> Result<()> {
     if use_compression {
         let mut encoder = ZlibEncoder::new(output, Compression::best());
@@ -127,7 +127,7 @@ fn serialize_to_writer_impl<T: Serialize, W: Write>(to_dump: &T, output: W, use_
 }
 
 /// Private low level helper function used to implement the public API.
-#[cfg(any(feature = "dump-load", feature = "dump-load-rs"))]
+#[cfg(feature = "dump-load")]
 fn deserialize_from_reader_impl<T: DeserializeOwned, R: BufRead>(input: R, use_compression: bool) -> Result<T> {
     if use_compression {
         let mut decoder = ZlibDecoder::new(input);
@@ -137,7 +137,7 @@ fn deserialize_from_reader_impl<T: DeserializeOwned, R: BufRead>(input: R, use_c
     }
 }
 
-#[cfg(all(feature = "parsing", feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "parsing", feature = "assets", feature = "dump-load"))]
 impl SyntaxSet {
     /// Instantiates a new syntax set from a binary dump of Sublime Text's default open source
     /// syntax definitions.
@@ -195,7 +195,7 @@ impl SyntaxSet {
     }
 }
 
-#[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "assets", feature = "dump-load"))]
 impl ThemeSet {
     /// Loads the set of default themes
     /// Currently includes (these are the keys for the map):
@@ -210,7 +210,7 @@ impl ThemeSet {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature = "yaml-load", any(feature = "dump-create", feature = "dump-create-rs"), any(feature = "dump-load", feature = "dump-load-rs")))]
+    #[cfg(all(feature = "yaml-load", feature = "dump-create", feature = "dump-load"))]
     #[test]
     fn can_dump_and_load() {
         use super::*;
@@ -225,7 +225,7 @@ mod tests {
         assert_eq!(ss.syntaxes().len(), ss2.syntaxes().len());
     }
 
-    #[cfg(all(feature = "yaml-load", any(feature = "dump-create", feature = "dump-create-rs"), any(feature = "dump-load", feature = "dump-load-rs")))]
+    #[cfg(all(feature = "yaml-load", feature = "dump-create", feature = "dump-load"))]
     #[test]
     fn dump_is_deterministic() {
         use super::*;
@@ -246,7 +246,7 @@ mod tests {
         assert_eq!(bin1, bin2);
     }
 
-    #[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+    #[cfg(all(feature = "assets", feature = "dump-load"))]
     #[test]
     fn has_default_themes() {
         use crate::highlighting::ThemeSet;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -251,7 +251,7 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
     }
 }
 
-#[cfg(all(feature = "assets", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "assets", feature = "dump-load"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -370,7 +370,7 @@ impl<'a> Highlighter<'a> {
     }
 }
 
-#[cfg(all(feature = "assets", feature = "parsing", any(feature = "dump-load", feature = "dump-load-rs")))]
+#[cfg(all(feature = "assets", feature = "parsing", feature = "dump-load"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -8,20 +8,16 @@
 //! [`ThemeSet`]: struct.ThemeSet.html
 mod highlighter;
 mod selector;
-#[cfg(feature = "plist-load")]
 pub(crate) mod settings;
 mod style;
 mod theme;
-#[cfg(feature = "plist-load")]
 mod theme_load;
 mod theme_set;
 
 pub use self::selector::*;
-#[cfg(feature = "plist-load")]
 pub use self::settings::SettingsError;
 pub use self::style::*;
 pub use self::theme::*;
-#[cfg(feature = "plist-load")]
 pub use self::theme_load::*;
 pub use self::highlighter::*;
 pub use self::theme_set::*;

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -1,5 +1,4 @@
 use super::theme::Theme;
-#[cfg(feature = "plist-load")]
 use super::settings::*;
 use super::super::LoadingError;
 use std::collections::BTreeMap;
@@ -34,7 +33,6 @@ impl ThemeSet {
     }
 
     /// Loads a theme given a path to a .tmTheme file
-    #[cfg(feature = "plist-load")]
     pub fn get_theme<P: AsRef<Path>>(path: P) -> Result<Theme, LoadingError> {
         let file = std::fs::File::open(path)?;
         let mut file = std::io::BufReader::new(file);
@@ -42,13 +40,11 @@ impl ThemeSet {
     }
 
     /// Loads a theme given a readable stream
-    #[cfg(feature = "plist-load")]
     pub fn load_from_reader<R: std::io::BufRead + std::io::Seek>(r: &mut R) -> Result<Theme, LoadingError> {
         Ok(Theme::parse_settings(read_plist(r)?)?)
     }
 
     /// Generate a `ThemeSet` from all themes in a folder
-    #[cfg(feature = "plist-load")]
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<ThemeSet, LoadingError> {
         let mut theme_set = Self::new();
         theme_set.add_from_folder(folder)?;
@@ -56,7 +52,6 @@ impl ThemeSet {
     }
 
     /// Load all the themes in the folder into this `ThemeSet`
-    #[cfg(feature = "plist-load")]
     pub fn add_from_folder<P: AsRef<Path>>(&mut self, folder: P) -> Result<(), LoadingError> {
         let paths = Self::discover_theme_paths(folder)?;
         for p in &paths {
@@ -74,7 +69,6 @@ impl ThemeSet {
 #[cfg(test)]
 mod tests {
     use crate::highlighting::{ThemeSet, Color};
-    #[cfg(feature = "plist-load")]
     #[test]
     fn can_parse_common_themes() {
         let themes = ThemeSet::load_from_folder("testdata").unwrap();

--- a/src/html.rs
+++ b/src/html.rs
@@ -518,7 +518,7 @@ pub fn start_highlighted_html_snippet(t: &Theme) -> (String, Color) {
 
 #[cfg(all(
     feature = "assets",
-    any(feature = "dump-load", feature = "dump-load-rs")
+    feature = "dump-load"
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate pretty_assertions;
 
-#[cfg(any(feature = "dump-load-rs", feature = "dump-load", feature = "dump-create", feature = "dump-create-rs"))]
+#[cfg(any(feature = "dump-load", feature = "dump-create"))]
 pub mod dumps;
 #[cfg(feature = "parsing")]
 pub mod easy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,6 @@ use std::fmt;
 use serde_json::Error as JsonError;
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 use crate::parsing::ParseSyntaxError;
-#[cfg(feature = "plist-load")]
 use crate::highlighting::{ParseThemeError, SettingsError};
 
 /// Common error type used by syntax and theme loading
@@ -66,17 +65,14 @@ pub enum LoadingError {
     #[cfg(feature = "metadata")]
     ParseMetadata(JsonError),
     /// a theme file was invalid in some way
-    #[cfg(feature = "plist-load")]
     ParseTheme(ParseThemeError),
     /// a theme's Plist syntax was invalid in some way
-    #[cfg(feature = "plist-load")]
     ReadSettings(SettingsError),
     /// A path given to a method was invalid.
     /// Possibly because it didn't reference a file or wasn't UTF-8.
     BadPath,
 }
 
-#[cfg(feature = "plist-load")]
 impl From<SettingsError> for LoadingError {
     fn from(error: SettingsError) -> LoadingError {
         LoadingError::ReadSettings(error)
@@ -89,7 +85,6 @@ impl From<IoError> for LoadingError {
     }
 }
 
-#[cfg(feature = "plist-load")]
 impl From<ParseThemeError> for LoadingError {
     fn from(error: ParseThemeError) -> LoadingError {
         LoadingError::ParseTheme(error)
@@ -127,9 +122,7 @@ impl fmt::Display for LoadingError {
             },
             #[cfg(feature = "metadata")]
             ParseMetadata(_) => write!(f, "Failed to parse JSON"),
-            #[cfg(feature = "plist-load")]
             ParseTheme(_) => write!(f, "Invalid syntax theme"),
-            #[cfg(feature = "plist-load")]
             ReadSettings(_) => write!(f, "Invalid syntax theme settings"),
             BadPath => write!(f, "Invalid path"),
         }


### PR DESCRIPTION
Fixes #402 

I ended up removing the `plist-load` feature because I see no way of keeping it around in a semver compatible and sane way. The [refactoring](https://github.com/trishume/syntect/pull/345) that made the introduction of that feature possible can we kept however, which is nice. So it should be easy to re-introduce it e.g. v5.0.0 at some later point.

I did consider making `plist-load` opt-out rather than opt-in to remain semver compatible. We could call it `no-plist-load`, and if enabled, the unneeded code could be excluded from the build. I think that is too unergonomic and counter-intuitive however, so I think it's better to simply remove it for now.

I also noticed that `dump-create-rs` and `dump-create` are the same since 2 years, since 2 years ago the default flate2 backend was changed to Rust. See https://github.com/rust-lang/flate2-rs/commit/c479d064e2. So there is no need to make a distinction any longer. This allows us to remain semver compatible with regards to the lazy-loading changes since now `parsing` can depend on `dump-create` and `dump-load` directly. I did not bother adding an entry about that in CHANGELOG.md since there is no semantic change for clients.

I could reproduce the build error in bat locally, and have confirmed that these changes fixes the build error.

I think it would be a good idea to not rush this PR in. Let's let it sit here for at least a few days so we have time to think this through and perhaps test some more. Any help with testing would be greatly appreciated.

(Oh, and I also noticed that I forgot to add a `pub` to an API, so I fixed this too in this PR.)