### PR TITLE
chore: replace yaml-rust with actively maintained yaml-rust2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true, crate = "yaml-rust2" }
+yaml-rust = { version = "0.4.5", optional = true, package = "yaml-rust2" }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true }
+yaml-rust = { version = "0.4.5", optional = true, crate = "yaml-rust2" }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"


### PR DESCRIPTION
It would be worth investigating if the dependency is required at all, this simply replaces it with the `crate` key in the `Cargo.toml` with `yaml-rust2`.

TODO: update changelog when everything is sorted out 👍