### PR TITLE
Add Docket to the Projects in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -230,6 +230,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [Cobalt](https://github.com/cobalt-org/cobalt.rs), a static site generator that uses `syntect` for highlighting code snippets.
 - [crowbook](https://github.com/lise-henry/crowbook), a Markdown book generator, uses `syntect` for code blocks.
 - [delta](https://github.com/dandavison/delta), a syntax-highlighting pager for Git.
+- [Docket](https://github.com/iwillspeak/docket), a documentation site generator that uses `syntect` for highlighting.
 - [hors](https://github.com/WindSoilder/hors), instant coding answers via command line, uses `syntect` for highlighting code blocks.
 - [mdcat](https://github.com/lunaryorn/mdcat), a console markdown printer, uses `syntect` for code blocks.
 - [Scribe](https://github.com/jmacdonald/scribe), a Rust text editor framework which uses `syntect` for highlighting.


### PR DESCRIPTION
Update the README to add a link to Docket. Docket is a documentation
site generator that uses `syntect` for highlighting.