### PR TITLE
Make CI green by changing MSRV policy to "last three stable versions"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.53"
+  MIN_SUPPORTED_RUST_VERSION: "1.64" # MSRV policy = last three versions of stable
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/src/html.rs
+++ b/src/html.rs
@@ -470,7 +470,7 @@ pub fn append_highlighted_html_for_styled_line(
             let include_bg = match bg {
                 IncludeBackground::Yes => true,
                 IncludeBackground::No => false,
-                IncludeBackground::IfDifferent(c) => (style.background != c),
+                IncludeBackground::IfDifferent(c) => style.background != c,
             };
             if include_bg {
                 write!(s, "background-color:")?;


### PR DESCRIPTION
CI has been red for a while now, caused by us not bumping MSRV.

It doesn't make sense for us to have a generous MSRV policy if we don't maintain it. So make our MSRV policy  less generous by changing it to "last three stable versions". This is also what `time` (which we frequently have MSRV problems with) will start using, see https://github.com/time-rs/time/discussions/535. Clap has an even less generous one: https://docs.rs/clap/latest/clap/

> We will support the last two minor Rust releases

If someone is interested in reading more about MSRV policies, I recommend to read these discussions:
* https://github.com/rust-lang/libs-team/issues/72
* https://github.com/matklad/once_cell/issues/201

The reality is that if someone needs a more generous MSRV policy, then that someone needs to help us maintain it. I'm afraid it's not going to be me. If someone insists on using an old version of Rust, I do not think it is unreasonable for us to insist on that someone to also use an old version of syntect.

Also fix a lint.
