### PR TITLE
Mention Broot in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -237,7 +237,8 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [tokio-cassandra](https://github.com/nhellwig/tokio-cassandra), CQL shell in Rust, uses `syntect` for shell colouring.
 - [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
 - [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
-- [The Way](https://github.com/out-of-cheese-error/the-way), A code snippets manager for your terminal that uses `syntect`for highlighting.
+- [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
+- [Broot](https://dystroy.org/broot), a terminal file manager, ises `syntect` for file previews
 
 
 ## License and Acknowledgements

--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
 - [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
-- [Broot](https://dystroy.org/broot), a terminal file manager, ises `syntect` for file previews
+- [Broot](https://dystroy.org/broot), a terminal file manager, uses `syntect` for file previews
 
 
 ## License and Acknowledgements

--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
 - [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
-- [Broot](https://dystroy.org/broot), a terminal file manager, uses `syntect` for file previews
+- [Broot](https://github.com/Canop/broot), a terminal file manager, uses `syntect` for file previews
 
 
 ## License and Acknowledgements

--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
 - [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
-- [Broot](https://github.com/Canop/broot), a terminal file manager, uses `syntect` for file previews
+- [Broot](https://github.com/Canop/broot), a terminal file manager, uses `syntect` for file previews.
 
 
 ## License and Acknowledgements


### PR DESCRIPTION
Some notes:

* tokio-cassandra appears to have been removed from GitHub, the link should probably be too
* the "approximate order by how long they've been using `syntect`" seems very off here, especially regarding the creation dates of the various repositories. Maybe just alpha sort ?