### PR TITLE
Replace direct panics with Errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,8 @@ jobs:
           --allow clippy::unknown_clippy_lints \
           --allow clippy::unnecessary_cast \
           --allow clippy::block_in_if_condition_stmt
+        # Prevent regressions of https://github.com/trishume/syntect/issues/98
+        cargo clippy --all-features --lib -- --deny clippy::panic
     - name: Run cargo check
       run: |
         cargo check --all-features --all-targets

--- a/examples/synhtml-css-classes.rs
+++ b/examples/synhtml-css-classes.rs
@@ -106,7 +106,7 @@ int main() {
     let css_dark_file = File::create(Path::new("theme-dark.css"))?;
     let mut css_dark_writer = BufWriter::new(&css_dark_file);
 
-    let css_dark = css_for_theme_with_class_style(dark_theme, ClassStyle::Spaced);
+    let css_dark = css_for_theme_with_class_style(dark_theme, ClassStyle::Spaced).unwrap();
     writeln!(css_dark_writer, "{}", css_dark)?;
 
     // create light color scheme css
@@ -114,7 +114,7 @@ int main() {
     let css_light_file = File::create(Path::new("theme-light.css"))?;
     let mut css_light_writer = BufWriter::new(&css_light_file);
 
-    let css_light = css_for_theme_with_class_style(light_theme, ClassStyle::Spaced);
+    let css_light = css_for_theme_with_class_style(light_theme, ClassStyle::Spaced).unwrap();
     writeln!(css_light_writer, "{}", css_light)?;
 
     Ok(())

--- a/examples/synstats.rs
+++ b/examples/synstats.rs
@@ -85,7 +85,7 @@ fn count_line(ops: &[(usize, ScopeStackOp)], line: &str, stack: &mut ScopeStack,
     let mut line_has_doc_comment = false;
     let mut line_has_code = false;
     for (s, op) in ScopeRegionIterator::new(ops, line) {
-        stack.apply(op);
+        stack.apply(op).unwrap();
         if s.is_empty() { // in this case we don't care about blank tokens
             continue;
         }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -283,7 +283,7 @@ fn test_file(
             }
             let mut col: usize = 0;
             for (s, op) in ScopeRegionIterator::new(&ops, &line) {
-                stack.apply(op);
+                stack.apply(op).unwrap();
                 if s.is_empty() {
                     // in this case we don't care about blank tokens
                     continue;

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -298,7 +298,7 @@ mod tests {
         let mut stack = ScopeStack::new();
         let mut token_count = 0;
         for (s, op) in ScopeRegionIterator::new(&ops, line) {
-            stack.apply(op);
+            stack.apply(op).expect("#[cfg(test)]");
             if s.is_empty() { // in this case we don't care about blank tokens
                 continue;
             }
@@ -326,7 +326,7 @@ mod tests {
 
             let mut iterated_ops: Vec<&ScopeStackOp> = Vec::new();
             for (_, op) in ScopeRegionIterator::new(&ops, line) {
-                stack.apply(op);
+                stack.apply(op).expect("#[cfg(test)]");
                 iterated_ops.push(op);
                 println!("{:?}", op);
             }

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -181,7 +181,7 @@ impl<'a, 'b> Iterator for RangedHighlightIterator<'a, 'b> {
                         m_caches.pop();
                     }
                 }
-            });
+            }).ok()?;
         }
         self.pos = end;
         self.index += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub enum Error {
     #[cfg(feature = "parsing")]
     #[error("Parsing error: {0}")]
     ParsingError(#[from] crate::parsing::ParsingError),
+    /// Scope error
+    #[error("Scope error: {0}")]
+    ScopeError(#[from] crate::parsing::ScopeError),
     /// Formatting error
     #[error("Formatting error: {0}")]
     Fmt(#[from] std::fmt::Error),

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
-use super::scope::*;
+use super::{scope::*, ParsingError};
 use super::regex::{Regex, Region};
 use regex_syntax::escape;
 use serde::{Serialize, Serializer};
@@ -192,29 +192,29 @@ pub fn context_iter<'a>(syntax_set: &'a SyntaxSet, context: &'a Context) -> Matc
 }
 
 impl Context {
-    /// Returns the match pattern at an index, panics if the thing isn't a match pattern
-    pub fn match_at(&self, index: usize) -> &MatchPattern {
+    /// Returns the match pattern at an index
+    pub fn match_at(&self, index: usize) -> Result<&MatchPattern, ParsingError> {
         match self.patterns[index] {
-            Pattern::Match(ref match_pat) => match_pat,
-            _ => panic!("bad index to match_at"),
+            Pattern::Match(ref match_pat) => Ok(match_pat),
+            _ => Err(ParsingError::BadMatchIndex(index)),
         }
     }
 }
 
 impl ContextReference {
-    /// find the pointed to context, panics if ref is not linked
-    pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> &'a Context {
+    /// find the pointed to context
+    pub fn resolve<'a>(&self, syntax_set: &'a SyntaxSet) -> Result<&'a Context, ParsingError> {
         match *self {
-            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id).unwrap(),
-            _ => panic!("Can only call resolve on linked references: {:?}", self),
+            ContextReference::Direct(ref context_id) => syntax_set.get_context(context_id),
+            _ => Err(ParsingError::UnresolvedContextReference(self.clone())),
         }
     }
 
-    /// get the context ID this reference points to, panics if ref is not linked
-    pub fn id(&self) -> ContextId {
+    /// get the context ID this reference points to
+    pub fn id(&self) -> Result<ContextId, ParsingError> {
         match *self {
-            ContextReference::Direct(ref context_id) => *context_id,
-            _ => panic!("Can only get ContextId of linked references: {:?}", self),
+            ContextReference::Direct(ref context_id) => Ok(*context_id),
+             _ => Err(ParsingError::UnresolvedContextReference(self.clone())),
         }
     }
 }


### PR DESCRIPTION
Even though there are still `.unwrap()`s and `.expect()`s left, this change should cover the most common error code paths.

If we find a new case of an error that we want to propagate, it is generally straightforward to deprecate the old function and add a new function that calls the old function and `.unwrap()`. This can be done in a minor release. In many cases this can hopefully be done without API changes since many parts of the API have been changed already.

On my low-end desktop, this PR does seem to have a slight (1-2%-ish) impact on performance. But it is hard to make a final judgement, because I get that kind of performance difference between benchmarks of the same commit on master. Either way, I think it is reasonable and expected to pay a slight performance penalty for (checking for) error propagation from hot code paths. But I am open to hearing other opinions.


Here is an example run of `cargo bench` with master as baseline (click to expand):
<details>
  <summary>cargo bench -- --baseline master-6b211f9-4 </summary>
  


```
/home/martin/src/syntect
46882e1 Replace direct panics with Errors  dont-panic   (origin/dont-panic)
% cargo bench -- --baseline master-6b211f9-4 
   Compiling syntect v4.7.1 (/home/martin/src/syntect)
    Finished bench [optimized] target(s) in 50.47s
     Running unittests (target/release/deps/highlighting-796b26013708fde3)
stack_matching          time:   [84.617 ns 84.639 ns 84.665 ns]                          
                        change: [-0.3473% -0.0122% +0.3243%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

highlight_html          time:   [456.56 ms 457.73 ms 459.21 ms]                         
                        change: [+1.3842% +1.7863% +2.1887%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe

highlight/"highlight_test.erb"                                                                            
                        time:   [1.8383 ms 1.8521 ms 1.8851 ms]
                        change: [-4.6083% +2.5368% +10.0000%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
highlight/"InspiredGitHub.tmTheme"                                                                           
                        time:   [25.995 ms 26.122 ms 26.244 ms]
                        change: [-0.2425% +0.7742% +1.6733%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
highlight/"Ruby.sublime-syntax"                                                                           
                        time:   [79.368 ms 79.514 ms 79.615 ms]
                        change: [+0.7164% +1.1379% +1.5952%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking highlight/"jquery.js": Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.6s.
highlight/"jquery.js"   time:   [669.55 ms 670.36 ms 671.18 ms]                                
                        change: [+0.5865% +1.3819% +2.0224%] (p = 0.00 < 0.05)
                        Change within noise threshold.
highlight/"parser.rs"   time:   [442.50 ms 443.91 ms 445.63 ms]                                
                        change: [+1.3417% +1.7942% +2.2518%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
highlight/"scope.rs"    time:   [43.036 ms 43.139 ms 43.304 ms]                                
                        change: [+1.6237% +3.4113% +5.2355%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe

     Running unittests (target/release/deps/load_and_highlight-ce9210706bcf7470)
load_and_highlight/"highlight_test.erb"                                                                           
                        time:   [32.574 ms 32.603 ms 32.638 ms]
                        change: [+0.0331% +0.1842% +0.3482%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 50 measurements (8.00%)
  2 (4.00%) high mild
  2 (4.00%) high severe
load_and_highlight/"InspiredGitHub.tmTheme"                                                                           
                        time:   [30.666 ms 30.724 ms 30.785 ms]
                        change: [-0.9729% -0.7384% -0.5029%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 50 measurements (6.00%)
  3 (6.00%) high mild
load_and_highlight/"Ruby.sublime-syntax"                                                                           
                        time:   [88.468 ms 88.529 ms 88.595 ms]
                        change: [+4.5497% +4.6433% +4.7461%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
Benchmarking load_and_highlight/"parser.rs": Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 22.8s, or reduce sample count to 10.
load_and_highlight/"parser.rs"                                                                          
                        time:   [453.57 ms 454.30 ms 455.10 ms]
                        change: [+1.7068% +1.9070% +2.1127%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 50 measurements (14.00%)
  7 (14.00%) high mild

     Running unittests (target/release/deps/loading-e67ac9fa9c16eca0)
load_internal_dump      time:   [1.5755 ms 1.5766 ms 1.5780 ms]                               
                        change: [+23.243% +23.647% +24.054%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high severe

load_internal_themes    time:   [1.6210 ms 1.6215 ms 1.6222 ms]                                 
                        change: [+1.7412% +2.0074% +2.2935%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) high mild
  4 (8.00%) high severe

load_theme              time:   [1.9683 ms 1.9690 ms 1.9698 ms]                       
                        change: [+0.1474% +0.4301% +0.6828%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  1 (2.00%) high mild
  4 (8.00%) high severe

Benchmarking add_from_folder: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 28.1s, or reduce sample count to 10.
add_from_folder         time:   [561.55 ms 561.74 ms 561.94 ms]                          
                        change: [-0.4230% -0.3721% -0.3231%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe

Benchmarking link_syntaxes: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 9.8s, or reduce sample count to 20.
link_syntaxes           time:   [195.43 ms 195.55 ms 195.68 ms]                        
                        change: [-0.3678% -0.2794% -0.1981%] (p = 0.00 < 0.05)
                        Change within noise threshold.

from_dump_file          time:   [1.3722 ms 1.3745 ms 1.3765 ms]                           
                        change: [-8.2878% -7.0064% -5.9791%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) high mild
  2 (4.00%) high severe

     Running unittests (target/release/deps/parsing-253403872c2ab027)
parse/"highlight_test.erb"                                                                            
                        time:   [1.8169 ms 1.8404 ms 1.8745 ms]
                        change: [-19.620% +0.6596% +29.851%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 6 outliers among 50 measurements (12.00%)
  2 (4.00%) high mild
  4 (8.00%) high severe
parse/"InspiredGitHub.tmTheme"                                                                           
                        time:   [18.250 ms 18.296 ms 18.344 ms]
                        change: [-0.8843% -0.5214% -0.1779%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
parse/"Ruby.sublime-syntax"                                                                           
                        time:   [77.483 ms 77.529 ms 77.579 ms]
                        change: [-1.6981% -1.5932% -1.4946%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high mild
Benchmarking parse/"jquery.js": Warming up for 30.000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 30.4s, or reduce sample count to 10.
parse/"jquery.js"       time:   [616.39 ms 617.68 ms 619.19 ms]                            
                        change: [+1.0887% +1.3171% +1.5799%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high severe
Benchmarking parse/"parser.rs": Warming up for 30.000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 20.1s, or reduce sample count to 10.
parse/"parser.rs"       time:   [410.44 ms 410.72 ms 411.06 ms]                            
                        change: [+1.2844% +1.3908% +1.5154%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe
parse/"scope.rs"        time:   [41.482 ms 41.521 ms 41.563 ms]                            
                        change: [+2.8638% +3.0041% +3.1593%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 50 measurements (6.00%)
  1 (2.00%) low mild
  1 (2.00%) high mild
  1 (2.00%) high severe

```

</details>

Some words on the details of this PR:
* In examples/ I simply `.unwrap()`
* In tests I do `.expect("#[cfg(test)]")` to make the diff easy to review
* In Iterator for RangedHighlightIterator I do `.ok()?` instead of propagating the error, but I feel like propagating the error is too big of a change at this point.
* I introduced a new `ScopeError` enum due to the `parsing` feature and the current structure of the code. It is possible that a new big restructuring of the code could avoid the need for that, but honestly I think we need to try to get 5.0.0 out at this point.
* Inside of `.any()` and `.map()` I do `.unwrap()` to not have to refactor the code. That can be fixed in 5.0.1 or 5.1.0 if necessary.
* I allow one instance of a `panic!()`  since it seems to be too much of an edge-case to propagate. I added a comment in the code.

This PR is for #98.

FWIW, here is a CI run of bat with all regression tests passing when using the code in this PR: https://github.com/Enselic/bat/pull/85