### PR TITLE
Fix example in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ let syntax = ps.find_syntax_by_extension("rs").unwrap();
 let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 for line in LinesWithEndings::from(s) {
-    let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap();
+    let ranges: Vec<(Style, &str)> = h.highlight(line, &ps);
     let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
     print!("{}", escaped);
 }


### PR DESCRIPTION
The signature is different: [`pub fn highlight<'b>(&mut self, line: &'b str, syntax_set: &SyntaxSet) -> Vec<(Style, &'b str)>`](https://docs.rs/syntect/latest/syntect/easy/struct.HighlightLines.html#method.highlight)