### PR TITLE
For 5.0.0: Bring back `plist-load` feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         # Run these tests in release mode since they're slow as heck otherwise
         cargo test --features default-fancy --no-default-features --release
-    - name: Ensure highlight works without 'yaml-load'
+    - name: Ensure highlight works without 'plist-load' and 'yaml-load' features
       run: |
         cargo run --example synhtml --no-default-features --features html,assets,dump-load,dump-create,regex-onig -- examples/synhtml.rs
     - name: make stuff

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 bitflags = "1.0.4"
-plist = "1"
+plist = { version = "1", optional = true }
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }
@@ -62,16 +62,18 @@ regex-onig = ["onig"]
 parsing = ["regex-syntax", "fnv", "dump-create", "dump-load"]
 
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
-metadata = ["parsing"]
+metadata = ["parsing", "plist-load"]
 # The `assets` feature enables inclusion of the default theme and syntax packages.
 # For `assets` to do anything, it requires `dump-load` to be set.
 assets = []
 html = ["parsing"]
+# Support for parsing .tmTheme files and .tmPreferences files
+plist-load = ["plist"]
 # Support for parsing .sublime-syntax files
 yaml-load = ["yaml-rust", "parsing"]
-default-onig = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
+default-onig = ["parsing", "assets", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature
-default-fancy = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
+default-fancy = ["parsing", "assets", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
 default = ["default-onig"]
 
 # [profile.release]

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -8,16 +8,20 @@
 //! [`ThemeSet`]: struct.ThemeSet.html
 mod highlighter;
 mod selector;
+#[cfg(feature = "plist-load")]
 pub(crate) mod settings;
 mod style;
 mod theme;
+#[cfg(feature = "plist-load")]
 mod theme_load;
 mod theme_set;
 
 pub use self::selector::*;
+#[cfg(feature = "plist-load")]
 pub use self::settings::SettingsError;
 pub use self::style::*;
 pub use self::theme::*;
+#[cfg(feature = "plist-load")]
 pub use self::theme_load::*;
 pub use self::highlighter::*;
 pub use self::theme_set::*;

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -1,4 +1,5 @@
 use super::theme::Theme;
+#[cfg(feature = "plist-load")]
 use super::settings::*;
 use super::super::LoadingError;
 use std::collections::BTreeMap;
@@ -33,6 +34,7 @@ impl ThemeSet {
     }
 
     /// Loads a theme given a path to a .tmTheme file
+    #[cfg(feature = "plist-load")]
     pub fn get_theme<P: AsRef<Path>>(path: P) -> Result<Theme, LoadingError> {
         let file = std::fs::File::open(path)?;
         let mut file = std::io::BufReader::new(file);
@@ -40,11 +42,13 @@ impl ThemeSet {
     }
 
     /// Loads a theme given a readable stream
+    #[cfg(feature = "plist-load")]
     pub fn load_from_reader<R: std::io::BufRead + std::io::Seek>(r: &mut R) -> Result<Theme, LoadingError> {
         Ok(Theme::parse_settings(read_plist(r)?)?)
     }
 
     /// Generate a `ThemeSet` from all themes in a folder
+    #[cfg(feature = "plist-load")]
     pub fn load_from_folder<P: AsRef<Path>>(folder: P) -> Result<ThemeSet, LoadingError> {
         let mut theme_set = Self::new();
         theme_set.add_from_folder(folder)?;
@@ -52,6 +56,7 @@ impl ThemeSet {
     }
 
     /// Load all the themes in the folder into this `ThemeSet`
+    #[cfg(feature = "plist-load")]
     pub fn add_from_folder<P: AsRef<Path>>(&mut self, folder: P) -> Result<(), LoadingError> {
         let paths = Self::discover_theme_paths(folder)?;
         for p in &paths {
@@ -69,6 +74,7 @@ impl ThemeSet {
 #[cfg(test)]
 mod tests {
     use crate::highlighting::{ThemeSet, Color};
+    #[cfg(feature = "plist-load")]
     #[test]
     fn can_parse_common_themes() {
         let themes = ThemeSet::load_from_folder("testdata").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ use std::fmt;
 use serde_json::Error as JsonError;
 #[cfg(all(feature = "yaml-load", feature = "parsing"))]
 use crate::parsing::ParseSyntaxError;
+#[cfg(feature = "plist-load")]
 use crate::highlighting::{ParseThemeError, SettingsError};
 
 /// Common error type used by syntax and theme loading
@@ -65,14 +66,17 @@ pub enum LoadingError {
     #[cfg(feature = "metadata")]
     ParseMetadata(JsonError),
     /// a theme file was invalid in some way
+    #[cfg(feature = "plist-load")]
     ParseTheme(ParseThemeError),
     /// a theme's Plist syntax was invalid in some way
+    #[cfg(feature = "plist-load")]
     ReadSettings(SettingsError),
     /// A path given to a method was invalid.
     /// Possibly because it didn't reference a file or wasn't UTF-8.
     BadPath,
 }
 
+#[cfg(feature = "plist-load")]
 impl From<SettingsError> for LoadingError {
     fn from(error: SettingsError) -> LoadingError {
         LoadingError::ReadSettings(error)
@@ -85,6 +89,7 @@ impl From<IoError> for LoadingError {
     }
 }
 
+#[cfg(feature = "plist-load")]
 impl From<ParseThemeError> for LoadingError {
     fn from(error: ParseThemeError) -> LoadingError {
         LoadingError::ParseTheme(error)
@@ -122,7 +127,9 @@ impl fmt::Display for LoadingError {
             },
             #[cfg(feature = "metadata")]
             ParseMetadata(_) => write!(f, "Failed to parse JSON"),
+            #[cfg(feature = "plist-load")]
             ParseTheme(_) => write!(f, "Invalid syntax theme"),
+            #[cfg(feature = "plist-load")]
             ReadSettings(_) => write!(f, "Invalid syntax theme settings"),
             BadPath => write!(f, "Invalid path"),
         }


### PR DESCRIPTION
Now that we need to do a major bump anyway due to the lazy-loading changes, we
can go ahead and bring back this feature that was recently removed due to semver
incompatibilities.

This is a pure code revert of

  ec8759934a4 "Remove `plist-load` feature (but keep new code structure)"