### PR TITLE
For 5.0.0: Rename `HighlightLines::highlight()` to `highlight_line()`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ let syntax = ps.find_syntax_by_extension("rs").unwrap();
 let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 for line in LinesWithEndings::from(s) {
-    let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
+    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
     print!("{}", escaped);
 }

--- a/benches/highlight_utils/mod.rs
+++ b/benches/highlight_utils/mod.rs
@@ -7,7 +7,7 @@ pub fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, t
     let mut h = HighlightLines::new(syntax, theme);
     let mut count = 0;
     for line in s.lines() {
-        let regions = h.highlight(line, syntax_set);
+        let regions = h.highlight_line(line, syntax_set);
         count += regions.len();
     }
     count

--- a/examples/latex-demo.rs
+++ b/examples/latex-demo.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
     for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-        let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
+        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
         let escaped = as_latex_escaped(&ranges[..]);
         println!("\n{:?}", line);
         println!("\n{}", escaped);

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -45,7 +45,7 @@ fn main() {
             let mut highlighter = HighlightFile::new(filename, &syntax_set, theme).unwrap();
 
             for line in contents {
-                for region in highlighter.highlight_lines.highlight(line, &syntax_set) {
+                for region in highlighter.highlight_lines.highlight_line(line, &syntax_set) {
                     regions.push(region);
                 }
             }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -103,7 +103,7 @@ fn main() {
                 }
 
                 {
-                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
+                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss);
                     print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
                 }
                 line.clear();

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -56,6 +56,11 @@ impl<'a> HighlightLines<'a> {
         }
     }
 
+    #[deprecated(since="5.0.0", note="Renamed to `highlight_line` to make it clear it should be passed a single line at a time")]
+    pub fn highlight<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)> {
+        self.highlight_line(line, syntax_set)
+    }
+
     /// Highlights a line of a file
     pub fn highlight_line<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)> {
         // println!("{}", self.highlight_state.path);

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -34,7 +34,7 @@ use std::path::Path;
 /// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 /// let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-///     let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
+///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
 ///     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
 ///     print!("{}", escaped);
 /// }
@@ -57,7 +57,7 @@ impl<'a> HighlightLines<'a> {
     }
 
     /// Highlights a line of a file
-    pub fn highlight<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)> {
+    pub fn highlight_line<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)> {
         // println!("{}", self.highlight_state.path);
         let ops = self.parse_state.parse_line(line, syntax_set);
         // use util::debug_print_ops;
@@ -108,7 +108,7 @@ impl<'a> HighlightFile<'a> {
     /// let mut line = String::new();
     /// while highlighter.reader.read_line(&mut line)? > 0 {
     ///     {
-    ///         let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
+    ///         let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss);
     ///         print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
     ///     } // until NLL this scope is needed so we can clear the buffer after
     ///     line.clear(); // read_line appends so we need to clear between lines
@@ -132,7 +132,7 @@ impl<'a> HighlightFile<'a> {
     /// let mut highlighter = HighlightFile::new("testdata/highlight_test.erb", &ss, &ts.themes["base16-ocean.dark"]).unwrap();
     /// for maybe_line in highlighter.reader.lines() {
     ///     let line = maybe_line.unwrap();
-    ///     let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight(&line, &ss);
+    ///     let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss);
     ///     println!("{}", as_24_bit_terminal_escaped(&regions[..], true));
     /// }
     /// ```
@@ -265,7 +265,7 @@ mod tests {
         let ts = ThemeSet::load_defaults();
         let syntax = ss.find_syntax_by_extension("rs").unwrap();
         let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
-        let ranges = h.highlight("pub struct Wow { hi: u64 }", &ss);
+        let ranges = h.highlight_line("pub struct Wow { hi: u64 }", &ss);
         assert!(ranges.len() > 4);
     }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -273,7 +273,7 @@ pub fn highlighted_html_for_string(
     let (mut output, bg) = start_highlighted_html_snippet(theme);
 
     for line in LinesWithEndings::from(s) {
-        let regions = highlighter.highlight(line, ss);
+        let regions = highlighter.highlight_line(line, ss);
         append_highlighted_html_for_styled_line(
             &regions[..],
             IncludeBackground::IfDifferent(bg),
@@ -301,7 +301,7 @@ pub fn highlighted_html_for_file<P: AsRef<Path>>(
     let mut line = String::new();
     while highlighter.reader.read_line(&mut line)? > 0 {
         {
-            let regions = highlighter.highlight_lines.highlight(&line, ss);
+            let regions = highlighter.highlight_lines.highlight_line(&line, ss);
             append_highlighted_html_for_styled_line(
                 &regions[..],
                 IncludeBackground::IfDifferent(bg),
@@ -432,7 +432,7 @@ fn write_css_color(s: &mut String, c: Color) {
 ///
 /// let syntax = ps.find_syntax_by_name("Ruby").unwrap();
 /// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
-/// let regions = h.highlight("5", &ps);
+/// let regions = h.highlight_line("5", &ps);
 /// let html = styled_line_to_highlighted_html(&regions[..], IncludeBackground::No);
 /// assert_eq!(html, "<span style=\"color:#d08770;\">5</span>");
 /// ```

--- a/src/util.rs
+++ b/src/util.rs
@@ -79,7 +79,7 @@ const LATEX_REPLACE: [(&str, &str); 3] = [
 ///
 /// let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-///     let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
+///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
 ///     let escaped = as_latex_escaped(&ranges[..]);
 ///     println!("{}", escaped);
 /// }


### PR DESCRIPTION
To make it clear that the function takes one line at a time.

This require a semver major bump, but we need to do that anyway due to the
syntax lazy-loading changes.

Fixes #314
