### PR TITLE
Implement `Error` and `Display` for all error enums by using `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 once_cell = "1.8"
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "html_reports" ] }

--- a/src/highlighting/settings.rs
+++ b/src/highlighting/settings.rs
@@ -13,9 +13,10 @@ pub trait ParseSettings: Sized {
 }
 
 /// An error parsing a settings file
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SettingsError {
     /// Incorrect Plist syntax
+    #[error("Incorrect Plist syntax: {0}")]
     Plist(PlistError),
 }
 

--- a/src/highlighting/settings.rs
+++ b/src/highlighting/settings.rs
@@ -14,6 +14,7 @@ pub trait ParseSettings: Sized {
 
 /// An error parsing a settings file
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SettingsError {
     /// Incorrect Plist syntax
     #[error("Incorrect Plist syntax: {0}")]

--- a/src/highlighting/theme_load.rs
+++ b/src/highlighting/theme_load.rs
@@ -11,27 +11,34 @@ use crate::parsing::ParseScopeError;
 
 use self::ParseThemeError::*;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ParseThemeError {
+    #[error("Incorrect underline option")]
     IncorrectUnderlineOption,
+    #[error("Incorrect font style: {0}")]
     IncorrectFontStyle(String),
+    #[error("Incorrect color")]
     IncorrectColor,
+    #[error("Incorrect syntax")]
     IncorrectSyntax,
+    #[error("Incorrect settings")]
     IncorrectSettings,
+    #[error("Undefined settings")]
     UndefinedSettings,
+    #[error("Undefined scope settings: {0}")]
     UndefinedScopeSettings(String),
+    #[error("Color sheme scope is not object")]
     ColorShemeScopeIsNotObject,
+    #[error("Color sheme settings is not object")]
     ColorShemeSettingsIsNotObject,
+    #[error("Scope selector is not string: {0}")]
     ScopeSelectorIsNotString(String),
+    #[error("Duplicate settings")]
     DuplicateSettings,
-    ScopeParse(ParseScopeError),
+    #[error("Scope parse error: {0}")]
+    ScopeParse(#[from] ParseScopeError),
 }
 
-impl From<ParseScopeError> for ParseThemeError {
-    fn from(error: ParseScopeError) -> ParseThemeError {
-        ScopeParse(error)
-    }
-}
 
 impl FromStr for UnderlineOption {
     type Err = ParseThemeError;

--- a/src/highlighting/theme_load.rs
+++ b/src/highlighting/theme_load.rs
@@ -12,6 +12,7 @@ use crate::parsing::ParseScopeError;
 use self::ParseThemeError::*;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ParseThemeError {
     #[error("Incorrect underline option")]
     IncorrectUnderlineOption,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ use crate::highlighting::{ParseThemeError, SettingsError};
 
 /// Common error type used by syntax and theme loading
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum LoadingError {
     /// error finding all the files in a directory
     #[error("error finding all the files in a directory: {0}")]

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -49,6 +49,7 @@ pub struct Scope {
 
 /// Not all strings are valid scopes
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ParseScopeError {
     /// Due to a limitation of the current optimized internal representation
     /// scopes can be at most 8 atoms long

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -48,13 +48,15 @@ pub struct Scope {
 }
 
 /// Not all strings are valid scopes
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ParseScopeError {
     /// Due to a limitation of the current optimized internal representation
     /// scopes can be at most 8 atoms long
+    #[error("Too long scope. Scopes can be at most 8 atoms long.")]
     TooLong,
     /// The internal representation uses 16 bits per atom, so if all scopes ever
     /// used by the program have more than 2^16-2 atoms, things break
+    #[error("Too many atoms. Max 2^16-2 atoms allowed.")]
     TooManyAtoms,
 }
 

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -102,7 +102,7 @@ fn load_syntax_file(p: &Path,
         lines_include_newline,
         p.file_stem().and_then(|x| x.to_str()),
     )
-    .map_err(|e| LoadingError::ParseSyntax(e, Some(format!("{}", p.display()))))
+    .map_err(|e| LoadingError::ParseSyntax(e, format!("{}", p.display())))
 }
 
 impl Clone for SyntaxSet {

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::ops::DerefMut;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ParseSyntaxError {
     /// Invalid YAML file syntax, or at least something yaml_rust can't handle
     #[error("Invalid YAML file syntax: {0}")]

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -1,0 +1,86 @@
+use std::{
+    error::Error,
+    fmt::Display,
+    io::{Error as IoError, ErrorKind},
+};
+
+use syntect::{
+    parsing::{ParseScopeError, ParseSyntaxError},
+    LoadingError,
+};
+
+#[test]
+fn loading_error_bad_path_display() {
+    assert_display(LoadingError::BadPath, "Invalid path");
+}
+
+#[test]
+fn loading_error_parse_syntax_display() {
+    assert_display(
+        LoadingError::ParseSyntax(
+            ParseSyntaxError::MissingMandatoryKey("main"),
+            String::from("file.sublime-syntax"),
+        ),
+        "file.sublime-syntax: Missing mandatory key in YAML file: main",
+    );
+}
+
+#[test]
+fn loading_error_io_source() {
+    let io_error_source = IoError::new(ErrorKind::Other, "this is an error string");
+    assert_display(
+        LoadingError::Io(io_error_source).source().unwrap(),
+        "this is an error string",
+    );
+}
+
+#[test]
+fn parse_syntax_error_missing_mandatory_key_display() {
+    assert_display(
+        ParseSyntaxError::MissingMandatoryKey("mandatory_key"),
+        "Missing mandatory key in YAML file: mandatory_key",
+    );
+}
+
+#[test]
+fn parse_syntax_error_regex_compile_error_display() {
+    assert_display(
+        ParseSyntaxError::RegexCompileError("[a-Z]".to_owned(), LoadingError::BadPath.into()),
+        "Error while compiling regex '[a-Z]': Invalid path",
+    );
+}
+
+#[test]
+fn parse_scope_error_display() {
+    assert_display(
+        ParseScopeError::TooLong,
+        "Too long scope. Scopes can be at most 8 atoms long.",
+    )
+}
+
+#[test]
+fn parse_syntax_error_regex_compile_error_source() {
+    let error = ParseSyntaxError::RegexCompileError(
+        "[[[[[[[[[[[[[[[".to_owned(),
+        LoadingError::BadPath.into(),
+    );
+    assert_display(error.source().unwrap(), "Invalid path");
+}
+
+#[test]
+fn loading_error_parse_syntax_source() {
+    let error = LoadingError::ParseSyntax(
+        ParseSyntaxError::RegexCompileError("[a-Z]".to_owned(), LoadingError::BadPath.into()),
+        String::from("any-file.sublime-syntax"),
+    );
+    assert_display(
+        error.source().unwrap(),
+        "Error while compiling regex '[a-Z]': Invalid path",
+    )
+}
+
+/// Helper to assert that a given implementation of [Display] generates the
+/// expected string.
+fn assert_display(display: impl Display, expected_display: &str) {
+    assert_eq!(format!("{}", display), String::from(expected_display));
+}


### PR DESCRIPTION
Also do some minor tweaks to the way errors are represented, and add basic integration tests for errors, to give a feel for how the errors behave. In general the backwards compatibility for clients should be good. As the [docs](https://docs.rs/thiserror/latest/thiserror/) for `thiserror` states (emphasis mine):

> Thiserror deliberately does not appear in your public API. You get the same thing as if you had written an implementation of std::error::Error by hand, and **switching from handwritten impls to thiserror or vice versa is not a breaking change.**

I.e. the code I remove should be implemented by the new `Error` derive.

Also mark all error enums as `#[non_exhaustive]` so we can add new error variants without semver breakage in the future.

Fixes #94

FWIW, `bat` has been using `thiserror` for [5 months](https://github.com/sharkdp/bat/pull/1820) without any issues so far.
