### PR TITLE
replace unmaintained yaml-rust with active fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true }
+yaml-rust2 = { version = "0.8.0", optional = true }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"
@@ -69,7 +69,7 @@ html = ["parsing"]
 # Support for parsing .tmTheme files and .tmPreferences files
 plist-load = ["plist"]
 # Support for parsing .sublime-syntax files
-yaml-load = ["yaml-rust", "parsing"]
+yaml-load = ["yaml-rust2", "parsing"]
 
 default-onig = ["parsing", "default-syntaxes", "default-themes", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -1,8 +1,8 @@
 use super::regex::{Regex, Region};
 use super::scope::*;
 use super::syntax_definition::*;
-use yaml_rust::{YamlLoader, Yaml, ScanError};
-use yaml_rust::yaml::Hash;
+use yaml_rust2::{YamlLoader, Yaml, ScanError};
+use yaml_rust2::yaml::Hash;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;


### PR DESCRIPTION
see https://github.com/rustsec/advisory-db/issues/1921 , I'm actually coming from https://github.com/rust-lang/docs.rs/issues/2469. 

When running the tests locally I'm seeing some test failures, probably related to the test setup, I assume that CI will do the necessary test setup and we'll see if this change is fine. 


As a personal sidenote: not using rustfmt actually made constributing a little harder for me, it's so standard in my personal experience that it's in my editor / IDE config automatically on safe, which I needed to disable for this change. 



