### PR TITLE
Bump MSRV to 1.53 to fix build with latest `time` release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.51"
+  MIN_SUPPORTED_RUST_VERSION: "1.53"
   CARGO_TERM_COLOR: always
 
 jobs:


### PR DESCRIPTION
The [time crate](https://github.com/time-rs/time) says

> The time crate is guaranteed to compile with any release of rustc from the past six months.

and the [release notes](https://github.com/time-rs/time/blob/main/CHANGELOG.md) for the latest releases made 2 days ago says

> The minimum supported Rust version is now 1.53.0.

This all sounds reasonable to me, so here is a PR to bump our MSRV.

This PR is made in response to [this](https://github.com/trishume/syntect/pull/419#issuecomment-1019401070) comment. I would advise against the mentioned alternative, to put an upper limit on `time`, because soon that will conflict some with other crate that puts an incompatible lower limit on `time`. So it's better to just bump MSRV if that is a viable option, which I think is the case here.