### PR TITLE
Fix misreading v4.7 information in documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove 'plist-load' feature again due to semver violation. [#403](https://github.com/trishume/syntect/pull/403)
 
+This version was removed from crates.io due to the semver violation issue.
+
 ## [Version 4.7.0](https://github.com/trishume/syntect/compare/v4.6.0...v4.7.0) (2021-12-25)
 
 - Lazy-load syntaxes to significantly improve startup time
@@ -17,7 +19,9 @@
 - Blend alpha value on converting colors to ANSI color sequences
 - Fix sample code in documentation to avoid double newlines
 - Fix lots of build warnings and lints
-- Add Criterion benchmarks for a whole syntect pipeline and for from_dump_file()
+- Add Criterion benchmarks for a whole syntect pipeline and for `from_dump_file()`
+
+This version was removed from crates.io due to the semver violation issue.
 
 ## [Version 4.6.0](https://github.com/trishume/syntect/compare/v4.5.0...v4.6.0) (2021-08-01)
 

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ I consider this project mostly complete, I still maintain it and review PRs, but
 `syntect` is [available on crates.io](https://crates.io/crates/syntect). You can install it by adding this line to your `Cargo.toml`:
 
 ```toml
-syntect = "4.7"
+syntect = "4.6"
 ```
 
 After that take a look at the [documentation](https://docs.rs/syntect) and the [examples](https://github.com/trishume/syntect/tree/master/examples).


### PR DESCRIPTION
I confirmed that v4.7.0 and v4.7.1 were unpublished due to the semver violation issue at #428.

However the readme file says v4.7 should be specified on installing syntect. This would be misreading since it causes an error that no such version exists on crates.io. And noting that the versions were unpublished in changelog would be better so that users can know that these versions were once released but not available on crates.io.