### PR TITLE
For 5.0.0: `ContextReference`: Mark as `#[non_exhaustive]`

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -103,17 +103,23 @@ pub struct MatchPattern {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum ContextReference {
+    #[non_exhaustive]
     Named(String),
+    #[non_exhaustive]
     ByScope {
         scope: Scope,
         sub_context: Option<String>,
     },
+    #[non_exhaustive]
     File {
         name: String,
         sub_context: Option<String>,
     },
+    #[non_exhaustive]
     Inline(String),
+    #[non_exhaustive]
     Direct(ContextId),
 }
 


### PR DESCRIPTION
Here is an adventurous PR.

This is so that we can add variants and variant fields without semver breakage. This
will likely be needed to fall back to "Plain Text" if embeds are missing. See
prototype code at https://github.com/Enselic/syntect/pull/6 and discussion at https://github.com/sharkdp/bat/issues/915#issuecomment-950274207. It would be nice to be able to fix that without requiring a major bump in syntect, and this PR should make that possible, with some luck.

If this gets merged for 5.0.0 I will add a CHANGELOG.md entry for it in #409 later (same with my other PRs)