### PR TITLE
Automate checking 'last 3 Rust versions' on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     name: Minimum supported rust version
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable minus 2 releases # MSRV policy = last three versions of stable
@@ -38,14 +38,14 @@ jobs:
     name: Documentation checks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps --document-private-items --all-features
 
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,6 @@ on:
     branches: [ master ]
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.64" # MSRV policy = last three versions of stable
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -17,11 +16,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ env.MIN_SUPPORTED_RUST_VERSION }}
-        default: true
-        profile: minimal
+        toolchain: stable minus 2 releases # MSRV policy = last three versions of stable
         components: clippy
     - name: Run cargo clippy
       run: |
@@ -51,6 +48,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build
       run: |
         cargo build


### PR DESCRIPTION
This PR replaces unmaintained [actions/toolchain](https://github.com/actions-rs/toolchain) with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain). It is well-maintained and supports 'stable minus N releases' syntax to specify toolchain version so that we don't need to maintain the `MIN_SUPPORTED_RUST_VERSION` variable manually. In addition, I updated `actions/checkout` since v2 seems no longer maintained in favor of v3.

I confirmed all jobs passed by this PR: https://github.com/rhysd/syntect/actions/runs/5453682953

Current master branch failed since Rust version was too old for some dependencies.