### PR TITLE
Make `highlight_line()` and `parse_line()` return `Result`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ let syntax = ps.find_syntax_by_extension("rs").unwrap();
 let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 for line in LinesWithEndings::from(s) {
-    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
     print!("{}", escaped);
 }

--- a/benches/highlight_utils/mod.rs
+++ b/benches/highlight_utils/mod.rs
@@ -7,7 +7,7 @@ pub fn do_highlight(s: &str, syntax_set: &SyntaxSet, syntax: &SyntaxReference, t
     let mut h = HighlightLines::new(syntax, theme);
     let mut count = 0;
     for line in s.lines() {
-        let regions = h.highlight_line(line, syntax_set);
+        let regions = h.highlight_line(line, syntax_set).unwrap();
         count += regions.len();
     }
     count

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -8,7 +8,7 @@ fn do_parse(s: &str, ss: &SyntaxSet, syntax: &SyntaxReference) -> usize {
     let mut state = ParseState::new(syntax);
     let mut count = 0;
     for line in s.lines() {
-        let ops = state.parse_line(line, ss);
+        let ops = state.parse_line(line, ss).unwrap();
         count += ops.len();
     }
     count

--- a/examples/latex-demo.rs
+++ b/examples/latex-demo.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
     for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
         let escaped = as_latex_escaped(&ranges[..]);
         println!("\n{:?}", line);
         println!("\n{}", escaped);

--- a/examples/parsyncat.rs
+++ b/examples/parsyncat.rs
@@ -45,7 +45,7 @@ fn main() {
             let mut highlighter = HighlightFile::new(filename, &syntax_set, theme).unwrap();
 
             for line in contents {
-                for region in highlighter.highlight_lines.highlight_line(line, &syntax_set) {
+                for region in highlighter.highlight_lines.highlight_line(line, &syntax_set).unwrap() {
                     regions.push(region);
                 }
             }

--- a/examples/syncat.rs
+++ b/examples/syncat.rs
@@ -103,7 +103,7 @@ fn main() {
                 }
 
                 {
-                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss);
+                    let regions: Vec<(Style, &str)> = highlighter.highlight_lines.highlight_line(&line, &ss).unwrap();
                     print!("{}", as_24_bit_terminal_escaped(&regions[..], true));
                 }
                 line.clear();

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -46,7 +46,7 @@ fn main() {
     let sr_rs = ss.find_syntax_by_extension("rs").unwrap();
     let mut rs_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_rs, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_rs) {
-        rs_html_generator.parse_html_for_line_which_includes_newline(line);
+        rs_html_generator.parse_html_for_line_which_includes_newline(line).unwrap();
     }
     let html_rs = rs_html_generator.finalize();
 
@@ -64,7 +64,7 @@ int main() {
     let sr_cpp = ss.find_syntax_by_extension("cpp").unwrap();
     let mut cpp_html_generator = ClassedHTMLGenerator::new_with_class_style(sr_cpp, &ss, ClassStyle::Spaced);
     for line in LinesWithEndings::from(code_cpp) {
-        cpp_html_generator.parse_html_for_line_which_includes_newline(line);
+        cpp_html_generator.parse_html_for_line_which_includes_newline(line).unwrap();
     }
     let html_cpp = cpp_html_generator.finalize();
 

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -133,7 +133,7 @@ fn count(ss: &SyntaxSet, path: &Path, stats: &mut Stats) {
     let mut stack = ScopeStack::new();
     while reader.read_line(&mut line).unwrap() > 0 {
         {
-            let ops = state.parse_line(&line, ss);
+            let ops = state.parse_line(&line, ss).unwrap();
             stats.chars += line.len();
             count_line(&ops, &line, &mut stack, stats);
         }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -273,7 +273,7 @@ fn test_file(
                     current_line_number, stack
                 );
             }
-            let ops = state.parse_line(&line, ss);
+            let ops = state.parse_line(&line, ss).unwrap();
             if out_opts.debug && !line_only_has_assertion {
                 if ops.is_empty() && !line.is_empty() {
                     println!("no operations for this line...");

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -389,7 +389,7 @@ mod tests {
 
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = "module Bob::Wow::Troll::Five; 5; end";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str)> = iter.collect();
         // println!("{:#?}", regions);
@@ -426,7 +426,7 @@ mod tests {
         // We start by parsing a python multiline-comment: """
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = r#"""""#;
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         assert_eq!(1, iter.count());
         let path = highlight_state.path;
@@ -434,7 +434,7 @@ mod tests {
         // We then parse the next line with a highlight state built from the previous state
         let mut highlight_state = HighlightState::new(&highlighter, path);
         let line = "multiline comment";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = HighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str)> = iter.collect();
 
@@ -548,7 +548,7 @@ mod tests {
 
         let mut highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         let line = "module Bob::Wow::Troll::Five; 5; end";
-        let ops = state.parse_line(line, &ps);
+        let ops = state.parse_line(line, &ps).expect("#[cfg(test)]");
         let iter = RangedHighlightIterator::new(&mut highlight_state, &ops[..], line, &highlighter);
         let regions: Vec<(Style, &str, Range<usize>)> = iter.collect();
         // println!("{:#?}", regions);

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -31,7 +31,7 @@ pub struct ThemeSettings {
     /// Color of the caret.
     pub caret: Option<Color>,
     /// Color of the line the caret is in.
-    /// Only used when the `higlight_line` setting is set to `true`.
+    /// Only used when the `highlight_line` setting is set to `true`.
     pub line_highlight: Option<Color>,
 
     /// The color to use for the squiggly underline drawn under misspelled words.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@ pub enum Error {
     /// An error occurred while loading a syntax or theme
     #[error("Loading error: {0}")]
     LoadingError(#[from] LoadingError),
+    /// An error occurred while parsing
+    #[cfg(feature = "parsing")]
+    #[error("Parsing error: {0}")]
+    ParsingError(#[from] crate::parsing::ParsingError),
     /// Formatting error
     #[error("Formatting error: {0}")]
     Fmt(#[from] std::fmt::Error),

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -163,7 +163,7 @@ impl<'a> Iterator for MatchIter<'a> {
                     Pattern::Include(ref ctx_ref) => {
                         let ctx_ptr = match *ctx_ref {
                             ContextReference::Direct(ref context_id) => {
-                                self.syntax_set.get_context(context_id)
+                                self.syntax_set.get_context(context_id).unwrap()
                             }
                             _ => return self.next(), // skip this and move onto the next one
                         };
@@ -205,7 +205,7 @@ impl ContextReference {
     /// find the pointed to context, panics if ref is not linked
     pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> &'a Context {
         match *self {
-            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id),
+            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id).unwrap(),
             _ => panic!("Can only call resolve on linked references: {:?}", self),
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -79,7 +79,7 @@ const LATEX_REPLACE: [(&str, &str); 3] = [
 ///
 /// let mut h = HighlightLines::new(syntax, &ts.themes["InspiredGitHub"]);
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps);
+///     let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
 ///     let escaped = as_latex_escaped(&ranges[..]);
 ///     println!("{}", escaped);
 /// }


### PR DESCRIPTION
And also  adapt most other related code to this change, and add a `Result` to another `html` function.

* In `examples/` and `benches/` I simply do .unwrap()

* In tests I do `.expect("#[cfg(test)]")` to make reviewing the diff easy

* In deprecated methods I simply do .expect("helpful hint about new method")

* In `uses_backrefs = uses_backrefs || proto_ids.iter().any(|id|syntax_set.get_context(id).unwrap().uses_backrefs);` I do an `.unwrap()` because `?` does not work inside of `.any()`. But that can be fixed later if necessary without semver breakage.

* To keep the scope of the PR manageable I do `.unwrap()` in `ContextReference::resolve()` and `impl<'a> Iterator for MatchIter<'a>` to not have to propagate an error further. That will be done in a follow-up PR.

The impact on the public API is as follows:

```
% cargo install cargo-public-items
% git checkout parse-and-highlight-line-with-result
% cargo public-items > /tmp/parse-and-highlight-line-with-result
% git ch origin/master
% cargo public-items > /tmp/master
% diff -U0 /tmp/master /tmp/parse-and-highlight-line-with-result
+pub enum syntect::parsing::ParsingError
+pub enum variant syntect::parsing::ParsingError::MissingContext(ContextId)
+pub fn syntect::parsing::ParsingError::fmt(&self, __formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result
+pub fn syntect::parsing::ParsingError::fmt(&self, f: &mut $crate::fmt::Formatter<'_>) -> $crate::fmt::Result
+pub enum variant syntect::Error::ParsingError(crate::parsing::ParsingError)
+pub fn syntect::Error::from(source: crate::parsing::ParsingError) -> Self
-pub fn syntect::easy::HighlightLines::highlight_line<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)>
+pub fn syntect::easy::HighlightLines::highlight_line<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Result<Vec<(Style, &'b str)>, Error>
-pub fn syntect::html::ClassedHTMLGenerator::parse_html_for_line_which_includes_newline(&mut self, line: &str)
+pub fn syntect::html::ClassedHTMLGenerator::parse_html_for_line_which_includes_newline(&mut self, line: &str) -> Result<(), Error>
-pub fn syntect::parsing::ParseState::parse_line(&mut self, line: &str, syntax_set: &SyntaxSet) -> Vec<(usize, ScopeStackOp)>
+pub fn syntect::parsing::ParseState::parse_line(&mut self, line: &str, syntax_set: &SyntaxSet) -> Result<Vec<(usize, ScopeStackOp)>, ParsingError>
```



Performance-wise I can not detect any significant difference on my low-end desktop

<details>
  <summary>Detailed benchmark numbers with master as baseline</summary>

```
/home/martin/src/syntect
22bccfa Make `highlight_line()` and `parse  parse-and-highlight-line-with-result   (origin/parse-and-highlight-line-with-result)
% cargo bench -- --baseline master-8e1dac8-2                                              
   Compiling syntect v4.7.1 (/home/martin/src/syntect)
    Finished bench [optimized] target(s) in 50.11s
     Running unittests (target/release/deps/highlighting-796b26013708fde3)
stack_matching          time:   [84.523 ns 84.566 ns 84.606 ns]                          
                        change: [-0.4863% -0.0499% +0.3400%] (p = 0.83 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

highlight_html          time:   [444.85 ms 445.46 ms 446.06 ms]                         
                        change: [-2.1037% -1.6964% -1.3659%] (p = 0.00 < 0.05)
                        Performance has improved.

highlight/"highlight_test.erb"                                                                            
                        time:   [1.7938 ms 1.8068 ms 1.8394 ms]
                        change: [-8.1140% -1.0209% +6.4469%] (p = 0.80 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
highlight/"InspiredGitHub.tmTheme"                                                                           
                        time:   [25.837 ms 26.086 ms 26.227 ms]
                        change: [-0.2408% +0.8110% +1.8373%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low severe
  1 (10.00%) low mild
  1 (10.00%) high mild
highlight/"Ruby.sublime-syntax"                                                                           
                        time:   [81.408 ms 81.545 ms 81.643 ms]
                        change: [+0.6270% +1.0745% +1.4963%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking highlight/"jquery.js": Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.5s.
highlight/"jquery.js"   time:   [657.62 ms 658.48 ms 659.52 ms]                                
                        change: [-0.8001% -0.5042% -0.2173%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
highlight/"parser.rs"   time:   [432.96 ms 433.37 ms 433.79 ms]                                
                        change: [-1.6067% -1.2167% -0.8924%] (p = 0.00 < 0.05)
                        Change within noise threshold.
highlight/"scope.rs"    time:   [41.394 ms 41.476 ms 41.656 ms]                                
                        change: [-2.9460% -1.3003% +0.3028%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

     Running unittests (target/release/deps/load_and_highlight-ce9210706bcf7470)
load_and_highlight/"highlight_test.erb"                                                                           
                        time:   [32.436 ms 32.467 ms 32.504 ms]
                        change: [-0.6338% -0.4986% -0.3580%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
load_and_highlight/"InspiredGitHub.tmTheme"                                                                           
                        time:   [30.556 ms 30.590 ms 30.625 ms]
                        change: [-1.2091% -1.0046% -0.8205%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) low mild
  1 (2.00%) high severe
load_and_highlight/"Ruby.sublime-syntax"                                                                           
                        time:   [85.098 ms 85.151 ms 85.212 ms]
                        change: [+0.5870% +0.6919% +0.7899%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe
Benchmarking load_and_highlight/"parser.rs": Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 22.2s, or reduce sample count to 10.
load_and_highlight/"parser.rs"                                                                          
                        time:   [443.27 ms 443.84 ms 444.44 ms]
                        change: [-1.2440% -1.0908% -0.9243%] (p = 0.00 < 0.05)
                        Change within noise threshold.

     Running unittests (target/release/deps/loading-e67ac9fa9c16eca0)
load_internal_dump      time:   [1.3314 ms 1.3327 ms 1.3339 ms]                               
                        change: [+4.7655% +5.1574% +5.5272%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high severe

load_internal_themes    time:   [1.5770 ms 1.5779 ms 1.5789 ms]                                 
                        change: [-0.6704% -0.3949% -0.1488%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) high mild
  4 (8.00%) high severe

load_theme              time:   [1.9622 ms 1.9630 ms 1.9639 ms]                       
                        change: [+0.6787% +0.9176% +1.1745%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 50 measurements (8.00%)
  1 (2.00%) high mild
  3 (6.00%) high severe

Benchmarking add_from_folder: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 28.3s, or reduce sample count to 10.
add_from_folder         time:   [563.75 ms 563.92 ms 564.11 ms]                          
                        change: [-0.0335% +0.0110% +0.0561%] (p = 0.65 > 0.05)
                        No change in performance detected.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe

Benchmarking link_syntaxes: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 9.8s, or reduce sample count to 20.
link_syntaxes           time:   [195.18 ms 195.29 ms 195.42 ms]                        
                        change: [-0.3727% -0.2915% -0.2134%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe

from_dump_file          time:   [1.4554 ms 1.4559 ms 1.4566 ms]                           
                        change: [-0.2638% +0.0265% +0.3184%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 7 outliers among 50 measurements (14.00%)
  2 (4.00%) high mild
  5 (10.00%) high severe

     Running unittests (target/release/deps/parsing-253403872c2ab027)
parse/"highlight_test.erb"                                                                            
                        time:   [1.7797 ms 1.8028 ms 1.8364 ms]
                        change: [-23.191% -2.6599% +24.693%] (p = 0.83 > 0.05)
                        No change in performance detected.
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) high mild
  4 (8.00%) high severe
parse/"InspiredGitHub.tmTheme"                                                                           
                        time:   [18.551 ms 18.609 ms 18.670 ms]
                        change: [-0.7899% -0.3712% +0.0706%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high mild
parse/"Ruby.sublime-syntax"                                                                           
                        time:   [77.605 ms 77.653 ms 77.707 ms]
                        change: [-0.3625% -0.2387% -0.1146%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
Benchmarking parse/"jquery.js": Warming up for 30.000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 29.6s, or reduce sample count to 10.
parse/"jquery.js"       time:   [604.46 ms 604.96 ms 605.45 ms]                            
                        change: [-3.2934% -3.1695% -3.0487%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking parse/"parser.rs": Warming up for 30.000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 19.7s, or reduce sample count to 10.
parse/"parser.rs"       time:   [400.78 ms 401.24 ms 401.74 ms]                            
                        change: [-4.5650% -4.3539% -4.1440%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
parse/"scope.rs"        time:   [39.973 ms 40.007 ms 40.045 ms]                            
                        change: [-4.9928% -4.6824% -4.3744%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
```
</details>

Finally a note on chaining many PRs together: I do that sometimes, but normally I have not written or at least not polished the code that comes next. Stacking many PRs on top of each other risks creating quite gnarly conflicts in case other PRs are merged in between or if you have code review comments on the first PR in a set, that other PRs depend on. So to be as efficient as possible in terms of man-hours (rather than calendar-hours) I prefer to take one step at a time in the right direction.

So if it is OK with you to keep our current pace, that is very much OK with me too.

This is one step towards resolving #98
