### PR TITLE
Automate the release process with a GitHub Actions workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+# To make a release:
+#
+# 1. Update Cargo.toml version and CHANGELOG.md on master
+# 2. Run workflow https://github.com/trishume/syntect/actions/workflows/Release.yml on master
+# 3. Done!
+
+on:
+  workflow_dispatch: # This workflow can only be triggered manually.
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Make sure regular CI passes before we make a release.
+  ci:
+    uses: ./.github/workflows/CI.yml
+
+  # After regular CI passes we publish to crates.io and push a git tag.
+  publish-and-tag:
+    needs: ci
+    runs-on: ubuntu-latest
+    environment:
+      name: crates.io
+      url: https://crates.io/crates/syntect
+    permissions:
+      contents: write # So we can push a tag.
+    outputs:
+      VERSION: ${{ steps.version.outputs.VERSION }}
+      TAG_NAME: ${{ steps.version.outputs.TAG_NAME }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo publish -p syntect
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: version
+        id: version
+        run: |
+          version=$(cargo read-manifest --manifest-path Cargo.toml | jq --raw-output .version)
+          echo "VERSION=${version}" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=v${version}" >> $GITHUB_OUTPUT
+      - name: push tag
+        run: |
+          git tag ${{ steps.version.outputs.TAG_NAME }}
+          git push origin ${{ steps.version.outputs.TAG_NAME }}
+
+  # Lastly, create a GitHub release. Note that the secret crates.io token is
+  # inaccessible to this job. That is good since we run some third party code.
+  release:
+    needs: publish-and-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # So we can create a release.
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo install parse-changelog@0.6.4 --locked
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes="$(parse-changelog CHANGELOG.md ${{ needs.publish-and-tag.outputs.VERSION }})"
+          title="${{ needs.publish-and-tag.outputs.TAG_NAME }}"
+          gh release create --title "$title" --notes "$notes" ${{ needs.publish-and-tag.outputs.TAG_NAME }}


### PR DESCRIPTION
To make it easy to make releases, automate the process via GitHub Actions.

Create a workflow that:
1. Runs cargo publish
2. Pushes a git tag, but only if the publish was successful.
3. Creates a GitHub Release with release notes from CHANGELOG.md, but only if creating the tag was successful.

# New release process

After this lands, this will be the new release process:

1. Update Cargo.toml version and CHANGELOG.md on master
2. Run workflow https://github.com/trishume/syntect/actions/workflows/Release.yml on master
3. Done!

# Help needed to setup

Hi @trishume ! Would be great if you could help set up an automated release process. I only need your help with this:

## Create a crates.io token

1. https://crates.io/settings/tokens/new
1. For expiration, I recommend 'No expiration' so we don't have to keep updating it.
1. For 'Scopes', select 'publish-update'. That way, if the token leaks, it can't be used to remove us as owners on crates.io.
1. For 'Crates', limit it to `syntect`.
1. Click 'Generate token'

If you prefer me to use a token belonging to my account, that's perfectly fine with me, just let me know. I'll then share it with you through gpg.

## Create a GitHub Actions secret

1. https://github.com/trishume/syntect/settings/environments/new and call it `crates.io`
1. Add secret and call it `CARGO_REGISTRY_TOKEN` and paste the above token
1. In 'Deployment branches and tags', make it available only to the branch 'master' by selecting "Protected branches only" on the dropbox to the right, to minimize risk of it leaking

Done! I'll take it from there.