### PR TITLE
Update `regex-syntax` to 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"
-regex-syntax = { version = "0.7", optional = true }
+regex-syntax = { version = "0.8", optional = true }
 bitflags = {version = "2.4", features = ["serde"] }
 plist = { version = "1.3", optional = true }
 bincode = { version = "1.0", optional = true }


### PR DESCRIPTION
I have updated the `regex-syntax` dependencies to 0.8.
I don't have a way to test this further than `cargo test --no-fail-fast`, which showed the same tests failing on `master` as on this. So it is the same in that regard.