### PR TITLE
Use Rust Cache Action to speed up builds.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - uses: Swatinem/rust-cache@v1
     - name: Build
       run: |
         cargo build


### PR DESCRIPTION
With caching, the time for the build step goes down from 1m 12s to 7s, as dependencies don't need to be rebuilt.

Before: https://github.com/sourcegraph/syntect/runs/4657761926
After: https://github.com/sourcegraph/syntect/runs/4658377802

In the After build, you'll see that the CI takes 3m 37s total, so this is roughly a ~25% improvement. 😄

Mirrors https://github.com/sourcegraph/syntect/pull/6