### PR TITLE
Fix all current lint with Rust 1.57

### DIFF
--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -82,7 +82,7 @@ fn main() {
             .unwrap_or_else(|| "base16-ocean.dark".to_string());
 
         let theme = ts.themes.get(&theme_file)
-            .map(|t| Cow::Borrowed(t))
+            .map(Cow::Borrowed)
             .unwrap_or_else(|| Cow::Owned(load_theme(&theme_file, matches.opt_present("cache-theme"))));
 
         for src in &matches.free[..] {

--- a/src/html.rs
+++ b/src/html.rs
@@ -447,7 +447,7 @@ pub fn styled_line_to_highlighted_html(v: &[(Style, &str)], bg: IncludeBackgroun
 pub fn append_highlighted_html_for_styled_line(
     v: &[(Style, &str)],
     bg: IncludeBackground,
-    mut s: &mut String,
+    s: &mut String,
 ) {
     let mut prev_style: Option<&Style> = None;
     for &(ref style, text) in v.iter() {
@@ -471,7 +471,7 @@ pub fn append_highlighted_html_for_styled_line(
             };
             if include_bg {
                 write!(s, "background-color:").unwrap();
-                write_css_color(&mut s, style.background);
+                write_css_color(s, style.background);
                 write!(s, ";").unwrap();
             }
             if style.font_style.contains(FontStyle::UNDERLINE) {
@@ -484,7 +484,7 @@ pub fn append_highlighted_html_for_styled_line(
                 write!(s, "font-style:italic;").unwrap();
             }
             write!(s, "color:").unwrap();
-            write_css_color(&mut s, style.foreground);
+            write_css_color(s, style.foreground);
             write!(s, ";\">{}", Escape(text)).unwrap();
         }
     }

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -486,12 +486,12 @@ mod tests {
         let indent_ctx = ps.metadata.metadata_for_scope(&rust_scopes);
 
         assert_eq!(indent_ctx.items.len(), 1, "failed to load rust metadata");
-        assert_eq!(indent_ctx.increase_indent("struct This {"), true);
-        assert_eq!(indent_ctx.increase_indent("struct This }"), false);
-        assert_eq!(indent_ctx.decrease_indent("     }"), true);
-        assert_eq!(indent_ctx.decrease_indent("struct This {"), false);
-        assert_eq!(indent_ctx.decrease_indent("struct This {}"), false);
-        assert_eq!(indent_ctx.increase_indent("struct This {}"), false);
+        assert!(indent_ctx.increase_indent("struct This {"));
+        assert!(!indent_ctx.increase_indent("struct This }"));
+        assert!(indent_ctx.decrease_indent("     }"));
+        assert!(!indent_ctx.decrease_indent("struct This {"));
+        assert!(!indent_ctx.decrease_indent("struct This {}"));
+        assert!(!indent_ctx.increase_indent("struct This {}"));
 
     }
 }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -599,7 +599,7 @@ impl SyntaxSetBuilder {
                         context.prototype = Some(*prototype_id);
                     }
                 }
-                Self::link_context(&mut context, syntax_index, &all_context_ids, &syntaxes);
+                Self::link_context(context, syntax_index, &all_context_ids, &syntaxes);
                 
                 if context.uses_backrefs {
                     found_more_backref_includes = true;

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -868,7 +868,7 @@ mod tests {
         assert_eq!(defn.scope, Scope::new("source.c").unwrap());
         let exts_empty: Vec<String> = Vec::new();
         assert_eq!(defn.file_extensions, exts_empty);
-        assert_eq!(defn.hidden, false);
+        assert!(!defn.hidden);
         assert!(defn.variables.is_empty());
         let defn2: SyntaxDefinition =
             SyntaxDefinition::load_from_str("
@@ -909,7 +909,7 @@ mod tests {
         assert_eq!(defn2.scope, top_level_scope);
         let exts: Vec<String> = vec![String::from("c"), String::from("h")];
         assert_eq!(defn2.file_extensions, exts);
-        assert_eq!(defn2.hidden, true);
+        assert!(defn2.hidden);
         assert_eq!(defn2.variables.get("ident").unwrap(), "[QY]+");
 
         let n: Vec<Scope> = Vec::new();
@@ -918,7 +918,7 @@ mod tests {
         let main = &defn2.contexts["main"];
         assert_eq!(main.meta_content_scope, vec![top_level_scope]);
         assert_eq!(main.meta_scope, n);
-        assert_eq!(main.meta_include_prototype, true);
+        assert!(main.meta_include_prototype);
 
         assert_eq!(defn2.contexts["__main"].meta_content_scope, n);
         assert_eq!(defn2.contexts["__start"].meta_content_scope, vec![top_level_scope]);


### PR DESCRIPTION
I prefer to keep lints at a minimum to make it easy to see when new ones are introduced.

I would be happy to upgrade our CI check to reject lint warnings and not only lint errors like we have today, if that would be OK.