### PR TITLE
Add parsing of gutterSettings

### DIFF
--- a/src/highlighting/theme_load.rs
+++ b/src/highlighting/theme_load.rs
@@ -300,7 +300,7 @@ impl ParseSettings for Theme {
             _ => return Err(IncorrectSyntax),
         };
         let mut iter = items.into_iter();
-        let settings = match iter.next() {
+        let mut settings = match iter.next() {
             Some(Settings::Object(mut obj)) => {
                 match obj.remove("settings") {
                     Some(settings) => ThemeSettings::parse_settings(settings)?,
@@ -309,6 +309,20 @@ impl ParseSettings for Theme {
             }
             _ => return Err(UndefinedSettings),
         };
+        if let Some(Settings::Object(obj)) = obj.remove("gutterSettings") {
+            for (key, value) in obj {
+                let color = Color::parse_settings(value).ok();
+                match &key[..] {
+                    "background" => {
+                        settings.gutter = settings.gutter.or(color)
+                    }
+                    "foreground" => {
+                        settings.gutter_foreground = settings.gutter_foreground.or(color)
+                    }
+                    _ => (),
+                }
+            }
+        }
         let mut scopes = Vec::new();
         for json in iter {
             // TODO option to disable best effort parsing and bubble up warnings

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -108,7 +108,25 @@ mod tests {
                 r: 0xc0,
                 g: 0xc5,
                 b: 0xce,
-                a: 0xFF,
+                a: 0xff,
+            }
+        );
+        assert_eq!(
+            theme.settings.gutter_foreground.unwrap(),
+            Color {
+                r: 0x65,
+                g: 0x73,
+                b: 0x7e,
+                a: 0xff,
+            }
+        );
+        assert_eq!(
+            theme.settings.gutter.unwrap(),
+            Color {
+                r: 0x34,
+                g: 0x3d,
+                b: 0x46,
+                a: 0xff,
             }
         );
         // unreachable!();


### PR DESCRIPTION
Many TextMate2 themes use `gutterSettings` to store colors for the gutter area. This is not supported by Sublime Text. This PR enables using `gutterSettings` to set the foreground and background of the gutter but only if they are not already set in `settings`.

Closes #469 