### PR TITLE
For 5.0.0: Split up feature `assets` into `default-syntaxes` and `default-themes`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,7 +73,3 @@ jobs:
     - name: Run tests without default features
       run: |
         cargo test --lib --no-default-features
-    - name: Run Xi tests
-      run: |
-        # Test the build configuration that Xi uses
-        cargo test --lib --no-default-features --features "assets dump-load"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,12 @@ jobs:
     - name: Ensure highlight works without 'yaml-load'
       run: |
         cargo run --example synhtml --no-default-features --features html,default-syntaxes,default-themes,regex-onig -- examples/synhtml.rs
+    - name: Run tests with 'default-syntaxes' but without 'default-themes'
+      run: |
+        cargo test --lib --example synstats --no-default-features --features default-syntaxes,yaml-load,regex-onig
+    - name: Run tests without default features
+      run: |
+        cargo test --lib --no-default-features
     - name: make stuff
       run: |
         make assets
@@ -70,6 +76,3 @@ jobs:
     - name: Docs
       run: |
         cargo doc
-    - name: Run tests without default features
-      run: |
-        cargo test --lib --no-default-features

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
         cargo test --features default-fancy --no-default-features --release
     - name: Ensure highlight works without 'yaml-load'
       run: |
-        cargo run --example synhtml --no-default-features --features html,assets,dump-load,dump-create,regex-onig -- examples/synhtml.rs
+        cargo run --example synhtml --no-default-features --features html,default-syntaxes,default-themes,regex-onig -- examples/synhtml.rs
     - name: make stuff
       run: |
         make assets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,15 +63,18 @@ parsing = ["regex-syntax", "fnv", "dump-create", "dump-load"]
 
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
 metadata = ["parsing"]
-# The `assets` feature enables inclusion of the default theme and syntax packages.
-# For `assets` to do anything, it requires `dump-load` to be set.
-assets = []
+
+# Enables inclusion of the default theme packages.
+default-syntaxes = ["parsing", "dump-load"]
+# Enables inclusion of the default syntax packages.
+default-themes = ["dump-load"]
+
 html = ["parsing"]
 # Support for parsing .sublime-syntax files
 yaml-load = ["yaml-rust", "parsing"]
-default-onig = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
+default-onig = ["parsing", "default-syntaxes", "default-themes", "html", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature
-default-fancy = ["parsing", "assets", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
+default-fancy = ["parsing", "default-syntaxes", "default-themes", "html", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
 default = ["default-onig"]
 
 # [profile.release]

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -22,9 +22,9 @@ use std::fs::File;
 use std::io::{BufRead};
 #[cfg(feature = "dump-create")]
 use std::io::{BufWriter, Write};
-#[cfg(all(feature = "parsing", feature = "assets", feature = "dump-load"))]
+#[cfg(all(feature = "default-syntaxes"))]
 use crate::parsing::SyntaxSet;
-#[cfg(all(feature = "assets", feature = "dump-load"))]
+#[cfg(all(feature = "default-themes"))]
 use crate::highlighting::ThemeSet;
 use std::path::Path;
 #[cfg(feature = "dump-create")]
@@ -137,7 +137,7 @@ fn deserialize_from_reader_impl<T: DeserializeOwned, R: BufRead>(input: R, use_c
     }
 }
 
-#[cfg(all(feature = "parsing", feature = "assets", feature = "dump-load"))]
+#[cfg(feature = "default-syntaxes")]
 impl SyntaxSet {
     /// Instantiates a new syntax set from a binary dump of Sublime Text's default open source
     /// syntax definitions.
@@ -195,7 +195,7 @@ impl SyntaxSet {
     }
 }
 
-#[cfg(all(feature = "assets", feature = "dump-load"))]
+#[cfg(all(feature = "default-themes"))]
 impl ThemeSet {
     /// Loads the set of default themes
     /// Currently includes (these are the keys for the map):
@@ -210,7 +210,7 @@ impl ThemeSet {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature = "yaml-load", feature = "dump-create", feature = "dump-load"))]
+    #[cfg(all(feature = "yaml-load", feature = "dump-create", feature = "dump-load", feature = "parsing"))]
     #[test]
     fn can_dump_and_load() {
         use super::*;
@@ -246,7 +246,7 @@ mod tests {
         assert_eq!(bin1, bin2);
     }
 
-    #[cfg(all(feature = "assets", feature = "dump-load"))]
+    #[cfg(feature = "default-themes")]
     #[test]
     fn has_default_themes() {
         use crate::highlighting::ThemeSet;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -251,14 +251,15 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
     }
 }
 
-#[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::parsing::{SyntaxSet, ParseState, ScopeStack};
+    #[cfg(feature = "default-themes")]
     use crate::highlighting::ThemeSet;
     use std::str::FromStr;
 
+    #[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
     #[test]
     fn can_highlight_lines() {
         let ss = SyntaxSet::load_defaults_nonewlines();
@@ -269,6 +270,7 @@ mod tests {
         assert!(ranges.len() > 4);
     }
 
+    #[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
     #[test]
     fn can_highlight_file() {
         let ss = SyntaxSet::load_defaults_nonewlines();
@@ -279,6 +281,7 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(feature = "default-syntaxes")]
     #[test]
     fn can_find_regions() {
         let ss = SyntaxSet::load_defaults_nonewlines();
@@ -303,6 +306,7 @@ mod tests {
         assert_eq!(token_count, 5);
     }
 
+    #[cfg(feature = "default-syntaxes")]
     #[test]
     fn can_find_regions_with_trailing_newline() {
         let ss = SyntaxSet::load_defaults_newlines();

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -251,7 +251,7 @@ impl<'a> Iterator for ScopeRegionIterator<'a> {
     }
 }
 
-#[cfg(all(feature = "assets", feature = "dump-load"))]
+#[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -370,7 +370,7 @@ impl<'a> Highlighter<'a> {
     }
 }
 
-#[cfg(all(feature = "assets", feature = "parsing", feature = "dump-load"))]
+#[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/html.rs
+++ b/src/html.rs
@@ -517,8 +517,8 @@ pub fn start_highlighted_html_snippet(t: &Theme) -> (String, Color) {
 }
 
 #[cfg(all(
-    feature = "assets",
-    feature = "dump-load"
+    feature = "default-syntaxes",
+    feature = "default-themes",
 ))]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Also specify hard dependencies directly in Cargo.toml instead of asking users to manually enable them. This allows us to simplify cfg directives.

Fixes #310

This will conflict with #407, but that should not affect code review, and I prefer getting this reviewed early over not having to sort out conflicts. The conflicts shouldn't be that bad.