### PR TITLE
Release.yml: Do not leak token to CI.yml

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -21,6 +21,8 @@ jobs:
   # Make sure regular CI passes before we make a release.
   ci:
     uses: ./.github/workflows/CI.yml
+    with:
+      one_time_crates_io_token_secret: masked
 
   # After regular CI passes we publish to crates.io and push a git tag.
   publish-and-tag:


### PR DESCRIPTION
v5.2.0 has been released.

I already revoked the token I used to publish, so this is not urgent. But this should make the token be completely masked in logs of all jobs.