### PR TITLE
Eliminate syntect library's dependency on serde's "derive" feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Run cargo check
       run: |
         cargo check --all-features --all-targets
+        # Check that if some other crate in the downstream dependency tree
+        # enables serde's "derive" feature, syntect still builds.
+        cargo check --all-features --features serde/derive
 
   documentation:
     name: Documentation checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ plist = { version = "1.3", optional = true }
 bincode = { version = "1.0", optional = true }
 flate2 = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
+serde_derive = "1.0"
 serde_json = "1.0"
 once_cell = "1.8"
 thiserror = "1.0"

--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -34,7 +34,7 @@ use flate2::bufread::ZlibDecoder;
 #[cfg(feature = "dump-create")]
 use flate2::Compression;
 #[cfg(feature = "dump-create")]
-use serde::Serialize;
+use serde::ser::Serialize;
 #[cfg(feature = "dump-load")]
 use serde::de::DeserializeOwned;
 

--- a/src/highlighting/selector.rs
+++ b/src/highlighting/selector.rs
@@ -2,7 +2,7 @@
 /// released under the MIT license by @defuz
 use crate::parsing::{Scope, ScopeStack, MatchPower, ParseScopeError};
 use std::str::FromStr;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A single selector consisting of a stack to match and a possible stack to
 /// exclude from being matched.

--- a/src/highlighting/style.rs
+++ b/src/highlighting/style.rs
@@ -1,7 +1,7 @@
 // Code based on [https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs](https://github.com/defuz/sublimate/blob/master/src/core/syntax/scope.rs)
 // released under the MIT license by @defuz
 use bitflags::bitflags;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Foreground and background colors, with font style
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/highlighting/theme.rs
+++ b/src/highlighting/theme.rs
@@ -2,7 +2,7 @@
 // released under the MIT license by @defuz
 use super::style::*;
 use super::selector::*;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A theme parsed from a `.tmTheme` file.
 ///

--- a/src/highlighting/theme_set.rs
+++ b/src/highlighting/theme_set.rs
@@ -2,7 +2,7 @@ use super::super::LoadingError;
 #[cfg(feature = "plist-load")]
 use super::settings::*;
 use super::theme::Theme;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/src/parsing/metadata.rs
+++ b/src/parsing/metadata.rs
@@ -7,8 +7,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::str::FromStr;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json;
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 
 use super::regex::Regex;
 use super::scope::{MatchPower, Scope};

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::OnceCell;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
 use std::error::Error;
 
 /// An abstraction for regex patterns.

--- a/src/parsing/scope.rs
+++ b/src/parsing/scope.rs
@@ -9,8 +9,9 @@ use std::cmp::{Ordering, min};
 use std::mem;
 
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde::de::{Error, Visitor};
+use serde::de::{Deserialize, Deserializer, Error, Visitor};
+use serde::ser::{Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 
 /// Scope related errors
 #[derive(Debug, thiserror::Error)]

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -9,7 +9,8 @@ use std::hash::Hash;
 use super::{scope::*, ParsingError};
 use super::regex::{Regex, Region};
 use regex_syntax::escape;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::ser::{Serialize, Serializer};
+use serde_derive::{Deserialize, Serialize};
 use crate::parsing::syntax_set::SyntaxSet;
 
 pub type CaptureMapping = Vec<(usize, Vec<Scope>)>;

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -17,7 +17,7 @@ use std::mem;
 use super::regex::Regex;
 use crate::parsing::syntax_definition::ContextId;
 use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A syntax set holds multiple syntaxes that have been linked together.
 ///


### PR DESCRIPTION
Here are charts from `cargo build --timings`.

Notice how **Before**, syn -> serde_derive -> serde -> {bincode,serde_json,plist} -> syntect is a bottleneck in the build, whereas **After**, nothing related to serde is on the critical path. Instead, libc -> cc -> onig_sys -> onig -> syntect is the new bottleneck.

The build is 15% faster end-to-end (7.6 seconds vs 8.9 seconds). More importantly, notice how if whatever downstream crate that depends on syntect has other dependencies that depend on serde, those can begin building after only 2.6 seconds, instead of after 6.3 seconds, which can speed up builds by up to 3.7 seconds, including making IDEs more responsive by that amount.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img src="https://github.com/trishume/syntect/assets/1940490/1555c3f3-8546-494f-8903-5a5221e7b6d4"></td><td><img src="https://github.com/trishume/syntect/assets/1940490/a140a011-611c-4ee7-b842-459d7ab34a9e"></td></tr>
</table>