### PR TITLE
Bump `plist` to 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = "2.0"
 regex-syntax = { version = "0.6", optional = true }
 lazy_static = "1.0"
 bitflags = "1.0.4"
-plist = "1"
+plist = "1.3"
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }


### PR DESCRIPTION
The commit where `plist` stops depending on `chrono` is https://github.com/ebarnard/rust-plist/commit/9ed64da1cc52ba766ae9ba84eefa6edffc31c90a, which was released in 1.3.0. So set that as the minimum version.

As a reminder, here is how cargo interprets semver strings: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

Closes #385