### PR TITLE
Fix `split_at` (return Result ver.)

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -323,42 +323,24 @@ mod tests {
     fn test_split_at() {
         let l: &[(u8, &str)] = &[];
         let (before, after) = split_at(l, 0).unwrap(); // empty
-        assert_eq!((&before[..], &after[..]), (&[][..], &[][..]));
+        assert_eq!((&before[..], &after[..]), (&[][..],&[][..]));
 
         let l = &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")];
 
         let (before, after) = split_at(l, 0).unwrap(); // at start
-        assert_eq!(
-            (&before[..], &after[..]),
-            (&[][..], &[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..])
-        );
+        assert_eq!((&before[..], &after[..]), (&[][..],&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..]));
 
         let (before, after) = split_at(l, 4).unwrap(); // inside token
-        assert_eq!(
-            (&before[..], &after[..]),
-            (
-                &[(0u8, "abc"), (1u8, "d")][..],
-                &[(1u8, "ef"), (2u8, "ghi")][..]
-            )
-        );
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "d")][..],&[(1u8, "ef"), (2u8, "ghi")][..]));
 
         let (before, after) = split_at(l, 3).unwrap(); // between tokens
-        assert_eq!(
-            (&before[..], &after[..]),
-            (&[(0u8, "abc")][..], &[(1u8, "def"), (2u8, "ghi")][..])
-        );
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc")][..],&[(1u8, "def"), (2u8, "ghi")][..]));
 
         let (before, after) = split_at(l, 9).unwrap(); // just after last token
-        assert_eq!(
-            (&before[..], &after[..]),
-            (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..])
-        );
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
 
         let (before, after) = split_at(l, 10).unwrap(); // out of bounds
-        assert_eq!(
-            (&before[..], &after[..]),
-            (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..])
-        );
+        assert_eq!((&before[..], &after[..]), (&[(0u8, "abc"), (1u8, "def"), (2u8, "ghi")][..], &[][..]));
 
         let l = &[(0u8, "こんにちは"), (1u8, "世界"), (2u8, "！")];
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,12 +40,12 @@ pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
     let mut s: String = String::new();
     for &(ref style, text) in v.iter() {
         if bg {
-            write!(
-                s,
-                "\x1b[48;2;{};{};{}m",
-                style.background.r, style.background.g, style.background.b
-            )
-            .unwrap();
+            write!(s,
+                   "\x1b[48;2;{};{};{}m",
+                   style.background.r,
+                   style.background.g,
+                   style.background.b)
+                .unwrap();
         }
         let fg = blend_fg_color(style.foreground, style.background);
         write!(s, "\x1b[38;2;{};{};{}m{}", fg.r, fg.g, fg.b, text).unwrap();
@@ -54,7 +54,11 @@ pub fn as_24_bit_terminal_escaped(v: &[(Style, &str)], bg: bool) -> String {
     s
 }
 
-const LATEX_REPLACE: [(&str, &str); 3] = [("\\", "\\\\"), ("{", "\\{"), ("}", "\\}")];
+const LATEX_REPLACE: [(&str, &str); 3] = [
+    ("\\", "\\\\"),
+    ("{", "\\{"),
+    ("}", "\\}"),
+];
 
 /// Formats the styled fragments using LaTeX textcolor directive.
 ///
@@ -104,13 +108,11 @@ pub fn as_latex_escaped(v: &[(Style, &str)]) -> String {
     let mut prev_style: Option<Style> = None;
     let mut content: String;
     fn textcolor(style: &Style, first: bool) -> String {
-        format!(
-            "{}\\textcolor[RGB]{{{},{},{}}}{{",
+        format!("{}\\textcolor[RGB]{{{},{},{}}}{{",
             if first { "" } else { "}" },
             style.foreground.r,
             style.foreground.b,
-            style.foreground.g
-        )
+            style.foreground.g)
     }
     for &(style, text) in v.iter() {
         if let Some(ps) = prev_style {
@@ -118,7 +120,7 @@ pub fn as_latex_escaped(v: &[(Style, &str)]) -> String {
                 " " => {
                     s.push(' ');
                     continue;
-                }
+                },
                 "\n" => continue,
                 _ => (),
             }
@@ -162,6 +164,7 @@ pub fn debug_print_ops(line: &str, ops: &[(usize, ScopeStackOp)]) {
     }
 }
 
+
 /// An iterator over the lines of a string, including the line endings.
 ///
 /// This is similar to the standard library's `lines` method on `str`, except
@@ -202,8 +205,7 @@ impl<'a> Iterator for LinesWithEndings<'a> {
         if self.input.is_empty() {
             return None;
         }
-        let split = self
-            .input
+        let split = self.input
             .find('\n')
             .map(|i| i + 1)
             .unwrap_or_else(|| self.input.len());
@@ -236,8 +238,7 @@ pub fn split_at<'a, A: Clone>(
 
     // Consume all tokens before the split
     let mut before = Vec::new();
-    for tok in rest {
-        // Use for instead of a while to avoid bounds checks
+    for tok in rest { // Use for instead of a while to avoid bounds checks
         if tok.1.len() > rest_split_i {
             break;
         }
@@ -290,7 +291,7 @@ pub fn modify_range<'a>(
     let (mut result, in_and_after) = split_at(v, r.start)?;
     let (inside, mut after) = split_at(&in_and_after, r.end - r.start)?;
 
-    result.extend(inside.iter().map(|(style, s)| (style.apply(modifier), *s)));
+    result.extend(inside.iter().map(|(style, s)| { (style.apply(modifier), *s)}));
     result.append(&mut after);
     Ok(result)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -249,6 +249,8 @@ pub fn split_at<'a, A: Clone>(
     let mut after = Vec::new();
     // If necessary, split the token the split falls inside
     if !rest.is_empty() && rest_split_i > 0 {
+        // Splitting in the middle of a multibyte character cause panic.
+        // To avoid it, this function may return Err.
         if !rest[0].1.is_char_boundary(rest_split_i) {
             return Err(std::fmt::Error);
         } else {
@@ -369,7 +371,7 @@ mod tests {
             )
         );
 
-        //Splitting inside a multibyte character returns Err
+        //Splitting in the middle of a multibyte character returns Err
         assert!(split_at(l, 4).is_err());
     }
 


### PR DESCRIPTION
Fixed #453 

See also another PR #456 .

This PR fixes `split_at`, which can panic when splitting occurs inside the middle of a wide character, to return `Result` to avoid panic.
Also includes some of rust-analyzer's formatting.

Test results:
commit 8678b7c68a7fbd195733aa23dcaa3dbaedaceb10

```
failures:
    highlighting::highlighter::tests::can_parse
    highlighting::highlighter::tests::can_parse_with_highlight_state_from_cache
    highlighting::highlighter::tests::test_ranges
    highlighting::theme_set::tests::can_parse_common_themes
    html::tests::strings
    html::tests::tricky_test_syntax
    parsing::parser::tests::can_compare_parse_states
    parsing::parser::tests::can_parse_backrefs
    parsing::parser::tests::can_parse_includes
    parsing::parser::tests::can_parse_issue25
    parsing::parser::tests::can_parse_preprocessor_rules
    parsing::parser::tests::can_parse_simple
    parsing::parser::tests::can_parse_yaml
    parsing::syntax_set::tests::can_load

test result: FAILED. 86 passed; 14 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.11s
```

fix-split_at-result

```
failures:
    highlighting::highlighter::tests::can_parse
    highlighting::highlighter::tests::can_parse_with_highlight_state_from_cache
    highlighting::highlighter::tests::test_ranges
    highlighting::theme_set::tests::can_parse_common_themes
    html::tests::strings
    html::tests::tricky_test_syntax
    parsing::parser::tests::can_compare_parse_states
    parsing::parser::tests::can_parse_backrefs
    parsing::parser::tests::can_parse_includes
    parsing::parser::tests::can_parse_issue25
    parsing::parser::tests::can_parse_preprocessor_rules
    parsing::parser::tests::can_parse_simple
    parsing::parser::tests::can_parse_yaml
    parsing::syntax_set::tests::can_load

test result: FAILED. 86 passed; 14 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.00s
```

which means nothing is changed by this PR except `split_at` and its test.