### PR TITLE
mlir: mlir is currently not syntax highlighted

### DIFF
--- a/testdata/test.mlir
+++ b/testdata/test.mlir
@@ -1,0 +1,13 @@
+// RUN: pylir-opt %s -convert-pylir-to-llvm --split-input-file | FileCheck %s
+
+func.func @is(%lhs : !py.dynamic, %rhs : !py.dynamic) -> i1 {
+    %0 = py.is %lhs, %rhs
+    return %0 : i1
+}
+
+// CHECK: @is
+// CHECK-SAME: %[[LHS:[[:alnum:]]+]]
+// CHECK-SAME: %[[RHS:[[:alnum:]]+]]
+// CHECK-NEXT: %[[RESULT:.*]] = llvm.icmp "eq" %[[LHS]], %[[RHS]]
+// CHECK-NEXT: llvm.return %[[RESULT]]
+


### PR DESCRIPTION
It seems that sublimehq/packages doesn't include syntax highlighting for MLIR files. Worth noting that they're syntax-highlighted on the GitHub interface, as well as on VSCode, with the MLIR package.