### PR TITLE
Add a CI check for the public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ rayon = "1.0.0"
 regex = "1.0"
 getopts = "0.2"
 pretty_assertions = "0.6"
+rustup-toolchain = "0.1.5"
+rustdoc-json = "0.8.7"
+public-api = "0.32.0"
+expect-test = "1.4.1"
 
 [features]
 

--- a/tests/public-api.txt
+++ b/tests/public-api.txt
@@ -1,0 +1,2424 @@
+pub mod syntect
+pub mod syntect::dumps
+pub fn syntect::dumps::dump_binary<T: serde::ser::Serialize>(o: &T) -> alloc::vec::Vec<u8>
+pub fn syntect::dumps::dump_to_file<T: serde::ser::Serialize, P: core::convert::AsRef<std::path::Path>>(o: &T, path: P) -> bincode::error::Result<()>
+pub fn syntect::dumps::dump_to_uncompressed_file<T: serde::ser::Serialize, P: core::convert::AsRef<std::path::Path>>(o: &T, path: P) -> bincode::error::Result<()>
+pub fn syntect::dumps::dump_to_writer<T: serde::ser::Serialize, W: std::io::Write>(to_dump: &T, output: W) -> bincode::error::Result<()>
+pub fn syntect::dumps::from_binary<T: serde::de::DeserializeOwned>(v: &[u8]) -> T
+pub fn syntect::dumps::from_dump_file<T: serde::de::DeserializeOwned, P: core::convert::AsRef<std::path::Path>>(path: P) -> bincode::error::Result<T>
+pub fn syntect::dumps::from_reader<T: serde::de::DeserializeOwned, R: std::io::BufRead>(input: R) -> bincode::error::Result<T>
+pub fn syntect::dumps::from_uncompressed_data<T: serde::de::DeserializeOwned>(v: &[u8]) -> bincode::error::Result<T>
+pub fn syntect::dumps::from_uncompressed_dump_file<T: serde::de::DeserializeOwned, P: core::convert::AsRef<std::path::Path>>(path: P) -> bincode::error::Result<T>
+pub mod syntect::easy
+pub struct syntect::easy::HighlightFile<'a>
+pub syntect::easy::HighlightFile::highlight_lines: syntect::easy::HighlightLines<'a>
+pub syntect::easy::HighlightFile::reader: std::io::buffered::bufreader::BufReader<std::fs::File>
+impl<'a> syntect::easy::HighlightFile<'a>
+pub fn syntect::easy::HighlightFile<'a>::new<P: core::convert::AsRef<std::path::Path>>(path_obj: P, ss: &syntect::parsing::SyntaxSet, theme: &'a syntect::highlighting::Theme) -> std::io::error::Result<syntect::easy::HighlightFile<'a>>
+impl<'a> !core::marker::Send for syntect::easy::HighlightFile<'a>
+impl<'a> !core::marker::Sync for syntect::easy::HighlightFile<'a>
+impl<'a> core::marker::Unpin for syntect::easy::HighlightFile<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::easy::HighlightFile<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::easy::HighlightFile<'a>
+impl<T, U> core::convert::Into<U> for syntect::easy::HighlightFile<'a> where U: core::convert::From<T>
+pub fn syntect::easy::HighlightFile<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::easy::HighlightFile<'a> where U: core::convert::Into<T>
+pub type syntect::easy::HighlightFile<'a>::Error = core::convert::Infallible
+pub fn syntect::easy::HighlightFile<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::easy::HighlightFile<'a> where U: core::convert::TryFrom<T>
+pub type syntect::easy::HighlightFile<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::easy::HighlightFile<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::easy::HighlightFile<'a> where T: 'static + core::marker::Sized
+pub fn syntect::easy::HighlightFile<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::easy::HighlightFile<'a> where T: core::marker::Sized
+pub fn syntect::easy::HighlightFile<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::easy::HighlightFile<'a> where T: core::marker::Sized
+pub fn syntect::easy::HighlightFile<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::easy::HighlightFile<'a>
+pub fn syntect::easy::HighlightFile<'a>::from(t: T) -> T
+pub struct syntect::easy::HighlightLines<'a>
+impl<'a> syntect::easy::HighlightLines<'a>
+pub fn syntect::easy::HighlightLines<'a>::highlight<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>
+pub fn syntect::easy::HighlightLines<'a>::highlight_line<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> core::result::Result<alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>, syntect::Error>
+pub fn syntect::easy::HighlightLines<'a>::new(syntax: &syntect::parsing::SyntaxReference, theme: &'a syntect::highlighting::Theme) -> syntect::easy::HighlightLines<'a>
+impl<'a> !core::marker::Send for syntect::easy::HighlightLines<'a>
+impl<'a> !core::marker::Sync for syntect::easy::HighlightLines<'a>
+impl<'a> core::marker::Unpin for syntect::easy::HighlightLines<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::easy::HighlightLines<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::easy::HighlightLines<'a>
+impl<T, U> core::convert::Into<U> for syntect::easy::HighlightLines<'a> where U: core::convert::From<T>
+pub fn syntect::easy::HighlightLines<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::easy::HighlightLines<'a> where U: core::convert::Into<T>
+pub type syntect::easy::HighlightLines<'a>::Error = core::convert::Infallible
+pub fn syntect::easy::HighlightLines<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::easy::HighlightLines<'a> where U: core::convert::TryFrom<T>
+pub type syntect::easy::HighlightLines<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::easy::HighlightLines<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::easy::HighlightLines<'a> where T: 'static + core::marker::Sized
+pub fn syntect::easy::HighlightLines<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::easy::HighlightLines<'a> where T: core::marker::Sized
+pub fn syntect::easy::HighlightLines<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::easy::HighlightLines<'a> where T: core::marker::Sized
+pub fn syntect::easy::HighlightLines<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::easy::HighlightLines<'a>
+pub fn syntect::easy::HighlightLines<'a>::from(t: T) -> T
+pub struct syntect::easy::ScopeRangeIterator<'a>
+impl<'a> syntect::easy::ScopeRangeIterator<'a>
+pub fn syntect::easy::ScopeRangeIterator<'a>::new(ops: &'a [(usize, syntect::parsing::ScopeStackOp)], line: &'a str) -> syntect::easy::ScopeRangeIterator<'a>
+impl<'a> core::iter::traits::iterator::Iterator for syntect::easy::ScopeRangeIterator<'a>
+pub type syntect::easy::ScopeRangeIterator<'a>::Item = (core::ops::range::Range<usize>, &'a syntect::parsing::ScopeStackOp)
+pub fn syntect::easy::ScopeRangeIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+impl<'a> core::fmt::Debug for syntect::easy::ScopeRangeIterator<'a>
+pub fn syntect::easy::ScopeRangeIterator<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Send for syntect::easy::ScopeRangeIterator<'a>
+impl<'a> core::marker::Sync for syntect::easy::ScopeRangeIterator<'a>
+impl<'a> core::marker::Unpin for syntect::easy::ScopeRangeIterator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::easy::ScopeRangeIterator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::easy::ScopeRangeIterator<'a>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::easy::ScopeRangeIterator<'a> where I: core::iter::traits::iterator::Iterator
+pub type syntect::easy::ScopeRangeIterator<'a>::IntoIter = I
+pub type syntect::easy::ScopeRangeIterator<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::easy::ScopeRangeIterator<'a>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::easy::ScopeRangeIterator<'a> where U: core::convert::From<T>
+pub fn syntect::easy::ScopeRangeIterator<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::easy::ScopeRangeIterator<'a> where U: core::convert::Into<T>
+pub type syntect::easy::ScopeRangeIterator<'a>::Error = core::convert::Infallible
+pub fn syntect::easy::ScopeRangeIterator<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::easy::ScopeRangeIterator<'a> where U: core::convert::TryFrom<T>
+pub type syntect::easy::ScopeRangeIterator<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::easy::ScopeRangeIterator<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::easy::ScopeRangeIterator<'a> where T: 'static + core::marker::Sized
+pub fn syntect::easy::ScopeRangeIterator<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::easy::ScopeRangeIterator<'a> where T: core::marker::Sized
+pub fn syntect::easy::ScopeRangeIterator<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::easy::ScopeRangeIterator<'a> where T: core::marker::Sized
+pub fn syntect::easy::ScopeRangeIterator<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::easy::ScopeRangeIterator<'a>
+pub fn syntect::easy::ScopeRangeIterator<'a>::from(t: T) -> T
+pub struct syntect::easy::ScopeRegionIterator<'a>
+impl<'a> syntect::easy::ScopeRegionIterator<'a>
+pub fn syntect::easy::ScopeRegionIterator<'a>::new(ops: &'a [(usize, syntect::parsing::ScopeStackOp)], line: &'a str) -> syntect::easy::ScopeRegionIterator<'a>
+impl<'a> core::iter::traits::iterator::Iterator for syntect::easy::ScopeRegionIterator<'a>
+pub type syntect::easy::ScopeRegionIterator<'a>::Item = (&'a str, &'a syntect::parsing::ScopeStackOp)
+pub fn syntect::easy::ScopeRegionIterator<'a>::next(&mut self) -> core::option::Option<Self::Item>
+impl<'a> core::fmt::Debug for syntect::easy::ScopeRegionIterator<'a>
+pub fn syntect::easy::ScopeRegionIterator<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Send for syntect::easy::ScopeRegionIterator<'a>
+impl<'a> core::marker::Sync for syntect::easy::ScopeRegionIterator<'a>
+impl<'a> core::marker::Unpin for syntect::easy::ScopeRegionIterator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::easy::ScopeRegionIterator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::easy::ScopeRegionIterator<'a>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::easy::ScopeRegionIterator<'a> where I: core::iter::traits::iterator::Iterator
+pub type syntect::easy::ScopeRegionIterator<'a>::IntoIter = I
+pub type syntect::easy::ScopeRegionIterator<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::easy::ScopeRegionIterator<'a>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::easy::ScopeRegionIterator<'a> where U: core::convert::From<T>
+pub fn syntect::easy::ScopeRegionIterator<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::easy::ScopeRegionIterator<'a> where U: core::convert::Into<T>
+pub type syntect::easy::ScopeRegionIterator<'a>::Error = core::convert::Infallible
+pub fn syntect::easy::ScopeRegionIterator<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::easy::ScopeRegionIterator<'a> where U: core::convert::TryFrom<T>
+pub type syntect::easy::ScopeRegionIterator<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::easy::ScopeRegionIterator<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::easy::ScopeRegionIterator<'a> where T: 'static + core::marker::Sized
+pub fn syntect::easy::ScopeRegionIterator<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::easy::ScopeRegionIterator<'a> where T: core::marker::Sized
+pub fn syntect::easy::ScopeRegionIterator<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::easy::ScopeRegionIterator<'a> where T: core::marker::Sized
+pub fn syntect::easy::ScopeRegionIterator<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::easy::ScopeRegionIterator<'a>
+pub fn syntect::easy::ScopeRegionIterator<'a>::from(t: T) -> T
+pub mod syntect::highlighting
+#[non_exhaustive] pub enum syntect::highlighting::ParseThemeError
+pub syntect::highlighting::ParseThemeError::ColorShemeScopeIsNotObject
+pub syntect::highlighting::ParseThemeError::ColorShemeSettingsIsNotObject
+pub syntect::highlighting::ParseThemeError::DuplicateSettings
+pub syntect::highlighting::ParseThemeError::IncorrectColor
+pub syntect::highlighting::ParseThemeError::IncorrectFontStyle(alloc::string::String)
+pub syntect::highlighting::ParseThemeError::IncorrectSettings
+pub syntect::highlighting::ParseThemeError::IncorrectSyntax
+pub syntect::highlighting::ParseThemeError::IncorrectUnderlineOption
+pub syntect::highlighting::ParseThemeError::ScopeParse(syntect::parsing::ParseScopeError)
+pub syntect::highlighting::ParseThemeError::ScopeSelectorIsNotString(alloc::string::String)
+pub syntect::highlighting::ParseThemeError::UndefinedScopeSettings(alloc::string::String)
+pub syntect::highlighting::ParseThemeError::UndefinedSettings
+impl core::convert::From<syntect::highlighting::ParseThemeError> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: syntect::highlighting::ParseThemeError) -> Self
+impl core::convert::From<syntect::parsing::ParseScopeError> for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::from(source: syntect::parsing::ParseScopeError) -> Self
+impl core::error::Error for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Display for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::highlighting::ParseThemeError
+impl core::marker::Sync for syntect::highlighting::ParseThemeError
+impl core::marker::Unpin for syntect::highlighting::ParseThemeError
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ParseThemeError
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ParseThemeError
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ParseThemeError where U: core::convert::From<T>
+pub fn syntect::highlighting::ParseThemeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ParseThemeError where U: core::convert::Into<T>
+pub type syntect::highlighting::ParseThemeError::Error = core::convert::Infallible
+pub fn syntect::highlighting::ParseThemeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ParseThemeError where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ParseThemeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ParseThemeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::highlighting::ParseThemeError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::highlighting::ParseThemeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::highlighting::ParseThemeError where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ParseThemeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ParseThemeError where T: core::marker::Sized
+pub fn syntect::highlighting::ParseThemeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ParseThemeError where T: core::marker::Sized
+pub fn syntect::highlighting::ParseThemeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::from(t: T) -> T
+#[non_exhaustive] pub enum syntect::highlighting::SettingsError
+pub syntect::highlighting::SettingsError::Plist(plist::error::Error)
+impl core::convert::From<plist::error::Error> for syntect::highlighting::SettingsError
+pub fn syntect::highlighting::SettingsError::from(error: plist::error::Error) -> syntect::highlighting::SettingsError
+impl core::convert::From<syntect::highlighting::SettingsError> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: syntect::highlighting::SettingsError) -> Self
+impl core::error::Error for syntect::highlighting::SettingsError
+impl core::fmt::Display for syntect::highlighting::SettingsError
+pub fn syntect::highlighting::SettingsError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::highlighting::SettingsError
+pub fn syntect::highlighting::SettingsError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::highlighting::SettingsError
+impl core::marker::Sync for syntect::highlighting::SettingsError
+impl core::marker::Unpin for syntect::highlighting::SettingsError
+impl !core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::SettingsError
+impl !core::panic::unwind_safe::UnwindSafe for syntect::highlighting::SettingsError
+impl<T, U> core::convert::Into<U> for syntect::highlighting::SettingsError where U: core::convert::From<T>
+pub fn syntect::highlighting::SettingsError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::SettingsError where U: core::convert::Into<T>
+pub type syntect::highlighting::SettingsError::Error = core::convert::Infallible
+pub fn syntect::highlighting::SettingsError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::SettingsError where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::SettingsError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::SettingsError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::highlighting::SettingsError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::highlighting::SettingsError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::highlighting::SettingsError where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::SettingsError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::SettingsError where T: core::marker::Sized
+pub fn syntect::highlighting::SettingsError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::SettingsError where T: core::marker::Sized
+pub fn syntect::highlighting::SettingsError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::SettingsError
+pub fn syntect::highlighting::SettingsError::from(t: T) -> T
+pub enum syntect::highlighting::UnderlineOption
+pub syntect::highlighting::UnderlineOption::None
+pub syntect::highlighting::UnderlineOption::SquigglyUnderline
+pub syntect::highlighting::UnderlineOption::StippledUnderline
+pub syntect::highlighting::UnderlineOption::Underline
+impl core::default::Default for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::default() -> syntect::highlighting::UnderlineOption
+impl core::str::traits::FromStr for syntect::highlighting::UnderlineOption
+pub type syntect::highlighting::UnderlineOption::Err = syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::UnderlineOption::from_str(s: &str) -> core::result::Result<syntect::highlighting::UnderlineOption, Self::Err>
+impl core::clone::Clone for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::clone(&self) -> syntect::highlighting::UnderlineOption
+impl core::cmp::PartialEq<syntect::highlighting::UnderlineOption> for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::eq(&self, other: &syntect::highlighting::UnderlineOption) -> bool
+impl core::fmt::Debug for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for syntect::highlighting::UnderlineOption
+impl serde::ser::Serialize for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::UnderlineOption
+impl core::marker::Sync for syntect::highlighting::UnderlineOption
+impl core::marker::Unpin for syntect::highlighting::UnderlineOption
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::UnderlineOption
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::UnderlineOption
+impl<T, U> core::convert::Into<U> for syntect::highlighting::UnderlineOption where U: core::convert::From<T>
+pub fn syntect::highlighting::UnderlineOption::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::UnderlineOption where U: core::convert::Into<T>
+pub type syntect::highlighting::UnderlineOption::Error = core::convert::Infallible
+pub fn syntect::highlighting::UnderlineOption::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::UnderlineOption where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::UnderlineOption::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::UnderlineOption::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::UnderlineOption where T: core::clone::Clone
+pub type syntect::highlighting::UnderlineOption::Owned = T
+pub fn syntect::highlighting::UnderlineOption::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::UnderlineOption::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::UnderlineOption where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::UnderlineOption::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::UnderlineOption where T: core::marker::Sized
+pub fn syntect::highlighting::UnderlineOption::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::UnderlineOption where T: core::marker::Sized
+pub fn syntect::highlighting::UnderlineOption::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::UnderlineOption
+pub fn syntect::highlighting::UnderlineOption::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::UnderlineOption where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::Color
+pub syntect::highlighting::Color::a: u8
+pub syntect::highlighting::Color::b: u8
+pub syntect::highlighting::Color::g: u8
+pub syntect::highlighting::Color::r: u8
+impl syntect::highlighting::Color
+pub const syntect::highlighting::Color::BLACK: syntect::highlighting::Color
+pub const syntect::highlighting::Color::WHITE: syntect::highlighting::Color
+impl core::fmt::Debug for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::str::traits::FromStr for syntect::highlighting::Color
+pub type syntect::highlighting::Color::Err = syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::Color::from_str(s: &str) -> core::result::Result<syntect::highlighting::Color, Self::Err>
+impl core::clone::Clone for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::clone(&self) -> syntect::highlighting::Color
+impl core::cmp::Eq for syntect::highlighting::Color
+impl core::cmp::PartialEq<syntect::highlighting::Color> for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::eq(&self, other: &syntect::highlighting::Color) -> bool
+impl core::hash::Hash for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for syntect::highlighting::Color
+impl core::marker::StructuralEq for syntect::highlighting::Color
+impl core::marker::StructuralPartialEq for syntect::highlighting::Color
+impl serde::ser::Serialize for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::Color
+impl core::marker::Sync for syntect::highlighting::Color
+impl core::marker::Unpin for syntect::highlighting::Color
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::Color
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::Color
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::Color where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::Color::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::Color where U: core::convert::From<T>
+pub fn syntect::highlighting::Color::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::Color where U: core::convert::Into<T>
+pub type syntect::highlighting::Color::Error = core::convert::Infallible
+pub fn syntect::highlighting::Color::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::Color where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::Color::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::Color::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::Color where T: core::clone::Clone
+pub type syntect::highlighting::Color::Owned = T
+pub fn syntect::highlighting::Color::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::Color::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::Color where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::Color::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::Color where T: core::marker::Sized
+pub fn syntect::highlighting::Color::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::Color where T: core::marker::Sized
+pub fn syntect::highlighting::Color::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::Color
+pub fn syntect::highlighting::Color::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::Color where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::FontStyle(_)
+impl syntect::highlighting::FontStyle
+pub const syntect::highlighting::FontStyle::BOLD: Self
+pub const syntect::highlighting::FontStyle::ITALIC: Self
+pub const syntect::highlighting::FontStyle::UNDERLINE: Self
+impl syntect::highlighting::FontStyle
+pub const fn syntect::highlighting::FontStyle::all() -> Self
+pub const fn syntect::highlighting::FontStyle::bits(&self) -> u8
+pub const fn syntect::highlighting::FontStyle::complement(self) -> Self
+pub const fn syntect::highlighting::FontStyle::contains(&self, other: Self) -> bool
+pub const fn syntect::highlighting::FontStyle::difference(self, other: Self) -> Self
+pub const fn syntect::highlighting::FontStyle::empty() -> Self
+pub const fn syntect::highlighting::FontStyle::from_bits(bits: u8) -> core::option::Option<Self>
+pub const fn syntect::highlighting::FontStyle::from_bits_retain(bits: u8) -> Self
+pub const fn syntect::highlighting::FontStyle::from_bits_truncate(bits: u8) -> Self
+pub fn syntect::highlighting::FontStyle::from_name(name: &str) -> core::option::Option<Self>
+pub fn syntect::highlighting::FontStyle::insert(&mut self, other: Self)
+pub const fn syntect::highlighting::FontStyle::intersection(self, other: Self) -> Self
+pub const fn syntect::highlighting::FontStyle::intersects(&self, other: Self) -> bool
+pub const fn syntect::highlighting::FontStyle::is_all(&self) -> bool
+pub const fn syntect::highlighting::FontStyle::is_empty(&self) -> bool
+pub fn syntect::highlighting::FontStyle::remove(&mut self, other: Self)
+pub fn syntect::highlighting::FontStyle::set(&mut self, other: Self, value: bool)
+pub const fn syntect::highlighting::FontStyle::symmetric_difference(self, other: Self) -> Self
+pub fn syntect::highlighting::FontStyle::toggle(&mut self, other: Self)
+pub const fn syntect::highlighting::FontStyle::union(self, other: Self) -> Self
+impl syntect::highlighting::FontStyle
+pub const fn syntect::highlighting::FontStyle::iter(&self) -> bitflags::iter::Iter<syntect::highlighting::FontStyle>
+pub const fn syntect::highlighting::FontStyle::iter_names(&self) -> bitflags::iter::IterNames<syntect::highlighting::FontStyle>
+impl bitflags::traits::Flags for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Bits = u8
+pub const syntect::highlighting::FontStyle::FLAGS: &'static [bitflags::traits::Flag<syntect::highlighting::FontStyle>]
+pub fn syntect::highlighting::FontStyle::bits(&self) -> u8
+pub fn syntect::highlighting::FontStyle::from_bits_retain(bits: u8) -> syntect::highlighting::FontStyle
+impl bitflags::traits::PublicFlags for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Internal = InternalBitFlags
+pub type syntect::highlighting::FontStyle::Primitive = u8
+impl core::default::Default for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::default() -> syntect::highlighting::FontStyle
+impl core::fmt::Binary for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::LowerHex for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Octal for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::UpperHex for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::iter::traits::collect::Extend<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::extend<T: core::iter::traits::collect::IntoIterator<Item = Self>>(&mut self, iterator: T)
+impl core::iter::traits::collect::FromIterator<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::from_iter<T: core::iter::traits::collect::IntoIterator<Item = Self>>(iterator: T) -> Self
+impl core::iter::traits::collect::IntoIterator for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::IntoIter = bitflags::iter::Iter<syntect::highlighting::FontStyle>
+pub type syntect::highlighting::FontStyle::Item = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::into_iter(self) -> Self::IntoIter
+impl core::ops::arith::Sub<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Output = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::sub(self, other: Self) -> Self
+impl core::ops::arith::SubAssign<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::sub_assign(&mut self, other: Self)
+impl core::ops::bit::BitAnd<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Output = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitand(self, other: Self) -> Self
+impl core::ops::bit::BitAndAssign<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitand_assign(&mut self, other: Self)
+impl core::ops::bit::BitOr<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Output = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitor(self, other: syntect::highlighting::FontStyle) -> Self
+impl core::ops::bit::BitOrAssign<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitor_assign(&mut self, other: Self)
+impl core::ops::bit::BitXor<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Output = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitxor(self, other: Self) -> Self
+impl core::ops::bit::BitXorAssign<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::bitxor_assign(&mut self, other: Self)
+impl core::ops::bit::Not for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Output = syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::not(self) -> Self
+impl core::str::traits::FromStr for syntect::highlighting::FontStyle
+pub type syntect::highlighting::FontStyle::Err = syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::FontStyle::from_str(s: &str) -> core::result::Result<syntect::highlighting::FontStyle, Self::Err>
+impl core::clone::Clone for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::clone(&self) -> syntect::highlighting::FontStyle
+impl core::cmp::Eq for syntect::highlighting::FontStyle
+impl core::cmp::PartialEq<syntect::highlighting::FontStyle> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::eq(&self, other: &syntect::highlighting::FontStyle) -> bool
+impl core::fmt::Debug for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for syntect::highlighting::FontStyle
+impl core::marker::StructuralEq for syntect::highlighting::FontStyle
+impl core::marker::StructuralPartialEq for syntect::highlighting::FontStyle
+impl serde::ser::Serialize for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::FontStyle
+impl core::marker::Sync for syntect::highlighting::FontStyle
+impl core::marker::Unpin for syntect::highlighting::FontStyle
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::FontStyle
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::FontStyle
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::FontStyle where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::FontStyle::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::FontStyle where U: core::convert::From<T>
+pub fn syntect::highlighting::FontStyle::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::FontStyle where U: core::convert::Into<T>
+pub type syntect::highlighting::FontStyle::Error = core::convert::Infallible
+pub fn syntect::highlighting::FontStyle::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::FontStyle where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::FontStyle::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::FontStyle::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::FontStyle where T: core::clone::Clone
+pub type syntect::highlighting::FontStyle::Owned = T
+pub fn syntect::highlighting::FontStyle::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::FontStyle::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::FontStyle where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::FontStyle::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::FontStyle where T: core::marker::Sized
+pub fn syntect::highlighting::FontStyle::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::FontStyle where T: core::marker::Sized
+pub fn syntect::highlighting::FontStyle::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::FontStyle
+pub fn syntect::highlighting::FontStyle::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::FontStyle where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> syntect::highlighting::HighlightIterator<'a, 'b>
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::new(state: &'a mut syntect::highlighting::HighlightState, changes: &'a [(usize, syntect::parsing::ScopeStackOp)], text: &'b str, highlighter: &'a syntect::highlighting::Highlighter<'_>) -> syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> core::iter::traits::iterator::Iterator for syntect::highlighting::HighlightIterator<'a, 'b>
+pub type syntect::highlighting::HighlightIterator<'a, 'b>::Item = (syntect::highlighting::Style, &'b str)
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::next(&mut self) -> core::option::Option<(syntect::highlighting::Style, &'b str)>
+impl<'a, 'b> core::fmt::Debug for syntect::highlighting::HighlightIterator<'a, 'b>
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a, 'b> core::marker::Send for syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> core::marker::Sync for syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> core::marker::Unpin for syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::HighlightIterator<'a, 'b>
+impl<'a, 'b> !core::panic::unwind_safe::UnwindSafe for syntect::highlighting::HighlightIterator<'a, 'b>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::highlighting::HighlightIterator<'a, 'b> where I: core::iter::traits::iterator::Iterator
+pub type syntect::highlighting::HighlightIterator<'a, 'b>::IntoIter = I
+pub type syntect::highlighting::HighlightIterator<'a, 'b>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::highlighting::HighlightIterator<'a, 'b> where U: core::convert::From<T>
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::HighlightIterator<'a, 'b> where U: core::convert::Into<T>
+pub type syntect::highlighting::HighlightIterator<'a, 'b>::Error = core::convert::Infallible
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::HighlightIterator<'a, 'b> where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::HighlightIterator<'a, 'b>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::highlighting::HighlightIterator<'a, 'b> where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::HighlightIterator<'a, 'b> where T: core::marker::Sized
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::HighlightIterator<'a, 'b> where T: core::marker::Sized
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::HighlightIterator<'a, 'b>
+pub fn syntect::highlighting::HighlightIterator<'a, 'b>::from(t: T) -> T
+pub struct syntect::highlighting::HighlightState
+pub syntect::highlighting::HighlightState::path: syntect::parsing::ScopeStack
+impl syntect::highlighting::HighlightState
+pub fn syntect::highlighting::HighlightState::new(highlighter: &syntect::highlighting::Highlighter<'_>, initial_stack: syntect::parsing::ScopeStack) -> syntect::highlighting::HighlightState
+impl core::clone::Clone for syntect::highlighting::HighlightState
+pub fn syntect::highlighting::HighlightState::clone(&self) -> syntect::highlighting::HighlightState
+impl core::cmp::Eq for syntect::highlighting::HighlightState
+impl core::cmp::PartialEq<syntect::highlighting::HighlightState> for syntect::highlighting::HighlightState
+pub fn syntect::highlighting::HighlightState::eq(&self, other: &syntect::highlighting::HighlightState) -> bool
+impl core::fmt::Debug for syntect::highlighting::HighlightState
+pub fn syntect::highlighting::HighlightState::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::highlighting::HighlightState
+impl core::marker::StructuralPartialEq for syntect::highlighting::HighlightState
+impl core::marker::Send for syntect::highlighting::HighlightState
+impl core::marker::Sync for syntect::highlighting::HighlightState
+impl core::marker::Unpin for syntect::highlighting::HighlightState
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::HighlightState
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::HighlightState
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::HighlightState where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::HighlightState::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::HighlightState where U: core::convert::From<T>
+pub fn syntect::highlighting::HighlightState::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::HighlightState where U: core::convert::Into<T>
+pub type syntect::highlighting::HighlightState::Error = core::convert::Infallible
+pub fn syntect::highlighting::HighlightState::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::HighlightState where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::HighlightState::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::HighlightState::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::HighlightState where T: core::clone::Clone
+pub type syntect::highlighting::HighlightState::Owned = T
+pub fn syntect::highlighting::HighlightState::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::HighlightState::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::HighlightState where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::HighlightState::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::HighlightState where T: core::marker::Sized
+pub fn syntect::highlighting::HighlightState::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::HighlightState where T: core::marker::Sized
+pub fn syntect::highlighting::HighlightState::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::HighlightState
+pub fn syntect::highlighting::HighlightState::from(t: T) -> T
+pub struct syntect::highlighting::Highlighter<'a>
+impl<'a> syntect::highlighting::Highlighter<'a>
+pub fn syntect::highlighting::Highlighter<'a>::get_default(&self) -> syntect::highlighting::Style
+pub fn syntect::highlighting::Highlighter<'a>::new(theme: &'a syntect::highlighting::Theme) -> syntect::highlighting::Highlighter<'a>
+pub fn syntect::highlighting::Highlighter<'a>::style_for_stack(&self, stack: &[syntect::parsing::Scope]) -> syntect::highlighting::Style
+pub fn syntect::highlighting::Highlighter<'a>::style_mod_for_stack(&self, path: &[syntect::parsing::Scope]) -> syntect::highlighting::StyleModifier
+impl<'a> core::fmt::Debug for syntect::highlighting::Highlighter<'a>
+pub fn syntect::highlighting::Highlighter<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Send for syntect::highlighting::Highlighter<'a>
+impl<'a> core::marker::Sync for syntect::highlighting::Highlighter<'a>
+impl<'a> core::marker::Unpin for syntect::highlighting::Highlighter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::Highlighter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::highlighting::Highlighter<'a>
+impl<T, U> core::convert::Into<U> for syntect::highlighting::Highlighter<'a> where U: core::convert::From<T>
+pub fn syntect::highlighting::Highlighter<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::Highlighter<'a> where U: core::convert::Into<T>
+pub type syntect::highlighting::Highlighter<'a>::Error = core::convert::Infallible
+pub fn syntect::highlighting::Highlighter<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::Highlighter<'a> where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::Highlighter<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::Highlighter<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::highlighting::Highlighter<'a> where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::Highlighter<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::Highlighter<'a> where T: core::marker::Sized
+pub fn syntect::highlighting::Highlighter<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::Highlighter<'a> where T: core::marker::Sized
+pub fn syntect::highlighting::Highlighter<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::Highlighter<'a>
+pub fn syntect::highlighting::Highlighter<'a>::from(t: T) -> T
+pub struct syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> syntect::highlighting::RangedHighlightIterator<'a, 'b>
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::new(state: &'a mut syntect::highlighting::HighlightState, changes: &'a [(usize, syntect::parsing::ScopeStackOp)], text: &'b str, highlighter: &'a syntect::highlighting::Highlighter<'_>) -> syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> core::iter::traits::iterator::Iterator for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+pub type syntect::highlighting::RangedHighlightIterator<'a, 'b>::Item = (syntect::highlighting::Style, &'b str, core::ops::range::Range<usize>)
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::next(&mut self) -> core::option::Option<(syntect::highlighting::Style, &'b str, core::ops::range::Range<usize>)>
+impl<'a, 'b> core::fmt::Debug for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a, 'b> core::marker::Send for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> core::marker::Sync for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> core::marker::Unpin for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<'a, 'b> !core::panic::unwind_safe::UnwindSafe for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::highlighting::RangedHighlightIterator<'a, 'b> where I: core::iter::traits::iterator::Iterator
+pub type syntect::highlighting::RangedHighlightIterator<'a, 'b>::IntoIter = I
+pub type syntect::highlighting::RangedHighlightIterator<'a, 'b>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::highlighting::RangedHighlightIterator<'a, 'b> where U: core::convert::From<T>
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::RangedHighlightIterator<'a, 'b> where U: core::convert::Into<T>
+pub type syntect::highlighting::RangedHighlightIterator<'a, 'b>::Error = core::convert::Infallible
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::RangedHighlightIterator<'a, 'b> where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::RangedHighlightIterator<'a, 'b>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::highlighting::RangedHighlightIterator<'a, 'b> where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::RangedHighlightIterator<'a, 'b> where T: core::marker::Sized
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::RangedHighlightIterator<'a, 'b> where T: core::marker::Sized
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::RangedHighlightIterator<'a, 'b>
+pub fn syntect::highlighting::RangedHighlightIterator<'a, 'b>::from(t: T) -> T
+pub struct syntect::highlighting::ScopeSelector
+pub syntect::highlighting::ScopeSelector::excludes: alloc::vec::Vec<syntect::parsing::ScopeStack>
+pub syntect::highlighting::ScopeSelector::path: syntect::parsing::ScopeStack
+impl syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::does_match(&self, stack: &[syntect::parsing::Scope]) -> core::option::Option<syntect::parsing::MatchPower>
+pub fn syntect::highlighting::ScopeSelector::extract_scopes(&self) -> alloc::vec::Vec<syntect::parsing::Scope>
+pub fn syntect::highlighting::ScopeSelector::extract_single_scope(&self) -> core::option::Option<syntect::parsing::Scope>
+impl core::str::traits::FromStr for syntect::highlighting::ScopeSelector
+pub type syntect::highlighting::ScopeSelector::Err = syntect::parsing::ParseScopeError
+pub fn syntect::highlighting::ScopeSelector::from_str(s: &str) -> core::result::Result<syntect::highlighting::ScopeSelector, syntect::parsing::ParseScopeError>
+impl core::clone::Clone for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::clone(&self) -> syntect::highlighting::ScopeSelector
+impl core::cmp::Eq for syntect::highlighting::ScopeSelector
+impl core::cmp::PartialEq<syntect::highlighting::ScopeSelector> for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::eq(&self, other: &syntect::highlighting::ScopeSelector) -> bool
+impl core::default::Default for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::default() -> syntect::highlighting::ScopeSelector
+impl core::fmt::Debug for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::highlighting::ScopeSelector
+impl core::marker::StructuralPartialEq for syntect::highlighting::ScopeSelector
+impl serde::ser::Serialize for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::ScopeSelector
+impl core::marker::Sync for syntect::highlighting::ScopeSelector
+impl core::marker::Unpin for syntect::highlighting::ScopeSelector
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ScopeSelector
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ScopeSelector
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::ScopeSelector where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::ScopeSelector::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ScopeSelector where U: core::convert::From<T>
+pub fn syntect::highlighting::ScopeSelector::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ScopeSelector where U: core::convert::Into<T>
+pub type syntect::highlighting::ScopeSelector::Error = core::convert::Infallible
+pub fn syntect::highlighting::ScopeSelector::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ScopeSelector where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ScopeSelector::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ScopeSelector::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::ScopeSelector where T: core::clone::Clone
+pub type syntect::highlighting::ScopeSelector::Owned = T
+pub fn syntect::highlighting::ScopeSelector::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::ScopeSelector::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::ScopeSelector where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ScopeSelector::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ScopeSelector where T: core::marker::Sized
+pub fn syntect::highlighting::ScopeSelector::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ScopeSelector where T: core::marker::Sized
+pub fn syntect::highlighting::ScopeSelector::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ScopeSelector
+pub fn syntect::highlighting::ScopeSelector::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::ScopeSelector where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::ScopeSelectors
+pub syntect::highlighting::ScopeSelectors::selectors: alloc::vec::Vec<syntect::highlighting::ScopeSelector>
+impl syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::does_match(&self, stack: &[syntect::parsing::Scope]) -> core::option::Option<syntect::parsing::MatchPower>
+impl core::str::traits::FromStr for syntect::highlighting::ScopeSelectors
+pub type syntect::highlighting::ScopeSelectors::Err = syntect::parsing::ParseScopeError
+pub fn syntect::highlighting::ScopeSelectors::from_str(s: &str) -> core::result::Result<syntect::highlighting::ScopeSelectors, syntect::parsing::ParseScopeError>
+impl core::clone::Clone for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::clone(&self) -> syntect::highlighting::ScopeSelectors
+impl core::cmp::Eq for syntect::highlighting::ScopeSelectors
+impl core::cmp::PartialEq<syntect::highlighting::ScopeSelectors> for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::eq(&self, other: &syntect::highlighting::ScopeSelectors) -> bool
+impl core::default::Default for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::default() -> syntect::highlighting::ScopeSelectors
+impl core::fmt::Debug for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::highlighting::ScopeSelectors
+impl core::marker::StructuralPartialEq for syntect::highlighting::ScopeSelectors
+impl serde::ser::Serialize for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::ScopeSelectors
+impl core::marker::Sync for syntect::highlighting::ScopeSelectors
+impl core::marker::Unpin for syntect::highlighting::ScopeSelectors
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ScopeSelectors
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ScopeSelectors
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::ScopeSelectors where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::ScopeSelectors::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ScopeSelectors where U: core::convert::From<T>
+pub fn syntect::highlighting::ScopeSelectors::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ScopeSelectors where U: core::convert::Into<T>
+pub type syntect::highlighting::ScopeSelectors::Error = core::convert::Infallible
+pub fn syntect::highlighting::ScopeSelectors::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ScopeSelectors where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ScopeSelectors::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ScopeSelectors::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::ScopeSelectors where T: core::clone::Clone
+pub type syntect::highlighting::ScopeSelectors::Owned = T
+pub fn syntect::highlighting::ScopeSelectors::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::ScopeSelectors::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::ScopeSelectors where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ScopeSelectors::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ScopeSelectors where T: core::marker::Sized
+pub fn syntect::highlighting::ScopeSelectors::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ScopeSelectors where T: core::marker::Sized
+pub fn syntect::highlighting::ScopeSelectors::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ScopeSelectors
+pub fn syntect::highlighting::ScopeSelectors::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::ScopeSelectors where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::ScoredStyle
+pub syntect::highlighting::ScoredStyle::background: (syntect::parsing::MatchPower, syntect::highlighting::Color)
+pub syntect::highlighting::ScoredStyle::font_style: (syntect::parsing::MatchPower, syntect::highlighting::FontStyle)
+pub syntect::highlighting::ScoredStyle::foreground: (syntect::parsing::MatchPower, syntect::highlighting::Color)
+impl core::clone::Clone for syntect::highlighting::ScoredStyle
+pub fn syntect::highlighting::ScoredStyle::clone(&self) -> syntect::highlighting::ScoredStyle
+impl core::cmp::Eq for syntect::highlighting::ScoredStyle
+impl core::cmp::PartialEq<syntect::highlighting::ScoredStyle> for syntect::highlighting::ScoredStyle
+pub fn syntect::highlighting::ScoredStyle::eq(&self, other: &syntect::highlighting::ScoredStyle) -> bool
+impl core::fmt::Debug for syntect::highlighting::ScoredStyle
+pub fn syntect::highlighting::ScoredStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::highlighting::ScoredStyle
+impl core::marker::StructuralPartialEq for syntect::highlighting::ScoredStyle
+impl core::marker::Send for syntect::highlighting::ScoredStyle
+impl core::marker::Sync for syntect::highlighting::ScoredStyle
+impl core::marker::Unpin for syntect::highlighting::ScoredStyle
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ScoredStyle
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ScoredStyle
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::ScoredStyle where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::ScoredStyle::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ScoredStyle where U: core::convert::From<T>
+pub fn syntect::highlighting::ScoredStyle::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ScoredStyle where U: core::convert::Into<T>
+pub type syntect::highlighting::ScoredStyle::Error = core::convert::Infallible
+pub fn syntect::highlighting::ScoredStyle::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ScoredStyle where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ScoredStyle::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ScoredStyle::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::ScoredStyle where T: core::clone::Clone
+pub type syntect::highlighting::ScoredStyle::Owned = T
+pub fn syntect::highlighting::ScoredStyle::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::ScoredStyle::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::ScoredStyle where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ScoredStyle::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ScoredStyle where T: core::marker::Sized
+pub fn syntect::highlighting::ScoredStyle::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ScoredStyle where T: core::marker::Sized
+pub fn syntect::highlighting::ScoredStyle::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ScoredStyle
+pub fn syntect::highlighting::ScoredStyle::from(t: T) -> T
+pub struct syntect::highlighting::Style
+pub syntect::highlighting::Style::background: syntect::highlighting::Color
+pub syntect::highlighting::Style::font_style: syntect::highlighting::FontStyle
+pub syntect::highlighting::Style::foreground: syntect::highlighting::Color
+impl syntect::highlighting::Style
+pub fn syntect::highlighting::Style::apply(&self, modifier: syntect::highlighting::StyleModifier) -> syntect::highlighting::Style
+impl core::default::Default for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::default() -> syntect::highlighting::Style
+impl core::clone::Clone for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::clone(&self) -> syntect::highlighting::Style
+impl core::cmp::Eq for syntect::highlighting::Style
+impl core::cmp::PartialEq<syntect::highlighting::Style> for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::eq(&self, other: &syntect::highlighting::Style) -> bool
+impl core::fmt::Debug for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for syntect::highlighting::Style
+impl core::marker::StructuralEq for syntect::highlighting::Style
+impl core::marker::StructuralPartialEq for syntect::highlighting::Style
+impl serde::ser::Serialize for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::Style
+impl core::marker::Sync for syntect::highlighting::Style
+impl core::marker::Unpin for syntect::highlighting::Style
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::Style
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::Style
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::Style where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::Style::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::Style where U: core::convert::From<T>
+pub fn syntect::highlighting::Style::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::Style where U: core::convert::Into<T>
+pub type syntect::highlighting::Style::Error = core::convert::Infallible
+pub fn syntect::highlighting::Style::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::Style where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::Style::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::Style::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::Style where T: core::clone::Clone
+pub type syntect::highlighting::Style::Owned = T
+pub fn syntect::highlighting::Style::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::Style::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::Style where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::Style::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::Style where T: core::marker::Sized
+pub fn syntect::highlighting::Style::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::Style where T: core::marker::Sized
+pub fn syntect::highlighting::Style::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::Style
+pub fn syntect::highlighting::Style::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::Style where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::StyleModifier
+pub syntect::highlighting::StyleModifier::background: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::StyleModifier::font_style: core::option::Option<syntect::highlighting::FontStyle>
+pub syntect::highlighting::StyleModifier::foreground: core::option::Option<syntect::highlighting::Color>
+impl syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::apply(&self, other: syntect::highlighting::StyleModifier) -> syntect::highlighting::StyleModifier
+impl core::clone::Clone for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::clone(&self) -> syntect::highlighting::StyleModifier
+impl core::cmp::Eq for syntect::highlighting::StyleModifier
+impl core::cmp::PartialEq<syntect::highlighting::StyleModifier> for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::eq(&self, other: &syntect::highlighting::StyleModifier) -> bool
+impl core::default::Default for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::default() -> syntect::highlighting::StyleModifier
+impl core::fmt::Debug for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for syntect::highlighting::StyleModifier
+impl core::marker::StructuralEq for syntect::highlighting::StyleModifier
+impl core::marker::StructuralPartialEq for syntect::highlighting::StyleModifier
+impl serde::ser::Serialize for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::StyleModifier
+impl core::marker::Sync for syntect::highlighting::StyleModifier
+impl core::marker::Unpin for syntect::highlighting::StyleModifier
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::StyleModifier
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::StyleModifier
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::highlighting::StyleModifier where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::highlighting::StyleModifier::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::highlighting::StyleModifier where U: core::convert::From<T>
+pub fn syntect::highlighting::StyleModifier::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::StyleModifier where U: core::convert::Into<T>
+pub type syntect::highlighting::StyleModifier::Error = core::convert::Infallible
+pub fn syntect::highlighting::StyleModifier::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::StyleModifier where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::StyleModifier::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::StyleModifier::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::StyleModifier where T: core::clone::Clone
+pub type syntect::highlighting::StyleModifier::Owned = T
+pub fn syntect::highlighting::StyleModifier::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::StyleModifier::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::StyleModifier where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::StyleModifier::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::StyleModifier where T: core::marker::Sized
+pub fn syntect::highlighting::StyleModifier::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::StyleModifier where T: core::marker::Sized
+pub fn syntect::highlighting::StyleModifier::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::StyleModifier
+pub fn syntect::highlighting::StyleModifier::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::StyleModifier where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::Theme
+pub syntect::highlighting::Theme::author: core::option::Option<alloc::string::String>
+pub syntect::highlighting::Theme::name: core::option::Option<alloc::string::String>
+pub syntect::highlighting::Theme::scopes: alloc::vec::Vec<syntect::highlighting::ThemeItem>
+pub syntect::highlighting::Theme::settings: syntect::highlighting::ThemeSettings
+impl core::clone::Clone for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::clone(&self) -> syntect::highlighting::Theme
+impl core::cmp::PartialEq<syntect::highlighting::Theme> for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::eq(&self, other: &syntect::highlighting::Theme) -> bool
+impl core::default::Default for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::default() -> syntect::highlighting::Theme
+impl core::fmt::Debug for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for syntect::highlighting::Theme
+impl serde::ser::Serialize for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::Theme
+impl core::marker::Sync for syntect::highlighting::Theme
+impl core::marker::Unpin for syntect::highlighting::Theme
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::Theme
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::Theme
+impl<T, U> core::convert::Into<U> for syntect::highlighting::Theme where U: core::convert::From<T>
+pub fn syntect::highlighting::Theme::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::Theme where U: core::convert::Into<T>
+pub type syntect::highlighting::Theme::Error = core::convert::Infallible
+pub fn syntect::highlighting::Theme::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::Theme where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::Theme::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::Theme::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::Theme where T: core::clone::Clone
+pub type syntect::highlighting::Theme::Owned = T
+pub fn syntect::highlighting::Theme::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::Theme::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::Theme where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::Theme::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::Theme where T: core::marker::Sized
+pub fn syntect::highlighting::Theme::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::Theme where T: core::marker::Sized
+pub fn syntect::highlighting::Theme::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::Theme
+pub fn syntect::highlighting::Theme::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::Theme where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::ThemeItem
+pub syntect::highlighting::ThemeItem::scope: syntect::highlighting::ScopeSelectors
+pub syntect::highlighting::ThemeItem::style: syntect::highlighting::StyleModifier
+impl core::clone::Clone for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::clone(&self) -> syntect::highlighting::ThemeItem
+impl core::cmp::PartialEq<syntect::highlighting::ThemeItem> for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::eq(&self, other: &syntect::highlighting::ThemeItem) -> bool
+impl core::default::Default for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::default() -> syntect::highlighting::ThemeItem
+impl core::fmt::Debug for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for syntect::highlighting::ThemeItem
+impl serde::ser::Serialize for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::ThemeItem
+impl core::marker::Sync for syntect::highlighting::ThemeItem
+impl core::marker::Unpin for syntect::highlighting::ThemeItem
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ThemeItem
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ThemeItem
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ThemeItem where U: core::convert::From<T>
+pub fn syntect::highlighting::ThemeItem::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ThemeItem where U: core::convert::Into<T>
+pub type syntect::highlighting::ThemeItem::Error = core::convert::Infallible
+pub fn syntect::highlighting::ThemeItem::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ThemeItem where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ThemeItem::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ThemeItem::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::ThemeItem where T: core::clone::Clone
+pub type syntect::highlighting::ThemeItem::Owned = T
+pub fn syntect::highlighting::ThemeItem::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::ThemeItem::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::ThemeItem where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ThemeItem::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ThemeItem where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeItem::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ThemeItem where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeItem::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ThemeItem
+pub fn syntect::highlighting::ThemeItem::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::ThemeItem where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::ThemeSet
+pub syntect::highlighting::ThemeSet::themes: alloc::collections::btree::map::BTreeMap<alloc::string::String, syntect::highlighting::Theme>
+impl syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::add_from_folder<P: core::convert::AsRef<std::path::Path>>(&mut self, folder: P) -> core::result::Result<(), syntect::LoadingError>
+pub fn syntect::highlighting::ThemeSet::discover_theme_paths<P: core::convert::AsRef<std::path::Path>>(folder: P) -> core::result::Result<alloc::vec::Vec<std::path::PathBuf>, syntect::LoadingError>
+pub fn syntect::highlighting::ThemeSet::get_theme<P: core::convert::AsRef<std::path::Path>>(path: P) -> core::result::Result<syntect::highlighting::Theme, syntect::LoadingError>
+pub fn syntect::highlighting::ThemeSet::load_from_folder<P: core::convert::AsRef<std::path::Path>>(folder: P) -> core::result::Result<syntect::highlighting::ThemeSet, syntect::LoadingError>
+pub fn syntect::highlighting::ThemeSet::load_from_reader<R: std::io::BufRead + std::io::Seek>(r: &mut R) -> core::result::Result<syntect::highlighting::Theme, syntect::LoadingError>
+pub fn syntect::highlighting::ThemeSet::new() -> syntect::highlighting::ThemeSet
+impl syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::load_defaults() -> syntect::highlighting::ThemeSet
+impl core::default::Default for syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::default() -> syntect::highlighting::ThemeSet
+impl core::fmt::Debug for syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::ThemeSet
+impl core::marker::Sync for syntect::highlighting::ThemeSet
+impl core::marker::Unpin for syntect::highlighting::ThemeSet
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ThemeSet
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ThemeSet
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ThemeSet where U: core::convert::From<T>
+pub fn syntect::highlighting::ThemeSet::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ThemeSet where U: core::convert::Into<T>
+pub type syntect::highlighting::ThemeSet::Error = core::convert::Infallible
+pub fn syntect::highlighting::ThemeSet::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ThemeSet where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ThemeSet::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ThemeSet::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::highlighting::ThemeSet where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ThemeSet::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ThemeSet where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeSet::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ThemeSet where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeSet::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ThemeSet
+pub fn syntect::highlighting::ThemeSet::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::ThemeSet where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::highlighting::ThemeSettings
+pub syntect::highlighting::ThemeSettings::accent: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::active_guide: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::background: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::bracket_contents_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::bracket_contents_options: core::option::Option<syntect::highlighting::UnderlineOption>
+pub syntect::highlighting::ThemeSettings::brackets_background: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::brackets_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::brackets_options: core::option::Option<syntect::highlighting::UnderlineOption>
+pub syntect::highlighting::ThemeSettings::caret: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::find_highlight: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::find_highlight_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::guide: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::gutter: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::gutter_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::highlight: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::inactive_selection: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::inactive_selection_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::line_highlight: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::minimap_border: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::misspelling: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::phantom_css: core::option::Option<alloc::string::String>
+pub syntect::highlighting::ThemeSettings::popup_css: core::option::Option<alloc::string::String>
+pub syntect::highlighting::ThemeSettings::selection: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::selection_border: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::selection_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::shadow: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::stack_guide: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::tags_foreground: core::option::Option<syntect::highlighting::Color>
+pub syntect::highlighting::ThemeSettings::tags_options: core::option::Option<syntect::highlighting::UnderlineOption>
+impl core::clone::Clone for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::clone(&self) -> syntect::highlighting::ThemeSettings
+impl core::cmp::PartialEq<syntect::highlighting::ThemeSettings> for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::eq(&self, other: &syntect::highlighting::ThemeSettings) -> bool
+impl core::default::Default for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::default() -> syntect::highlighting::ThemeSettings
+impl core::fmt::Debug for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for syntect::highlighting::ThemeSettings
+impl serde::ser::Serialize for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::highlighting::ThemeSettings
+impl core::marker::Sync for syntect::highlighting::ThemeSettings
+impl core::marker::Unpin for syntect::highlighting::ThemeSettings
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::highlighting::ThemeSettings
+impl core::panic::unwind_safe::UnwindSafe for syntect::highlighting::ThemeSettings
+impl<T, U> core::convert::Into<U> for syntect::highlighting::ThemeSettings where U: core::convert::From<T>
+pub fn syntect::highlighting::ThemeSettings::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::highlighting::ThemeSettings where U: core::convert::Into<T>
+pub type syntect::highlighting::ThemeSettings::Error = core::convert::Infallible
+pub fn syntect::highlighting::ThemeSettings::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::highlighting::ThemeSettings where U: core::convert::TryFrom<T>
+pub type syntect::highlighting::ThemeSettings::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::highlighting::ThemeSettings::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::highlighting::ThemeSettings where T: core::clone::Clone
+pub type syntect::highlighting::ThemeSettings::Owned = T
+pub fn syntect::highlighting::ThemeSettings::clone_into(&self, target: &mut T)
+pub fn syntect::highlighting::ThemeSettings::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::highlighting::ThemeSettings where T: 'static + core::marker::Sized
+pub fn syntect::highlighting::ThemeSettings::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::highlighting::ThemeSettings where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeSettings::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::highlighting::ThemeSettings where T: core::marker::Sized
+pub fn syntect::highlighting::ThemeSettings::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::highlighting::ThemeSettings
+pub fn syntect::highlighting::ThemeSettings::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::highlighting::ThemeSettings where T: for<'de> serde::de::Deserialize<'de>
+pub mod syntect::html
+#[non_exhaustive] pub enum syntect::html::ClassStyle
+pub syntect::html::ClassStyle::Spaced
+pub syntect::html::ClassStyle::SpacedPrefixed
+pub syntect::html::ClassStyle::SpacedPrefixed::prefix: &'static str
+impl core::clone::Clone for syntect::html::ClassStyle
+pub fn syntect::html::ClassStyle::clone(&self) -> syntect::html::ClassStyle
+impl core::cmp::Eq for syntect::html::ClassStyle
+impl core::cmp::PartialEq<syntect::html::ClassStyle> for syntect::html::ClassStyle
+pub fn syntect::html::ClassStyle::eq(&self, other: &syntect::html::ClassStyle) -> bool
+impl core::fmt::Debug for syntect::html::ClassStyle
+pub fn syntect::html::ClassStyle::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for syntect::html::ClassStyle
+impl core::marker::StructuralEq for syntect::html::ClassStyle
+impl core::marker::StructuralPartialEq for syntect::html::ClassStyle
+impl core::marker::Send for syntect::html::ClassStyle
+impl core::marker::Sync for syntect::html::ClassStyle
+impl core::marker::Unpin for syntect::html::ClassStyle
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::html::ClassStyle
+impl core::panic::unwind_safe::UnwindSafe for syntect::html::ClassStyle
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::html::ClassStyle where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::html::ClassStyle::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::html::ClassStyle where U: core::convert::From<T>
+pub fn syntect::html::ClassStyle::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::html::ClassStyle where U: core::convert::Into<T>
+pub type syntect::html::ClassStyle::Error = core::convert::Infallible
+pub fn syntect::html::ClassStyle::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::html::ClassStyle where U: core::convert::TryFrom<T>
+pub type syntect::html::ClassStyle::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::html::ClassStyle::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::html::ClassStyle where T: core::clone::Clone
+pub type syntect::html::ClassStyle::Owned = T
+pub fn syntect::html::ClassStyle::clone_into(&self, target: &mut T)
+pub fn syntect::html::ClassStyle::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::html::ClassStyle where T: 'static + core::marker::Sized
+pub fn syntect::html::ClassStyle::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::html::ClassStyle where T: core::marker::Sized
+pub fn syntect::html::ClassStyle::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::html::ClassStyle where T: core::marker::Sized
+pub fn syntect::html::ClassStyle::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::html::ClassStyle
+pub fn syntect::html::ClassStyle::from(t: T) -> T
+pub enum syntect::html::IncludeBackground
+pub syntect::html::IncludeBackground::IfDifferent(syntect::highlighting::Color)
+pub syntect::html::IncludeBackground::No
+pub syntect::html::IncludeBackground::Yes
+impl core::clone::Clone for syntect::html::IncludeBackground
+pub fn syntect::html::IncludeBackground::clone(&self) -> syntect::html::IncludeBackground
+impl core::cmp::Eq for syntect::html::IncludeBackground
+impl core::cmp::PartialEq<syntect::html::IncludeBackground> for syntect::html::IncludeBackground
+pub fn syntect::html::IncludeBackground::eq(&self, other: &syntect::html::IncludeBackground) -> bool
+impl core::fmt::Debug for syntect::html::IncludeBackground
+pub fn syntect::html::IncludeBackground::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for syntect::html::IncludeBackground
+impl core::marker::StructuralEq for syntect::html::IncludeBackground
+impl core::marker::StructuralPartialEq for syntect::html::IncludeBackground
+impl core::marker::Send for syntect::html::IncludeBackground
+impl core::marker::Sync for syntect::html::IncludeBackground
+impl core::marker::Unpin for syntect::html::IncludeBackground
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::html::IncludeBackground
+impl core::panic::unwind_safe::UnwindSafe for syntect::html::IncludeBackground
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::html::IncludeBackground where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::html::IncludeBackground::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::html::IncludeBackground where U: core::convert::From<T>
+pub fn syntect::html::IncludeBackground::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::html::IncludeBackground where U: core::convert::Into<T>
+pub type syntect::html::IncludeBackground::Error = core::convert::Infallible
+pub fn syntect::html::IncludeBackground::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::html::IncludeBackground where U: core::convert::TryFrom<T>
+pub type syntect::html::IncludeBackground::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::html::IncludeBackground::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::html::IncludeBackground where T: core::clone::Clone
+pub type syntect::html::IncludeBackground::Owned = T
+pub fn syntect::html::IncludeBackground::clone_into(&self, target: &mut T)
+pub fn syntect::html::IncludeBackground::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::html::IncludeBackground where T: 'static + core::marker::Sized
+pub fn syntect::html::IncludeBackground::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::html::IncludeBackground where T: core::marker::Sized
+pub fn syntect::html::IncludeBackground::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::html::IncludeBackground where T: core::marker::Sized
+pub fn syntect::html::IncludeBackground::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::html::IncludeBackground
+pub fn syntect::html::IncludeBackground::from(t: T) -> T
+pub struct syntect::html::ClassedHTMLGenerator<'a>
+impl<'a> syntect::html::ClassedHTMLGenerator<'a>
+pub fn syntect::html::ClassedHTMLGenerator<'a>::finalize(self) -> alloc::string::String
+pub fn syntect::html::ClassedHTMLGenerator<'a>::new(syntax_reference: &'a syntect::parsing::SyntaxReference, syntax_set: &'a syntect::parsing::SyntaxSet) -> syntect::html::ClassedHTMLGenerator<'a>
+pub fn syntect::html::ClassedHTMLGenerator<'a>::new_with_class_style(syntax_reference: &'a syntect::parsing::SyntaxReference, syntax_set: &'a syntect::parsing::SyntaxSet, style: syntect::html::ClassStyle) -> syntect::html::ClassedHTMLGenerator<'a>
+pub fn syntect::html::ClassedHTMLGenerator<'a>::parse_html_for_line(&mut self, line: &str)
+pub fn syntect::html::ClassedHTMLGenerator<'a>::parse_html_for_line_which_includes_newline(&mut self, line: &str) -> core::result::Result<(), syntect::Error>
+impl<'a> !core::marker::Send for syntect::html::ClassedHTMLGenerator<'a>
+impl<'a> !core::marker::Sync for syntect::html::ClassedHTMLGenerator<'a>
+impl<'a> core::marker::Unpin for syntect::html::ClassedHTMLGenerator<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::html::ClassedHTMLGenerator<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::html::ClassedHTMLGenerator<'a>
+impl<T, U> core::convert::Into<U> for syntect::html::ClassedHTMLGenerator<'a> where U: core::convert::From<T>
+pub fn syntect::html::ClassedHTMLGenerator<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::html::ClassedHTMLGenerator<'a> where U: core::convert::Into<T>
+pub type syntect::html::ClassedHTMLGenerator<'a>::Error = core::convert::Infallible
+pub fn syntect::html::ClassedHTMLGenerator<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::html::ClassedHTMLGenerator<'a> where U: core::convert::TryFrom<T>
+pub type syntect::html::ClassedHTMLGenerator<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::html::ClassedHTMLGenerator<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::html::ClassedHTMLGenerator<'a> where T: 'static + core::marker::Sized
+pub fn syntect::html::ClassedHTMLGenerator<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::html::ClassedHTMLGenerator<'a> where T: core::marker::Sized
+pub fn syntect::html::ClassedHTMLGenerator<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::html::ClassedHTMLGenerator<'a> where T: core::marker::Sized
+pub fn syntect::html::ClassedHTMLGenerator<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::html::ClassedHTMLGenerator<'a>
+pub fn syntect::html::ClassedHTMLGenerator<'a>::from(t: T) -> T
+pub fn syntect::html::append_highlighted_html_for_styled_line(v: &[(syntect::highlighting::Style, &str)], bg: syntect::html::IncludeBackground, s: &mut alloc::string::String) -> core::result::Result<(), syntect::Error>
+pub fn syntect::html::css_for_theme(theme: &syntect::highlighting::Theme) -> alloc::string::String
+pub fn syntect::html::css_for_theme_with_class_style(theme: &syntect::highlighting::Theme, style: syntect::html::ClassStyle) -> core::result::Result<alloc::string::String, syntect::Error>
+pub fn syntect::html::highlighted_html_for_file<P: core::convert::AsRef<std::path::Path>>(path: P, ss: &syntect::parsing::SyntaxSet, theme: &syntect::highlighting::Theme) -> core::result::Result<alloc::string::String, syntect::Error>
+pub fn syntect::html::highlighted_html_for_string(s: &str, ss: &syntect::parsing::SyntaxSet, syntax: &syntect::parsing::SyntaxReference, theme: &syntect::highlighting::Theme) -> core::result::Result<alloc::string::String, syntect::Error>
+pub fn syntect::html::line_tokens_to_classed_spans(line: &str, ops: &[(usize, syntect::parsing::ScopeStackOp)], style: syntect::html::ClassStyle, stack: &mut syntect::parsing::ScopeStack) -> core::result::Result<(alloc::string::String, isize), syntect::Error>
+pub fn syntect::html::start_highlighted_html_snippet(t: &syntect::highlighting::Theme) -> (alloc::string::String, syntect::highlighting::Color)
+pub fn syntect::html::styled_line_to_highlighted_html(v: &[(syntect::highlighting::Style, &str)], bg: syntect::html::IncludeBackground) -> core::result::Result<alloc::string::String, syntect::Error>
+pub fn syntect::html::tokens_to_classed_html(line: &str, ops: &[(usize, syntect::parsing::ScopeStackOp)], style: syntect::html::ClassStyle) -> alloc::string::String
+pub fn syntect::html::tokens_to_classed_spans(line: &str, ops: &[(usize, syntect::parsing::ScopeStackOp)], style: syntect::html::ClassStyle) -> (alloc::string::String, isize)
+pub mod syntect::parsing
+pub mod syntect::parsing::syntax_definition
+#[non_exhaustive] pub enum syntect::parsing::syntax_definition::ContextReference
+#[non_exhaustive] pub syntect::parsing::syntax_definition::ContextReference::ByScope
+pub syntect::parsing::syntax_definition::ContextReference::ByScope::scope: syntect::parsing::Scope
+pub syntect::parsing::syntax_definition::ContextReference::ByScope::sub_context: core::option::Option<alloc::string::String>
+pub syntect::parsing::syntax_definition::ContextReference::ByScope::with_escape: bool
+#[non_exhaustive] pub syntect::parsing::syntax_definition::ContextReference::Direct(syntect::parsing::syntax_definition::ContextId)
+#[non_exhaustive] pub syntect::parsing::syntax_definition::ContextReference::File
+pub syntect::parsing::syntax_definition::ContextReference::File::name: alloc::string::String
+pub syntect::parsing::syntax_definition::ContextReference::File::sub_context: core::option::Option<alloc::string::String>
+pub syntect::parsing::syntax_definition::ContextReference::File::with_escape: bool
+#[non_exhaustive] pub syntect::parsing::syntax_definition::ContextReference::Inline(alloc::string::String)
+#[non_exhaustive] pub syntect::parsing::syntax_definition::ContextReference::Named(alloc::string::String)
+impl syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::id(&self) -> core::result::Result<syntect::parsing::syntax_definition::ContextId, syntect::parsing::ParsingError>
+pub fn syntect::parsing::syntax_definition::ContextReference::resolve<'a>(&self, syntax_set: &'a syntect::parsing::SyntaxSet) -> core::result::Result<&'a syntect::parsing::syntax_definition::Context, syntect::parsing::ParsingError>
+impl core::clone::Clone for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::clone(&self) -> syntect::parsing::syntax_definition::ContextReference
+impl core::cmp::Eq for syntect::parsing::syntax_definition::ContextReference
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::ContextReference> for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::eq(&self, other: &syntect::parsing::syntax_definition::ContextReference) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::ContextReference
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::ContextReference
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::ContextReference
+impl core::marker::Sync for syntect::parsing::syntax_definition::ContextReference
+impl core::marker::Unpin for syntect::parsing::syntax_definition::ContextReference
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::ContextReference
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::ContextReference
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::ContextReference where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextReference::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::ContextReference where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::ContextReference::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::ContextReference where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::ContextReference::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::ContextReference::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::ContextReference where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::ContextReference::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::ContextReference::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::ContextReference where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::ContextReference::Owned = T
+pub fn syntect::parsing::syntax_definition::ContextReference::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::ContextReference::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::ContextReference where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextReference::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::ContextReference where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextReference::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::ContextReference where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextReference::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::ContextReference
+pub fn syntect::parsing::syntax_definition::ContextReference::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::ContextReference where T: for<'de> serde::de::Deserialize<'de>
+pub enum syntect::parsing::syntax_definition::MatchOperation
+pub syntect::parsing::syntax_definition::MatchOperation::None
+pub syntect::parsing::syntax_definition::MatchOperation::Pop
+pub syntect::parsing::syntax_definition::MatchOperation::Push(alloc::vec::Vec<syntect::parsing::syntax_definition::ContextReference>)
+pub syntect::parsing::syntax_definition::MatchOperation::Set(alloc::vec::Vec<syntect::parsing::syntax_definition::ContextReference>)
+impl core::clone::Clone for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::clone(&self) -> syntect::parsing::syntax_definition::MatchOperation
+impl core::cmp::Eq for syntect::parsing::syntax_definition::MatchOperation
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::MatchOperation> for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::eq(&self, other: &syntect::parsing::syntax_definition::MatchOperation) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::MatchOperation
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::MatchOperation
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::MatchOperation
+impl core::marker::Sync for syntect::parsing::syntax_definition::MatchOperation
+impl core::marker::Unpin for syntect::parsing::syntax_definition::MatchOperation
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::MatchOperation
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::MatchOperation
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::MatchOperation where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchOperation::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::MatchOperation where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::MatchOperation::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::MatchOperation where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::MatchOperation::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::MatchOperation::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::MatchOperation where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::MatchOperation::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::MatchOperation::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::MatchOperation where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::MatchOperation::Owned = T
+pub fn syntect::parsing::syntax_definition::MatchOperation::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::MatchOperation::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::MatchOperation where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchOperation::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::MatchOperation where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchOperation::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::MatchOperation where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchOperation::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::MatchOperation
+pub fn syntect::parsing::syntax_definition::MatchOperation::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::MatchOperation where T: for<'de> serde::de::Deserialize<'de>
+pub enum syntect::parsing::syntax_definition::Pattern
+pub syntect::parsing::syntax_definition::Pattern::Include(syntect::parsing::syntax_definition::ContextReference)
+pub syntect::parsing::syntax_definition::Pattern::Match(syntect::parsing::syntax_definition::MatchPattern)
+impl core::clone::Clone for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::clone(&self) -> syntect::parsing::syntax_definition::Pattern
+impl core::cmp::Eq for syntect::parsing::syntax_definition::Pattern
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::Pattern> for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::eq(&self, other: &syntect::parsing::syntax_definition::Pattern) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::Pattern
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::Pattern
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::Pattern
+impl core::marker::Sync for syntect::parsing::syntax_definition::Pattern
+impl core::marker::Unpin for syntect::parsing::syntax_definition::Pattern
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::Pattern
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::Pattern
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::Pattern where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Pattern::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::Pattern where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::Pattern::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::Pattern where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::Pattern::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::Pattern::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::Pattern where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::Pattern::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::Pattern::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::Pattern where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::Pattern::Owned = T
+pub fn syntect::parsing::syntax_definition::Pattern::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::Pattern::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::Pattern where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Pattern::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::Pattern where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Pattern::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::Pattern where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Pattern::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::Pattern
+pub fn syntect::parsing::syntax_definition::Pattern::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::Pattern where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::syntax_definition::Context
+pub syntect::parsing::syntax_definition::Context::clear_scopes: core::option::Option<syntect::parsing::ClearAmount>
+pub syntect::parsing::syntax_definition::Context::meta_content_scope: alloc::vec::Vec<syntect::parsing::Scope>
+pub syntect::parsing::syntax_definition::Context::meta_include_prototype: bool
+pub syntect::parsing::syntax_definition::Context::meta_scope: alloc::vec::Vec<syntect::parsing::Scope>
+pub syntect::parsing::syntax_definition::Context::patterns: alloc::vec::Vec<syntect::parsing::syntax_definition::Pattern>
+pub syntect::parsing::syntax_definition::Context::prototype: core::option::Option<syntect::parsing::syntax_definition::ContextId>
+pub syntect::parsing::syntax_definition::Context::uses_backrefs: bool
+impl syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::match_at(&self, index: usize) -> core::result::Result<&syntect::parsing::syntax_definition::MatchPattern, syntect::parsing::ParsingError>
+impl syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::new(meta_include_prototype: bool) -> syntect::parsing::syntax_definition::Context
+impl core::clone::Clone for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::clone(&self) -> syntect::parsing::syntax_definition::Context
+impl core::cmp::Eq for syntect::parsing::syntax_definition::Context
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::Context> for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::eq(&self, other: &syntect::parsing::syntax_definition::Context) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::Context
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::Context
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::Context
+impl core::marker::Sync for syntect::parsing::syntax_definition::Context
+impl core::marker::Unpin for syntect::parsing::syntax_definition::Context
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::Context
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::Context
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::Context where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Context::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::Context where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::Context::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::Context where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::Context::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::Context::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::Context where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::Context::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::Context::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::Context where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::Context::Owned = T
+pub fn syntect::parsing::syntax_definition::Context::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::Context::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::Context where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Context::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::Context where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Context::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::Context where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::Context::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::Context
+pub fn syntect::parsing::syntax_definition::Context::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::Context where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::syntax_definition::ContextId
+impl core::clone::Clone for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::clone(&self) -> syntect::parsing::syntax_definition::ContextId
+impl core::cmp::Eq for syntect::parsing::syntax_definition::ContextId
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::ContextId> for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::eq(&self, other: &syntect::parsing::syntax_definition::ContextId) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for syntect::parsing::syntax_definition::ContextId
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::ContextId
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::ContextId
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::ContextId
+impl core::marker::Sync for syntect::parsing::syntax_definition::ContextId
+impl core::marker::Unpin for syntect::parsing::syntax_definition::ContextId
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::ContextId
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::ContextId
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::ContextId where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextId::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::ContextId where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::ContextId::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::ContextId where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::ContextId::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::ContextId::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::ContextId where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::ContextId::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::ContextId::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::ContextId where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::ContextId::Owned = T
+pub fn syntect::parsing::syntax_definition::ContextId::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::ContextId::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::ContextId where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextId::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::ContextId where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextId::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::ContextId where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::ContextId::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::ContextId
+pub fn syntect::parsing::syntax_definition::ContextId::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::ContextId where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::syntax_definition::MatchIter<'a>
+impl<'a> core::iter::traits::iterator::Iterator for syntect::parsing::syntax_definition::MatchIter<'a>
+pub type syntect::parsing::syntax_definition::MatchIter<'a>::Item = (&'a syntect::parsing::syntax_definition::Context, usize)
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::next(&mut self) -> core::option::Option<(&'a syntect::parsing::syntax_definition::Context, usize)>
+impl<'a> core::fmt::Debug for syntect::parsing::syntax_definition::MatchIter<'a>
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Send for syntect::parsing::syntax_definition::MatchIter<'a>
+impl<'a> core::marker::Sync for syntect::parsing::syntax_definition::MatchIter<'a>
+impl<'a> core::marker::Unpin for syntect::parsing::syntax_definition::MatchIter<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::MatchIter<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::MatchIter<'a>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::parsing::syntax_definition::MatchIter<'a> where I: core::iter::traits::iterator::Iterator
+pub type syntect::parsing::syntax_definition::MatchIter<'a>::IntoIter = I
+pub type syntect::parsing::syntax_definition::MatchIter<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::MatchIter<'a> where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::MatchIter<'a> where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::MatchIter<'a>::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::MatchIter<'a> where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::MatchIter<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::parsing::syntax_definition::MatchIter<'a> where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::MatchIter<'a> where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::MatchIter<'a> where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::MatchIter<'a>
+pub fn syntect::parsing::syntax_definition::MatchIter<'a>::from(t: T) -> T
+pub struct syntect::parsing::syntax_definition::MatchPattern
+pub syntect::parsing::syntax_definition::MatchPattern::captures: core::option::Option<syntect::parsing::syntax_definition::CaptureMapping>
+pub syntect::parsing::syntax_definition::MatchPattern::has_captures: bool
+pub syntect::parsing::syntax_definition::MatchPattern::operation: syntect::parsing::syntax_definition::MatchOperation
+pub syntect::parsing::syntax_definition::MatchPattern::regex: syntect::parsing::Regex
+pub syntect::parsing::syntax_definition::MatchPattern::scope: alloc::vec::Vec<syntect::parsing::Scope>
+pub syntect::parsing::syntax_definition::MatchPattern::with_prototype: core::option::Option<syntect::parsing::syntax_definition::ContextReference>
+impl syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::new(has_captures: bool, regex_str: alloc::string::String, scope: alloc::vec::Vec<syntect::parsing::Scope>, captures: core::option::Option<syntect::parsing::syntax_definition::CaptureMapping>, operation: syntect::parsing::syntax_definition::MatchOperation, with_prototype: core::option::Option<syntect::parsing::syntax_definition::ContextReference>) -> syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::regex(&self) -> &syntect::parsing::Regex
+pub fn syntect::parsing::syntax_definition::MatchPattern::regex_with_refs(&self, region: &syntect::parsing::Region, text: &str) -> syntect::parsing::Regex
+impl core::clone::Clone for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::clone(&self) -> syntect::parsing::syntax_definition::MatchPattern
+impl core::cmp::Eq for syntect::parsing::syntax_definition::MatchPattern
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::MatchPattern> for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::eq(&self, other: &syntect::parsing::syntax_definition::MatchPattern) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::MatchPattern
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::MatchPattern
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::MatchPattern
+impl core::marker::Sync for syntect::parsing::syntax_definition::MatchPattern
+impl core::marker::Unpin for syntect::parsing::syntax_definition::MatchPattern
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::MatchPattern
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::MatchPattern
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::MatchPattern where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchPattern::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::MatchPattern where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::MatchPattern::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::MatchPattern where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::MatchPattern::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::MatchPattern::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::MatchPattern where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::MatchPattern::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::MatchPattern::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::MatchPattern where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::MatchPattern::Owned = T
+pub fn syntect::parsing::syntax_definition::MatchPattern::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::MatchPattern::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::MatchPattern where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchPattern::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::MatchPattern where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchPattern::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::MatchPattern where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::MatchPattern::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::MatchPattern
+pub fn syntect::parsing::syntax_definition::MatchPattern::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::MatchPattern where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::syntax_definition::SyntaxDefinition
+pub syntect::parsing::syntax_definition::SyntaxDefinition::contexts: std::collections::hash::map::HashMap<alloc::string::String, syntect::parsing::syntax_definition::Context>
+pub syntect::parsing::syntax_definition::SyntaxDefinition::file_extensions: alloc::vec::Vec<alloc::string::String>
+pub syntect::parsing::syntax_definition::SyntaxDefinition::first_line_match: core::option::Option<alloc::string::String>
+pub syntect::parsing::syntax_definition::SyntaxDefinition::hidden: bool
+pub syntect::parsing::syntax_definition::SyntaxDefinition::name: alloc::string::String
+pub syntect::parsing::syntax_definition::SyntaxDefinition::scope: syntect::parsing::Scope
+pub syntect::parsing::syntax_definition::SyntaxDefinition::variables: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::load_from_str(s: &str, lines_include_newline: bool, fallback_name: core::option::Option<&str>) -> core::result::Result<syntect::parsing::syntax_definition::SyntaxDefinition, syntect::parsing::ParseSyntaxError>
+impl core::clone::Clone for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::clone(&self) -> syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::cmp::Eq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::SyntaxDefinition> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::eq(&self, other: &syntect::parsing::syntax_definition::SyntaxDefinition) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::Sync for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::Unpin for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::SyntaxDefinition
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::SyntaxDefinition where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Owned = T
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::SyntaxDefinition where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::SyntaxDefinition where T: for<'de> serde::de::Deserialize<'de>
+pub fn syntect::parsing::syntax_definition::context_iter<'a>(syntax_set: &'a syntect::parsing::SyntaxSet, context: &'a syntect::parsing::syntax_definition::Context) -> syntect::parsing::syntax_definition::MatchIter<'a>
+pub type syntect::parsing::syntax_definition::CaptureMapping = alloc::vec::Vec<(usize, alloc::vec::Vec<syntect::parsing::Scope>)>
+pub enum syntect::parsing::BasicScopeStackOp
+pub syntect::parsing::BasicScopeStackOp::Pop
+pub syntect::parsing::BasicScopeStackOp::Push(syntect::parsing::Scope)
+impl core::clone::Clone for syntect::parsing::BasicScopeStackOp
+pub fn syntect::parsing::BasicScopeStackOp::clone(&self) -> syntect::parsing::BasicScopeStackOp
+impl core::cmp::Eq for syntect::parsing::BasicScopeStackOp
+impl core::cmp::PartialEq<syntect::parsing::BasicScopeStackOp> for syntect::parsing::BasicScopeStackOp
+pub fn syntect::parsing::BasicScopeStackOp::eq(&self, other: &syntect::parsing::BasicScopeStackOp) -> bool
+impl core::fmt::Debug for syntect::parsing::BasicScopeStackOp
+pub fn syntect::parsing::BasicScopeStackOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::BasicScopeStackOp
+impl core::marker::StructuralPartialEq for syntect::parsing::BasicScopeStackOp
+impl core::marker::Send for syntect::parsing::BasicScopeStackOp
+impl core::marker::Sync for syntect::parsing::BasicScopeStackOp
+impl core::marker::Unpin for syntect::parsing::BasicScopeStackOp
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::BasicScopeStackOp
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::BasicScopeStackOp
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::BasicScopeStackOp where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::BasicScopeStackOp::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::BasicScopeStackOp where U: core::convert::From<T>
+pub fn syntect::parsing::BasicScopeStackOp::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::BasicScopeStackOp where U: core::convert::Into<T>
+pub type syntect::parsing::BasicScopeStackOp::Error = core::convert::Infallible
+pub fn syntect::parsing::BasicScopeStackOp::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::BasicScopeStackOp where U: core::convert::TryFrom<T>
+pub type syntect::parsing::BasicScopeStackOp::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::BasicScopeStackOp::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::BasicScopeStackOp where T: core::clone::Clone
+pub type syntect::parsing::BasicScopeStackOp::Owned = T
+pub fn syntect::parsing::BasicScopeStackOp::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::BasicScopeStackOp::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::BasicScopeStackOp where T: 'static + core::marker::Sized
+pub fn syntect::parsing::BasicScopeStackOp::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::BasicScopeStackOp where T: core::marker::Sized
+pub fn syntect::parsing::BasicScopeStackOp::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::BasicScopeStackOp where T: core::marker::Sized
+pub fn syntect::parsing::BasicScopeStackOp::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::BasicScopeStackOp
+pub fn syntect::parsing::BasicScopeStackOp::from(t: T) -> T
+pub enum syntect::parsing::ClearAmount
+pub syntect::parsing::ClearAmount::All
+pub syntect::parsing::ClearAmount::TopN(usize)
+impl core::clone::Clone for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::clone(&self) -> syntect::parsing::ClearAmount
+impl core::cmp::Eq for syntect::parsing::ClearAmount
+impl core::cmp::PartialEq<syntect::parsing::ClearAmount> for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::eq(&self, other: &syntect::parsing::ClearAmount) -> bool
+impl core::fmt::Debug for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for syntect::parsing::ClearAmount
+impl core::marker::StructuralEq for syntect::parsing::ClearAmount
+impl core::marker::StructuralPartialEq for syntect::parsing::ClearAmount
+impl serde::ser::Serialize for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::ClearAmount
+impl core::marker::Sync for syntect::parsing::ClearAmount
+impl core::marker::Unpin for syntect::parsing::ClearAmount
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ClearAmount
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ClearAmount
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::ClearAmount where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::ClearAmount::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::ClearAmount where U: core::convert::From<T>
+pub fn syntect::parsing::ClearAmount::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ClearAmount where U: core::convert::Into<T>
+pub type syntect::parsing::ClearAmount::Error = core::convert::Infallible
+pub fn syntect::parsing::ClearAmount::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ClearAmount where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ClearAmount::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ClearAmount::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::ClearAmount where T: core::clone::Clone
+pub type syntect::parsing::ClearAmount::Owned = T
+pub fn syntect::parsing::ClearAmount::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::ClearAmount::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::ClearAmount where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ClearAmount::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ClearAmount where T: core::marker::Sized
+pub fn syntect::parsing::ClearAmount::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ClearAmount where T: core::marker::Sized
+pub fn syntect::parsing::ClearAmount::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ClearAmount
+pub fn syntect::parsing::ClearAmount::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::ClearAmount where T: for<'de> serde::de::Deserialize<'de>
+#[non_exhaustive] pub enum syntect::parsing::ParseScopeError
+pub syntect::parsing::ParseScopeError::TooLong
+pub syntect::parsing::ParseScopeError::TooManyAtoms
+impl core::convert::From<syntect::parsing::ParseScopeError> for syntect::highlighting::ParseThemeError
+pub fn syntect::highlighting::ParseThemeError::from(source: syntect::parsing::ParseScopeError) -> Self
+impl core::error::Error for syntect::parsing::ParseScopeError
+impl core::fmt::Display for syntect::parsing::ParseScopeError
+pub fn syntect::parsing::ParseScopeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::parsing::ParseScopeError
+pub fn syntect::parsing::ParseScopeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::ParseScopeError
+impl core::marker::Sync for syntect::parsing::ParseScopeError
+impl core::marker::Unpin for syntect::parsing::ParseScopeError
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ParseScopeError
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParseScopeError
+impl<T, U> core::convert::Into<U> for syntect::parsing::ParseScopeError where U: core::convert::From<T>
+pub fn syntect::parsing::ParseScopeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ParseScopeError where U: core::convert::Into<T>
+pub type syntect::parsing::ParseScopeError::Error = core::convert::Infallible
+pub fn syntect::parsing::ParseScopeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ParseScopeError where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ParseScopeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ParseScopeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::parsing::ParseScopeError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::ParseScopeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::ParseScopeError where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ParseScopeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ParseScopeError where T: core::marker::Sized
+pub fn syntect::parsing::ParseScopeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ParseScopeError where T: core::marker::Sized
+pub fn syntect::parsing::ParseScopeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ParseScopeError
+pub fn syntect::parsing::ParseScopeError::from(t: T) -> T
+#[non_exhaustive] pub enum syntect::parsing::ParseSyntaxError
+pub syntect::parsing::ParseSyntaxError::BadFileRef
+pub syntect::parsing::ParseSyntaxError::EmptyFile
+pub syntect::parsing::ParseSyntaxError::InvalidScope(syntect::parsing::ParseScopeError)
+pub syntect::parsing::ParseSyntaxError::InvalidYaml(yaml_rust::scanner::ScanError)
+pub syntect::parsing::ParseSyntaxError::MainMissing
+pub syntect::parsing::ParseSyntaxError::MissingMandatoryKey(&'static str)
+pub syntect::parsing::ParseSyntaxError::RegexCompileError(alloc::string::String, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>)
+pub syntect::parsing::ParseSyntaxError::TypeMismatch
+impl core::convert::From<yaml_rust::scanner::ScanError> for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::from(source: yaml_rust::scanner::ScanError) -> Self
+impl core::error::Error for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Display for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::ParseSyntaxError
+impl core::marker::Sync for syntect::parsing::ParseSyntaxError
+impl core::marker::Unpin for syntect::parsing::ParseSyntaxError
+impl !core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ParseSyntaxError
+impl !core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParseSyntaxError
+impl<T, U> core::convert::Into<U> for syntect::parsing::ParseSyntaxError where U: core::convert::From<T>
+pub fn syntect::parsing::ParseSyntaxError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ParseSyntaxError where U: core::convert::Into<T>
+pub type syntect::parsing::ParseSyntaxError::Error = core::convert::Infallible
+pub fn syntect::parsing::ParseSyntaxError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ParseSyntaxError where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ParseSyntaxError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ParseSyntaxError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::parsing::ParseSyntaxError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::ParseSyntaxError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::ParseSyntaxError where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ParseSyntaxError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ParseSyntaxError where T: core::marker::Sized
+pub fn syntect::parsing::ParseSyntaxError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ParseSyntaxError where T: core::marker::Sized
+pub fn syntect::parsing::ParseSyntaxError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::from(t: T) -> T
+#[non_exhaustive] pub enum syntect::parsing::ParsingError
+pub syntect::parsing::ParsingError::BadMatchIndex(usize)
+pub syntect::parsing::ParsingError::MissingContext(syntect::parsing::syntax_definition::ContextId)
+pub syntect::parsing::ParsingError::MissingMainContext
+pub syntect::parsing::ParsingError::UnresolvedContextReference(syntect::parsing::syntax_definition::ContextReference)
+impl core::convert::From<syntect::parsing::ParsingError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::parsing::ParsingError) -> Self
+impl core::error::Error for syntect::parsing::ParsingError
+impl core::fmt::Display for syntect::parsing::ParsingError
+pub fn syntect::parsing::ParsingError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::parsing::ParsingError
+pub fn syntect::parsing::ParsingError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::ParsingError
+impl core::marker::Sync for syntect::parsing::ParsingError
+impl core::marker::Unpin for syntect::parsing::ParsingError
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ParsingError
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParsingError
+impl<T, U> core::convert::Into<U> for syntect::parsing::ParsingError where U: core::convert::From<T>
+pub fn syntect::parsing::ParsingError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ParsingError where U: core::convert::Into<T>
+pub type syntect::parsing::ParsingError::Error = core::convert::Infallible
+pub fn syntect::parsing::ParsingError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ParsingError where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ParsingError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ParsingError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::parsing::ParsingError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::ParsingError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::ParsingError where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ParsingError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ParsingError where T: core::marker::Sized
+pub fn syntect::parsing::ParsingError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ParsingError where T: core::marker::Sized
+pub fn syntect::parsing::ParsingError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ParsingError
+pub fn syntect::parsing::ParsingError::from(t: T) -> T
+#[non_exhaustive] pub enum syntect::parsing::ScopeError
+pub syntect::parsing::ScopeError::NoClearedScopesToRestore
+impl core::convert::From<syntect::parsing::ScopeError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::parsing::ScopeError) -> Self
+impl core::error::Error for syntect::parsing::ScopeError
+impl core::fmt::Display for syntect::parsing::ScopeError
+pub fn syntect::parsing::ScopeError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::parsing::ScopeError
+pub fn syntect::parsing::ScopeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::ScopeError
+impl core::marker::Sync for syntect::parsing::ScopeError
+impl core::marker::Unpin for syntect::parsing::ScopeError
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ScopeError
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ScopeError
+impl<T, U> core::convert::Into<U> for syntect::parsing::ScopeError where U: core::convert::From<T>
+pub fn syntect::parsing::ScopeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ScopeError where U: core::convert::Into<T>
+pub type syntect::parsing::ScopeError::Error = core::convert::Infallible
+pub fn syntect::parsing::ScopeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ScopeError where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ScopeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ScopeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::parsing::ScopeError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::ScopeError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::ScopeError where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ScopeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ScopeError where T: core::marker::Sized
+pub fn syntect::parsing::ScopeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ScopeError where T: core::marker::Sized
+pub fn syntect::parsing::ScopeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ScopeError
+pub fn syntect::parsing::ScopeError::from(t: T) -> T
+pub enum syntect::parsing::ScopeStackOp
+pub syntect::parsing::ScopeStackOp::Clear(syntect::parsing::ClearAmount)
+pub syntect::parsing::ScopeStackOp::Noop
+pub syntect::parsing::ScopeStackOp::Pop(usize)
+pub syntect::parsing::ScopeStackOp::Push(syntect::parsing::Scope)
+pub syntect::parsing::ScopeStackOp::Restore
+impl core::clone::Clone for syntect::parsing::ScopeStackOp
+pub fn syntect::parsing::ScopeStackOp::clone(&self) -> syntect::parsing::ScopeStackOp
+impl core::cmp::Eq for syntect::parsing::ScopeStackOp
+impl core::cmp::PartialEq<syntect::parsing::ScopeStackOp> for syntect::parsing::ScopeStackOp
+pub fn syntect::parsing::ScopeStackOp::eq(&self, other: &syntect::parsing::ScopeStackOp) -> bool
+impl core::fmt::Debug for syntect::parsing::ScopeStackOp
+pub fn syntect::parsing::ScopeStackOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::ScopeStackOp
+impl core::marker::StructuralPartialEq for syntect::parsing::ScopeStackOp
+impl core::marker::Send for syntect::parsing::ScopeStackOp
+impl core::marker::Sync for syntect::parsing::ScopeStackOp
+impl core::marker::Unpin for syntect::parsing::ScopeStackOp
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ScopeStackOp
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ScopeStackOp
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::ScopeStackOp where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::ScopeStackOp::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::ScopeStackOp where U: core::convert::From<T>
+pub fn syntect::parsing::ScopeStackOp::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ScopeStackOp where U: core::convert::Into<T>
+pub type syntect::parsing::ScopeStackOp::Error = core::convert::Infallible
+pub fn syntect::parsing::ScopeStackOp::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ScopeStackOp where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ScopeStackOp::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ScopeStackOp::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::ScopeStackOp where T: core::clone::Clone
+pub type syntect::parsing::ScopeStackOp::Owned = T
+pub fn syntect::parsing::ScopeStackOp::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::ScopeStackOp::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::ScopeStackOp where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ScopeStackOp::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ScopeStackOp where T: core::marker::Sized
+pub fn syntect::parsing::ScopeStackOp::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ScopeStackOp where T: core::marker::Sized
+pub fn syntect::parsing::ScopeStackOp::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ScopeStackOp
+pub fn syntect::parsing::ScopeStackOp::from(t: T) -> T
+pub struct syntect::parsing::MatchPower(pub f64)
+impl core::cmp::Eq for syntect::parsing::MatchPower
+impl core::cmp::Ord for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::cmp(&self, other: &Self) -> core::cmp::Ordering
+impl core::clone::Clone for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::clone(&self) -> syntect::parsing::MatchPower
+impl core::cmp::PartialEq<syntect::parsing::MatchPower> for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::eq(&self, other: &syntect::parsing::MatchPower) -> bool
+impl core::cmp::PartialOrd<syntect::parsing::MatchPower> for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::partial_cmp(&self, other: &syntect::parsing::MatchPower) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for syntect::parsing::MatchPower
+impl core::marker::StructuralPartialEq for syntect::parsing::MatchPower
+impl core::marker::Send for syntect::parsing::MatchPower
+impl core::marker::Sync for syntect::parsing::MatchPower
+impl core::marker::Unpin for syntect::parsing::MatchPower
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::MatchPower
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::MatchPower
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::MatchPower where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::MatchPower::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::MatchPower where U: core::convert::From<T>
+pub fn syntect::parsing::MatchPower::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::MatchPower where U: core::convert::Into<T>
+pub type syntect::parsing::MatchPower::Error = core::convert::Infallible
+pub fn syntect::parsing::MatchPower::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::MatchPower where U: core::convert::TryFrom<T>
+pub type syntect::parsing::MatchPower::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::MatchPower::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::MatchPower where T: core::clone::Clone
+pub type syntect::parsing::MatchPower::Owned = T
+pub fn syntect::parsing::MatchPower::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::MatchPower::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::MatchPower where T: 'static + core::marker::Sized
+pub fn syntect::parsing::MatchPower::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::MatchPower where T: core::marker::Sized
+pub fn syntect::parsing::MatchPower::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::MatchPower where T: core::marker::Sized
+pub fn syntect::parsing::MatchPower::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::MatchPower
+pub fn syntect::parsing::MatchPower::from(t: T) -> T
+pub struct syntect::parsing::ParseState
+impl syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::new(syntax: &syntect::parsing::SyntaxReference) -> syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::parse_line(&mut self, line: &str, syntax_set: &syntect::parsing::SyntaxSet) -> core::result::Result<alloc::vec::Vec<(usize, syntect::parsing::ScopeStackOp)>, syntect::parsing::ParsingError>
+impl core::clone::Clone for syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::clone(&self) -> syntect::parsing::ParseState
+impl core::cmp::Eq for syntect::parsing::ParseState
+impl core::cmp::PartialEq<syntect::parsing::ParseState> for syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::eq(&self, other: &syntect::parsing::ParseState) -> bool
+impl core::fmt::Debug for syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::ParseState
+impl core::marker::StructuralPartialEq for syntect::parsing::ParseState
+impl !core::marker::Send for syntect::parsing::ParseState
+impl !core::marker::Sync for syntect::parsing::ParseState
+impl core::marker::Unpin for syntect::parsing::ParseState
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ParseState
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParseState
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::ParseState where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::ParseState::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::ParseState where U: core::convert::From<T>
+pub fn syntect::parsing::ParseState::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ParseState where U: core::convert::Into<T>
+pub type syntect::parsing::ParseState::Error = core::convert::Infallible
+pub fn syntect::parsing::ParseState::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ParseState where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ParseState::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ParseState::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::ParseState where T: core::clone::Clone
+pub type syntect::parsing::ParseState::Owned = T
+pub fn syntect::parsing::ParseState::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::ParseState::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::ParseState where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ParseState::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ParseState where T: core::marker::Sized
+pub fn syntect::parsing::ParseState::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ParseState where T: core::marker::Sized
+pub fn syntect::parsing::ParseState::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ParseState
+pub fn syntect::parsing::ParseState::from(t: T) -> T
+pub struct syntect::parsing::Regex
+impl syntect::parsing::Regex
+pub fn syntect::parsing::Regex::is_match(&self, text: &str) -> bool
+pub fn syntect::parsing::Regex::new(regex_str: alloc::string::String) -> Self
+pub fn syntect::parsing::Regex::regex_str(&self) -> &str
+pub fn syntect::parsing::Regex::search(&self, text: &str, begin: usize, end: usize, region: core::option::Option<&mut syntect::parsing::Region>) -> bool
+pub fn syntect::parsing::Regex::try_compile(regex_str: &str) -> core::option::Option<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>>
+impl core::clone::Clone for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::clone(&self) -> Self
+impl core::cmp::Eq for syntect::parsing::Regex
+impl core::cmp::PartialEq<syntect::parsing::Regex> for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::eq(&self, other: &syntect::parsing::Regex) -> bool
+impl serde::ser::Serialize for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl core::fmt::Debug for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::Regex
+impl core::marker::Sync for syntect::parsing::Regex
+impl core::marker::Unpin for syntect::parsing::Regex
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::Regex
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::Regex
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::Regex where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::Regex::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::Regex where U: core::convert::From<T>
+pub fn syntect::parsing::Regex::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::Regex where U: core::convert::Into<T>
+pub type syntect::parsing::Regex::Error = core::convert::Infallible
+pub fn syntect::parsing::Regex::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::Regex where U: core::convert::TryFrom<T>
+pub type syntect::parsing::Regex::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::Regex::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::Regex where T: core::clone::Clone
+pub type syntect::parsing::Regex::Owned = T
+pub fn syntect::parsing::Regex::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::Regex::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::Regex where T: 'static + core::marker::Sized
+pub fn syntect::parsing::Regex::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::Regex where T: core::marker::Sized
+pub fn syntect::parsing::Regex::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::Regex where T: core::marker::Sized
+pub fn syntect::parsing::Regex::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::Regex
+pub fn syntect::parsing::Regex::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::Regex where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::Region
+impl syntect::parsing::Region
+pub fn syntect::parsing::Region::new() -> Self
+pub fn syntect::parsing::Region::pos(&self, index: usize) -> core::option::Option<(usize, usize)>
+impl core::default::Default for syntect::parsing::Region
+pub fn syntect::parsing::Region::default() -> Self
+impl core::clone::Clone for syntect::parsing::Region
+pub fn syntect::parsing::Region::clone(&self) -> syntect::parsing::Region
+impl core::cmp::Eq for syntect::parsing::Region
+impl core::cmp::PartialEq<syntect::parsing::Region> for syntect::parsing::Region
+pub fn syntect::parsing::Region::eq(&self, other: &syntect::parsing::Region) -> bool
+impl core::fmt::Debug for syntect::parsing::Region
+pub fn syntect::parsing::Region::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::Region
+impl core::marker::StructuralPartialEq for syntect::parsing::Region
+impl !core::marker::Send for syntect::parsing::Region
+impl !core::marker::Sync for syntect::parsing::Region
+impl core::marker::Unpin for syntect::parsing::Region
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::Region
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::Region
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::Region where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::Region::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::Region where U: core::convert::From<T>
+pub fn syntect::parsing::Region::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::Region where U: core::convert::Into<T>
+pub type syntect::parsing::Region::Error = core::convert::Infallible
+pub fn syntect::parsing::Region::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::Region where U: core::convert::TryFrom<T>
+pub type syntect::parsing::Region::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::Region::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::Region where T: core::clone::Clone
+pub type syntect::parsing::Region::Owned = T
+pub fn syntect::parsing::Region::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::Region::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::Region where T: 'static + core::marker::Sized
+pub fn syntect::parsing::Region::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::Region where T: core::marker::Sized
+pub fn syntect::parsing::Region::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::Region where T: core::marker::Sized
+pub fn syntect::parsing::Region::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::Region
+pub fn syntect::parsing::Region::from(t: T) -> T
+pub struct syntect::parsing::Scope
+impl syntect::parsing::Scope
+pub fn syntect::parsing::Scope::atom_at(self, index: usize) -> u16
+pub fn syntect::parsing::Scope::build_string(self) -> alloc::string::String
+pub fn syntect::parsing::Scope::is_empty(self) -> bool
+pub fn syntect::parsing::Scope::is_prefix_of(self, s: syntect::parsing::Scope) -> bool
+pub fn syntect::parsing::Scope::len(self) -> u32
+pub fn syntect::parsing::Scope::new(s: &str) -> core::result::Result<syntect::parsing::Scope, syntect::parsing::ParseScopeError>
+impl core::fmt::Debug for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::str::traits::FromStr for syntect::parsing::Scope
+pub type syntect::parsing::Scope::Err = syntect::parsing::ParseScopeError
+pub fn syntect::parsing::Scope::from_str(s: &str) -> core::result::Result<syntect::parsing::Scope, syntect::parsing::ParseScopeError>
+impl serde::ser::Serialize for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::serialize<S>(&self, serializer: S) -> core::result::Result<<S as serde::ser::Serializer>::Ok, <S as serde::ser::Serializer>::Error> where S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::deserialize<D>(deserializer: D) -> core::result::Result<Self, <D as serde::de::Deserializer>::Error> where D: serde::de::Deserializer<'de>
+impl core::clone::Clone for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::clone(&self) -> syntect::parsing::Scope
+impl core::cmp::Eq for syntect::parsing::Scope
+impl core::cmp::Ord for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::cmp(&self, other: &syntect::parsing::Scope) -> core::cmp::Ordering
+impl core::cmp::PartialEq<syntect::parsing::Scope> for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::eq(&self, other: &syntect::parsing::Scope) -> bool
+impl core::cmp::PartialOrd<syntect::parsing::Scope> for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::partial_cmp(&self, other: &syntect::parsing::Scope) -> core::option::Option<core::cmp::Ordering>
+impl core::default::Default for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::default() -> syntect::parsing::Scope
+impl core::hash::Hash for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+impl core::marker::Copy for syntect::parsing::Scope
+impl core::marker::StructuralEq for syntect::parsing::Scope
+impl core::marker::StructuralPartialEq for syntect::parsing::Scope
+impl core::marker::Send for syntect::parsing::Scope
+impl core::marker::Sync for syntect::parsing::Scope
+impl core::marker::Unpin for syntect::parsing::Scope
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::Scope
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::Scope
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::Scope where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::Scope::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::Scope where U: core::convert::From<T>
+pub fn syntect::parsing::Scope::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::Scope where U: core::convert::Into<T>
+pub type syntect::parsing::Scope::Error = core::convert::Infallible
+pub fn syntect::parsing::Scope::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::Scope where U: core::convert::TryFrom<T>
+pub type syntect::parsing::Scope::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::Scope::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::Scope where T: core::clone::Clone
+pub type syntect::parsing::Scope::Owned = T
+pub fn syntect::parsing::Scope::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::Scope::to_owned(&self) -> T
+impl<T> alloc::string::ToString for syntect::parsing::Scope where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::Scope::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::Scope where T: 'static + core::marker::Sized
+pub fn syntect::parsing::Scope::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::Scope where T: core::marker::Sized
+pub fn syntect::parsing::Scope::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::Scope where T: core::marker::Sized
+pub fn syntect::parsing::Scope::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::Scope
+pub fn syntect::parsing::Scope::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::Scope where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::ScopeRepository
+impl syntect::parsing::ScopeRepository
+pub fn syntect::parsing::ScopeRepository::atom_str(&self, atom_number: u16) -> &str
+pub fn syntect::parsing::ScopeRepository::build(&mut self, s: &str) -> core::result::Result<syntect::parsing::Scope, syntect::parsing::ParseScopeError>
+pub fn syntect::parsing::ScopeRepository::to_string(&self, scope: syntect::parsing::Scope) -> alloc::string::String
+impl core::fmt::Debug for syntect::parsing::ScopeRepository
+pub fn syntect::parsing::ScopeRepository::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::parsing::ScopeRepository
+impl core::marker::Sync for syntect::parsing::ScopeRepository
+impl core::marker::Unpin for syntect::parsing::ScopeRepository
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ScopeRepository
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ScopeRepository
+impl<T, U> core::convert::Into<U> for syntect::parsing::ScopeRepository where U: core::convert::From<T>
+pub fn syntect::parsing::ScopeRepository::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ScopeRepository where U: core::convert::Into<T>
+pub type syntect::parsing::ScopeRepository::Error = core::convert::Infallible
+pub fn syntect::parsing::ScopeRepository::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ScopeRepository where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ScopeRepository::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ScopeRepository::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::parsing::ScopeRepository where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ScopeRepository::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ScopeRepository where T: core::marker::Sized
+pub fn syntect::parsing::ScopeRepository::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ScopeRepository where T: core::marker::Sized
+pub fn syntect::parsing::ScopeRepository::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ScopeRepository
+pub fn syntect::parsing::ScopeRepository::from(t: T) -> T
+pub struct syntect::parsing::ScopeStack
+pub syntect::parsing::ScopeStack::scopes: alloc::vec::Vec<syntect::parsing::Scope>
+impl syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::apply(&mut self, op: &syntect::parsing::ScopeStackOp) -> core::result::Result<(), syntect::parsing::ScopeError>
+pub fn syntect::parsing::ScopeStack::apply_with_hook<F>(&mut self, op: &syntect::parsing::ScopeStackOp, hook: F) -> core::result::Result<(), syntect::parsing::ScopeError> where F: core::ops::function::FnMut(syntect::parsing::BasicScopeStackOp, &[syntect::parsing::Scope])
+pub fn syntect::parsing::ScopeStack::as_slice(&self) -> &[syntect::parsing::Scope]
+pub fn syntect::parsing::ScopeStack::bottom_n(&self, n: usize) -> &[syntect::parsing::Scope]
+pub fn syntect::parsing::ScopeStack::debug_print(&self, repo: &syntect::parsing::ScopeRepository)
+pub fn syntect::parsing::ScopeStack::does_match(&self, stack: &[syntect::parsing::Scope]) -> core::option::Option<syntect::parsing::MatchPower>
+pub fn syntect::parsing::ScopeStack::from_vec(v: alloc::vec::Vec<syntect::parsing::Scope>) -> syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::is_empty(&self) -> bool
+pub fn syntect::parsing::ScopeStack::len(&self) -> usize
+pub fn syntect::parsing::ScopeStack::new() -> syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::pop(&mut self)
+pub fn syntect::parsing::ScopeStack::push(&mut self, s: syntect::parsing::Scope)
+impl core::fmt::Display for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::str::traits::FromStr for syntect::parsing::ScopeStack
+pub type syntect::parsing::ScopeStack::Err = syntect::parsing::ParseScopeError
+pub fn syntect::parsing::ScopeStack::from_str(s: &str) -> core::result::Result<syntect::parsing::ScopeStack, syntect::parsing::ParseScopeError>
+impl core::clone::Clone for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::clone(&self) -> syntect::parsing::ScopeStack
+impl core::cmp::Eq for syntect::parsing::ScopeStack
+impl core::cmp::PartialEq<syntect::parsing::ScopeStack> for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::eq(&self, other: &syntect::parsing::ScopeStack) -> bool
+impl core::default::Default for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::default() -> syntect::parsing::ScopeStack
+impl core::fmt::Debug for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::ScopeStack
+impl core::marker::StructuralPartialEq for syntect::parsing::ScopeStack
+impl serde::ser::Serialize for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::ScopeStack
+impl core::marker::Sync for syntect::parsing::ScopeStack
+impl core::marker::Unpin for syntect::parsing::ScopeStack
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::ScopeStack
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ScopeStack
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::ScopeStack where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::ScopeStack::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::ScopeStack where U: core::convert::From<T>
+pub fn syntect::parsing::ScopeStack::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::ScopeStack where U: core::convert::Into<T>
+pub type syntect::parsing::ScopeStack::Error = core::convert::Infallible
+pub fn syntect::parsing::ScopeStack::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::ScopeStack where U: core::convert::TryFrom<T>
+pub type syntect::parsing::ScopeStack::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::ScopeStack::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::ScopeStack where T: core::clone::Clone
+pub type syntect::parsing::ScopeStack::Owned = T
+pub fn syntect::parsing::ScopeStack::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::ScopeStack::to_owned(&self) -> T
+impl<T> alloc::string::ToString for syntect::parsing::ScopeStack where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::parsing::ScopeStack::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::parsing::ScopeStack where T: 'static + core::marker::Sized
+pub fn syntect::parsing::ScopeStack::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::ScopeStack where T: core::marker::Sized
+pub fn syntect::parsing::ScopeStack::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::ScopeStack where T: core::marker::Sized
+pub fn syntect::parsing::ScopeStack::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::ScopeStack
+pub fn syntect::parsing::ScopeStack::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::ScopeStack where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::SyntaxDefinition
+pub syntect::parsing::SyntaxDefinition::contexts: std::collections::hash::map::HashMap<alloc::string::String, syntect::parsing::syntax_definition::Context>
+pub syntect::parsing::SyntaxDefinition::file_extensions: alloc::vec::Vec<alloc::string::String>
+pub syntect::parsing::SyntaxDefinition::first_line_match: core::option::Option<alloc::string::String>
+pub syntect::parsing::SyntaxDefinition::hidden: bool
+pub syntect::parsing::SyntaxDefinition::name: alloc::string::String
+pub syntect::parsing::SyntaxDefinition::scope: syntect::parsing::Scope
+pub syntect::parsing::SyntaxDefinition::variables: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::load_from_str(s: &str, lines_include_newline: bool, fallback_name: core::option::Option<&str>) -> core::result::Result<syntect::parsing::syntax_definition::SyntaxDefinition, syntect::parsing::ParseSyntaxError>
+impl core::clone::Clone for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::clone(&self) -> syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::cmp::Eq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::cmp::PartialEq<syntect::parsing::syntax_definition::SyntaxDefinition> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::eq(&self, other: &syntect::parsing::syntax_definition::SyntaxDefinition) -> bool
+impl core::fmt::Debug for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralEq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::StructuralPartialEq for syntect::parsing::syntax_definition::SyntaxDefinition
+impl serde::ser::Serialize for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::Sync for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::marker::Unpin for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::syntax_definition::SyntaxDefinition
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::syntax_definition::SyntaxDefinition
+impl<Q, K> indexmap::equivalent::Equivalent<K> for syntect::parsing::syntax_definition::SyntaxDefinition where Q: core::cmp::Eq + core::marker::Sized, K: core::borrow::Borrow<Q> + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::From<T>
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::Into<T>
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Error = core::convert::Infallible
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::syntax_definition::SyntaxDefinition where U: core::convert::TryFrom<T>
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::clone::Clone
+pub type syntect::parsing::syntax_definition::SyntaxDefinition::Owned = T
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::syntax_definition::SyntaxDefinition where T: 'static + core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::syntax_definition::SyntaxDefinition where T: core::marker::Sized
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::syntax_definition::SyntaxDefinition
+pub fn syntect::parsing::syntax_definition::SyntaxDefinition::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::syntax_definition::SyntaxDefinition where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::SyntaxReference
+pub syntect::parsing::SyntaxReference::file_extensions: alloc::vec::Vec<alloc::string::String>
+pub syntect::parsing::SyntaxReference::first_line_match: core::option::Option<alloc::string::String>
+pub syntect::parsing::SyntaxReference::hidden: bool
+pub syntect::parsing::SyntaxReference::name: alloc::string::String
+pub syntect::parsing::SyntaxReference::scope: syntect::parsing::Scope
+pub syntect::parsing::SyntaxReference::variables: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxReference::clone(&self) -> syntect::parsing::SyntaxReference
+impl core::fmt::Debug for syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxReference::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxReference::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxReference::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::SyntaxReference
+impl core::marker::Sync for syntect::parsing::SyntaxReference
+impl core::marker::Unpin for syntect::parsing::SyntaxReference
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::SyntaxReference
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::SyntaxReference
+impl<T, U> core::convert::Into<U> for syntect::parsing::SyntaxReference where U: core::convert::From<T>
+pub fn syntect::parsing::SyntaxReference::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::SyntaxReference where U: core::convert::Into<T>
+pub type syntect::parsing::SyntaxReference::Error = core::convert::Infallible
+pub fn syntect::parsing::SyntaxReference::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::SyntaxReference where U: core::convert::TryFrom<T>
+pub type syntect::parsing::SyntaxReference::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::SyntaxReference::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::SyntaxReference where T: core::clone::Clone
+pub type syntect::parsing::SyntaxReference::Owned = T
+pub fn syntect::parsing::SyntaxReference::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::SyntaxReference::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::SyntaxReference where T: 'static + core::marker::Sized
+pub fn syntect::parsing::SyntaxReference::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::SyntaxReference where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxReference::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::SyntaxReference where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxReference::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxReference::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::SyntaxReference where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::SyntaxSet
+impl syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_extension<'a>(&'a self, extension: &str) -> core::option::Option<&'a syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_first_line<'a>(&'a self, s: &str) -> core::option::Option<&'a syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_name<'a>(&'a self, name: &str) -> core::option::Option<&'a syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_path<'a>(&'a self, path: &str) -> core::option::Option<&'a syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_scope(&self, scope: syntect::parsing::Scope) -> core::option::Option<&syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_by_token<'a>(&'a self, s: &str) -> core::option::Option<&'a syntect::parsing::SyntaxReference>
+pub fn syntect::parsing::SyntaxSet::find_syntax_for_file<P: core::convert::AsRef<std::path::Path>>(&self, path_obj: P) -> std::io::error::Result<core::option::Option<&syntect::parsing::SyntaxReference>>
+pub fn syntect::parsing::SyntaxSet::find_syntax_plain_text(&self) -> &syntect::parsing::SyntaxReference
+pub fn syntect::parsing::SyntaxSet::find_unlinked_contexts(&self) -> alloc::collections::btree::set::BTreeSet<alloc::string::String>
+pub fn syntect::parsing::SyntaxSet::into_builder(self) -> syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSet::load_from_folder<P: core::convert::AsRef<std::path::Path>>(folder: P) -> core::result::Result<syntect::parsing::SyntaxSet, syntect::LoadingError>
+pub fn syntect::parsing::SyntaxSet::new() -> syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::syntaxes(&self) -> &[syntect::parsing::SyntaxReference]
+impl syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::load_defaults_newlines() -> syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::load_defaults_nonewlines() -> syntect::parsing::SyntaxSet
+impl core::clone::Clone for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::clone(&self) -> syntect::parsing::SyntaxSet
+impl core::default::Default for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::default() -> Self
+impl core::fmt::Debug for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Send for syntect::parsing::SyntaxSet
+impl core::marker::Sync for syntect::parsing::SyntaxSet
+impl core::marker::Unpin for syntect::parsing::SyntaxSet
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::SyntaxSet
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::SyntaxSet
+impl<T, U> core::convert::Into<U> for syntect::parsing::SyntaxSet where U: core::convert::From<T>
+pub fn syntect::parsing::SyntaxSet::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::SyntaxSet where U: core::convert::Into<T>
+pub type syntect::parsing::SyntaxSet::Error = core::convert::Infallible
+pub fn syntect::parsing::SyntaxSet::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::SyntaxSet where U: core::convert::TryFrom<T>
+pub type syntect::parsing::SyntaxSet::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::SyntaxSet::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::SyntaxSet where T: core::clone::Clone
+pub type syntect::parsing::SyntaxSet::Owned = T
+pub fn syntect::parsing::SyntaxSet::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::SyntaxSet::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::SyntaxSet where T: 'static + core::marker::Sized
+pub fn syntect::parsing::SyntaxSet::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::SyntaxSet where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxSet::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::SyntaxSet where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxSet::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSet::from(t: T) -> T
+impl<T> serde::de::DeserializeOwned for syntect::parsing::SyntaxSet where T: for<'de> serde::de::Deserialize<'de>
+pub struct syntect::parsing::SyntaxSetBuilder
+impl syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSetBuilder::add(&mut self, syntax: syntect::parsing::syntax_definition::SyntaxDefinition)
+pub fn syntect::parsing::SyntaxSetBuilder::add_from_folder<P: core::convert::AsRef<std::path::Path>>(&mut self, folder: P, lines_include_newline: bool) -> core::result::Result<(), syntect::LoadingError>
+pub fn syntect::parsing::SyntaxSetBuilder::add_plain_text_syntax(&mut self)
+pub fn syntect::parsing::SyntaxSetBuilder::build(self) -> syntect::parsing::SyntaxSet
+pub fn syntect::parsing::SyntaxSetBuilder::new() -> syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSetBuilder::syntaxes(&self) -> &[syntect::parsing::syntax_definition::SyntaxDefinition]
+impl core::clone::Clone for syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSetBuilder::clone(&self) -> syntect::parsing::SyntaxSetBuilder
+impl core::default::Default for syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSetBuilder::default() -> syntect::parsing::SyntaxSetBuilder
+impl core::marker::Send for syntect::parsing::SyntaxSetBuilder
+impl core::marker::Sync for syntect::parsing::SyntaxSetBuilder
+impl core::marker::Unpin for syntect::parsing::SyntaxSetBuilder
+impl core::panic::unwind_safe::RefUnwindSafe for syntect::parsing::SyntaxSetBuilder
+impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::SyntaxSetBuilder
+impl<T, U> core::convert::Into<U> for syntect::parsing::SyntaxSetBuilder where U: core::convert::From<T>
+pub fn syntect::parsing::SyntaxSetBuilder::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::parsing::SyntaxSetBuilder where U: core::convert::Into<T>
+pub type syntect::parsing::SyntaxSetBuilder::Error = core::convert::Infallible
+pub fn syntect::parsing::SyntaxSetBuilder::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::parsing::SyntaxSetBuilder where U: core::convert::TryFrom<T>
+pub type syntect::parsing::SyntaxSetBuilder::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::parsing::SyntaxSetBuilder::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for syntect::parsing::SyntaxSetBuilder where T: core::clone::Clone
+pub type syntect::parsing::SyntaxSetBuilder::Owned = T
+pub fn syntect::parsing::SyntaxSetBuilder::clone_into(&self, target: &mut T)
+pub fn syntect::parsing::SyntaxSetBuilder::to_owned(&self) -> T
+impl<T> core::any::Any for syntect::parsing::SyntaxSetBuilder where T: 'static + core::marker::Sized
+pub fn syntect::parsing::SyntaxSetBuilder::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::parsing::SyntaxSetBuilder where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxSetBuilder::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::parsing::SyntaxSetBuilder where T: core::marker::Sized
+pub fn syntect::parsing::SyntaxSetBuilder::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::parsing::SyntaxSetBuilder
+pub fn syntect::parsing::SyntaxSetBuilder::from(t: T) -> T
+pub const syntect::parsing::ATOM_LEN_BITS: u16 = 3u16
+pub static syntect::parsing::SCOPE_REPO: once_cell::sync::Lazy<std::sync::mutex::Mutex<syntect::parsing::ScopeRepository>>
+pub mod syntect::util
+pub struct syntect::util::LinesWithEndings<'a>
+impl<'a> syntect::util::LinesWithEndings<'a>
+pub fn syntect::util::LinesWithEndings<'a>::from(input: &'a str) -> syntect::util::LinesWithEndings<'a>
+impl<'a> core::iter::traits::iterator::Iterator for syntect::util::LinesWithEndings<'a>
+pub type syntect::util::LinesWithEndings<'a>::Item = &'a str
+pub fn syntect::util::LinesWithEndings<'a>::next(&mut self) -> core::option::Option<&'a str>
+impl<'a> core::marker::Send for syntect::util::LinesWithEndings<'a>
+impl<'a> core::marker::Sync for syntect::util::LinesWithEndings<'a>
+impl<'a> core::marker::Unpin for syntect::util::LinesWithEndings<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::util::LinesWithEndings<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::util::LinesWithEndings<'a>
+impl<I> core::iter::traits::collect::IntoIterator for syntect::util::LinesWithEndings<'a> where I: core::iter::traits::iterator::Iterator
+pub type syntect::util::LinesWithEndings<'a>::IntoIter = I
+pub type syntect::util::LinesWithEndings<'a>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+pub fn syntect::util::LinesWithEndings<'a>::into_iter(self) -> I
+impl<T, U> core::convert::Into<U> for syntect::util::LinesWithEndings<'a> where U: core::convert::From<T>
+pub fn syntect::util::LinesWithEndings<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::util::LinesWithEndings<'a> where U: core::convert::Into<T>
+pub type syntect::util::LinesWithEndings<'a>::Error = core::convert::Infallible
+pub fn syntect::util::LinesWithEndings<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::util::LinesWithEndings<'a> where U: core::convert::TryFrom<T>
+pub type syntect::util::LinesWithEndings<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::util::LinesWithEndings<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for syntect::util::LinesWithEndings<'a> where T: 'static + core::marker::Sized
+pub fn syntect::util::LinesWithEndings<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::util::LinesWithEndings<'a> where T: core::marker::Sized
+pub fn syntect::util::LinesWithEndings<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::util::LinesWithEndings<'a> where T: core::marker::Sized
+pub fn syntect::util::LinesWithEndings<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::util::LinesWithEndings<'a>
+pub fn syntect::util::LinesWithEndings<'a>::from(t: T) -> T
+pub fn syntect::util::as_24_bit_terminal_escaped(v: &[(syntect::highlighting::Style, &str)], bg: bool) -> alloc::string::String
+pub fn syntect::util::as_latex_escaped(v: &[(syntect::highlighting::Style, &str)]) -> alloc::string::String
+pub fn syntect::util::debug_print_ops(line: &str, ops: &[(usize, syntect::parsing::ScopeStackOp)])
+pub fn syntect::util::modify_range<'a>(v: &[(syntect::highlighting::Style, &'a str)], r: core::ops::range::Range<usize>, modifier: syntect::highlighting::StyleModifier) -> alloc::vec::Vec<(syntect::highlighting::Style, &'a str)>
+pub fn syntect::util::split_at<'a, A: core::clone::Clone>(v: &[(A, &'a str)], split_i: usize) -> (alloc::vec::Vec<(A, &'a str)>, alloc::vec::Vec<(A, &'a str)>)
+#[non_exhaustive] pub enum syntect::Error
+pub syntect::Error::Fmt(core::fmt::Error)
+pub syntect::Error::Io(std::io::error::Error)
+pub syntect::Error::LoadingError(syntect::LoadingError)
+pub syntect::Error::ParsingError(syntect::parsing::ParsingError)
+pub syntect::Error::ScopeError(syntect::parsing::ScopeError)
+impl core::convert::From<core::fmt::Error> for syntect::Error
+pub fn syntect::Error::from(source: core::fmt::Error) -> Self
+impl core::convert::From<std::io::error::Error> for syntect::Error
+pub fn syntect::Error::from(source: std::io::error::Error) -> Self
+impl core::convert::From<syntect::LoadingError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::LoadingError) -> Self
+impl core::convert::From<syntect::parsing::ParsingError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::parsing::ParsingError) -> Self
+impl core::convert::From<syntect::parsing::ScopeError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::parsing::ScopeError) -> Self
+impl core::error::Error for syntect::Error
+pub fn syntect::Error::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Display for syntect::Error
+pub fn syntect::Error::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::Error
+pub fn syntect::Error::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::Error
+impl core::marker::Sync for syntect::Error
+impl core::marker::Unpin for syntect::Error
+impl !core::panic::unwind_safe::RefUnwindSafe for syntect::Error
+impl !core::panic::unwind_safe::UnwindSafe for syntect::Error
+impl<T, U> core::convert::Into<U> for syntect::Error where U: core::convert::From<T>
+pub fn syntect::Error::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::Error where U: core::convert::Into<T>
+pub type syntect::Error::Error = core::convert::Infallible
+pub fn syntect::Error::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::Error where U: core::convert::TryFrom<T>
+pub type syntect::Error::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::Error::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::Error where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::Error::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::Error where T: 'static + core::marker::Sized
+pub fn syntect::Error::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::Error where T: core::marker::Sized
+pub fn syntect::Error::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::Error where T: core::marker::Sized
+pub fn syntect::Error::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::Error
+pub fn syntect::Error::from(t: T) -> T
+#[non_exhaustive] pub enum syntect::LoadingError
+pub syntect::LoadingError::BadPath
+pub syntect::LoadingError::Io(std::io::error::Error)
+pub syntect::LoadingError::ParseSyntax(syntect::parsing::ParseSyntaxError, alloc::string::String)
+pub syntect::LoadingError::ParseTheme(syntect::highlighting::ParseThemeError)
+pub syntect::LoadingError::ReadSettings(syntect::highlighting::SettingsError)
+pub syntect::LoadingError::WalkDir(walkdir::error::Error)
+impl core::convert::From<std::io::error::Error> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: std::io::error::Error) -> Self
+impl core::convert::From<syntect::LoadingError> for syntect::Error
+pub fn syntect::Error::from(source: syntect::LoadingError) -> Self
+impl core::convert::From<syntect::highlighting::ParseThemeError> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: syntect::highlighting::ParseThemeError) -> Self
+impl core::convert::From<syntect::highlighting::SettingsError> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: syntect::highlighting::SettingsError) -> Self
+impl core::convert::From<walkdir::error::Error> for syntect::LoadingError
+pub fn syntect::LoadingError::from(source: walkdir::error::Error) -> Self
+impl core::error::Error for syntect::LoadingError
+pub fn syntect::LoadingError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
+impl core::fmt::Display for syntect::LoadingError
+pub fn syntect::LoadingError::fmt(&self, __formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Debug for syntect::LoadingError
+pub fn syntect::LoadingError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Send for syntect::LoadingError
+impl core::marker::Sync for syntect::LoadingError
+impl core::marker::Unpin for syntect::LoadingError
+impl !core::panic::unwind_safe::RefUnwindSafe for syntect::LoadingError
+impl !core::panic::unwind_safe::UnwindSafe for syntect::LoadingError
+impl<T, U> core::convert::Into<U> for syntect::LoadingError where U: core::convert::From<T>
+pub fn syntect::LoadingError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for syntect::LoadingError where U: core::convert::Into<T>
+pub type syntect::LoadingError::Error = core::convert::Infallible
+pub fn syntect::LoadingError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for syntect::LoadingError where U: core::convert::TryFrom<T>
+pub type syntect::LoadingError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn syntect::LoadingError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::string::ToString for syntect::LoadingError where T: core::fmt::Display + core::marker::Sized
+pub fn syntect::LoadingError::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for syntect::LoadingError where T: 'static + core::marker::Sized
+pub fn syntect::LoadingError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for syntect::LoadingError where T: core::marker::Sized
+pub fn syntect::LoadingError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for syntect::LoadingError where T: core::marker::Sized
+pub fn syntect::LoadingError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for syntect::LoadingError
+pub fn syntect::LoadingError::from(t: T) -> T

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,0 +1,19 @@
+#[test]
+fn public_api() {
+    // Install a compatible nightly toolchain if it is missing
+    rustup_toolchain::install(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+
+    // Build rustdoc JSON
+    let rustdoc_json = rustdoc_json::Builder::default()
+        .toolchain(public_api::MINIMUM_NIGHTLY_RUST_VERSION)
+        .build()
+        .unwrap();
+
+    // Derive the public API from the rustdoc JSON
+    let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+        .build()
+        .unwrap();
+
+    // Assert that the public API looks correct
+    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+}


### PR DESCRIPTION
In the case of https://github.com/trishume/syntect/pull/490 we probably would have thought twice before merge if we knew it changed the public API in a semver incompatible way.

Add a CI check to detect changes to the public API to avoid surprises in the future. I have followed the instructions at https://github.com/Enselic/cargo-public-api#-as-a-ci-check.

Full disclosure: I am the maintainer of the `rustup-toolchain`, `rustdoc-json`, and `public-api` crates we begin to dev-depend on.