### PR TITLE
Remove unused imports in tests for yaml_load.rs

### DIFF
--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -887,7 +887,6 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsing::syntax_definition::*;
     use crate::parsing::Scope;
 
     #[test]


### PR DESCRIPTION
While working on #530, I noticed `cargo test` warned unused imports in test code.

```
warning: unused import: `crate::parsing::syntax_definition::*`
   --> src/parsing/yaml_load.rs:890:9
    |
890 |     use crate::parsing::syntax_definition::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
```

This PR fixes the warning.