### PR TITLE
Update `regex-syntax`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.10", optional = true }
 walkdir = "2.0"
-regex-syntax = { version = "0.6", optional = true }
+regex-syntax = { version = "0.7", optional = true }
 bitflags = "1.0.4"
 plist = { version = "1.3", optional = true }
 bincode = { version = "1.0", optional = true }


### PR DESCRIPTION
This PR removes a duplicate `regex-syntax` dependency. `syntect` previously depended on the crate both directly (0.6) and indirectly through `fancy-regex` (0.7), resulting in a dependency on both versions. This PR updates `regex-syntax` to 0.7 everywhere.