### PR TITLE
Fall back to 'Plain Text' if a referenced syntax is missing

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -111,11 +111,18 @@ pub enum ContextReference {
     ByScope {
         scope: Scope,
         sub_context: Option<String>,
+        /// `true` if this reference by scope is part of an `embed` for which
+        /// there is an `escape`. In other words a reference for a context for
+        /// which there "always is a way out". Enables falling back to `Plain
+        /// Text` syntax in case the referenced scope is missing.
+        with_escape: bool,
     },
     #[non_exhaustive]
     File {
         name: String,
         sub_context: Option<String>,
+        /// Same semantics as for [`Self::ByScope::with_escape`].
+        with_escape: bool,
     },
     #[non_exhaustive]
     Inline(String),

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -1024,10 +1024,16 @@ mod tests {
         let syntax = syntax_set.find_syntax_by_extension("z").unwrap();
         let mut parse_state = ParseState::new(syntax);
         let ops = parse_state.parse_line("z go_x x leave_x z", &syntax_set);
-        let expected_text_plain = (6, ScopeStackOp::Push(Scope::new("text.plain").unwrap()));
-        assert_ops_contain(&ops, &expected_text_plain);
-        let expected_text_plain_pop = (9, ScopeStackOp::Pop(1));
-        assert_ops_contain(&ops, &expected_text_plain_pop);
+        let expected_ops = vec![
+            (0, ScopeStackOp::Push(Scope::new("source.z").unwrap())),
+            (0, ScopeStackOp::Push(Scope::new("z").unwrap())),
+            (1, ScopeStackOp::Pop(1)),
+            (6, ScopeStackOp::Push(Scope::new("text.plain").unwrap())),
+            (9, ScopeStackOp::Pop(1)),
+            (17, ScopeStackOp::Push(Scope::new("z").unwrap())),
+            (18, ScopeStackOp::Pop(1)),
+        ];
+        assert_eq!(ops, expected_ops);
     }
 
     #[test]


### PR DESCRIPTION
The consequence of this change is that if `syntect` encounters a syntax
that references another syntax that is not present, `syntect` will
fallback to Plain Text syntax instead of erroring/panicking. Falling
back to Plain Text in cases like this seems to be what Sublime Text is
doing too.

For example, `bat` has a syntax for Vue, but Vue references a syntax
with scope `text.pug`, which is not included in bat (by default).

So if `bat` encounters the following `vue-with-pug.vue` file:
```
<template lang='pug'>
  #container.col
    p This shall be formated as Plain Text as long as a Pug syntax definition is missing
</template>
```
`bat` currently panics with:

```
% bat ~/Desktop/vue-with-pug.vue
───────┬────────────────────────────────────────────────────────────────
       │ File: /Users/martin/Desktop/vue-with-pug.vue
       │ Size: 140 B
───────┼────────────────────────────────────────────────────────────────
thread 'main' panicked at 'Can only call resolve on linked references: ByScope { scope: <text.pug>, sub_context: None }', /Users/martin/.cargo/registry/src/github.com-1ecc6299db9ec823/syntect-4.6.0/src/parsing/syntax_definition.rs:191:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With this change, instead of panicking, `bat` will print the file with
the pug parts highlighted as Plain Text:

<img width="995" alt="Skärmavbild 2022-03-12 kl  08 03 16" src="https://user-images.githubusercontent.com/115040/158007884-074db0b7-3fb9-41a1-97da-8f9589871d7b.png">

Closes #421
