### PR TITLE
chore: Bump nightly version to fix the test suite

### DIFF
--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,11 +1,19 @@
 #[test]
 fn public_api() {
+    // NOTE: consider switching back to using `public_api::MINIMUM_NIGHTLY_RUST_VERSION` after the
+    // version is newer than the one set here
+    let nightly_version = "nightly-2023-09-18";
+    assert_eq!(
+        public_api::MINIMUM_NIGHTLY_RUST_VERSION,
+        "nightly-2023-08-25"
+    );
+
     // Install a compatible nightly toolchain if it is missing
-    rustup_toolchain::install(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+    rustup_toolchain::install(nightly_version).unwrap();
 
     // Build rustdoc JSON
     let rustdoc_json = rustdoc_json::Builder::default()
-        .toolchain(public_api::MINIMUM_NIGHTLY_RUST_VERSION)
+        .toolchain(nightly_version)
         .build()
         .unwrap();
 


### PR DESCRIPTION
`serde` made a release adding support for saturating types that fails to compile on the specific nightly that's currently set as `public_api::MINIMUM_NIGHTLY_RUST_VERSION` and it can't be fixed at this point without breaking backwards compat. This PR bumps the nightly version used for the public API check to the first one that starts compiling successfully again