### PR TITLE
Fix unmaintained audit warning for yaml-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,10 @@ keywords = ["syntax", "highlighting", "highlighter", "colouring", "parsing"]
 categories = ["parser-implementations", "parsing", "text-processing"]
 readme = "Readme.md"
 license = "MIT"
-version = "5.2.0" # remember to update html_root_url
+version = "5.2.0"                                                                                                # remember to update html_root_url
 authors = ["Tristan Hume <tristan@thume.ca>"]
 edition = "2021"
-exclude = [
-    "testdata/*",
-    "/scripts/*",
-    "/Makefile",
-    "/codecov.yml"
-]
+exclude = ["testdata/*", "/scripts/*", "/Makefile", "/codecov.yml"]
 
 [dependencies]
 yaml-rust2 = { version = "0.8", optional = true, default_features = false }
@@ -35,7 +30,7 @@ once_cell = "1.8"
 thiserror = "1.0"
 
 [dev-dependencies]
-criterion = { version = "0.3", features = [ "html_reports" ] }
+criterion = { version = "0.3", features = ["html_reports"] }
 rayon = "1.0.0"
 regex = "1.0"
 getopts = "0.2"
@@ -71,9 +66,29 @@ plist-load = ["plist"]
 # Support for parsing .sublime-syntax files
 yaml-load = ["yaml-rust2", "parsing"]
 
-default-onig = ["parsing", "default-syntaxes", "default-themes", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-onig"]
+default-onig = [
+  "parsing",
+  "default-syntaxes",
+  "default-themes",
+  "html",
+  "plist-load",
+  "yaml-load",
+  "dump-load",
+  "dump-create",
+  "regex-onig",
+]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature
-default-fancy = ["parsing", "default-syntaxes", "default-themes", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-fancy"]
+default-fancy = [
+  "parsing",
+  "default-syntaxes",
+  "default-themes",
+  "html",
+  "plist-load",
+  "yaml-load",
+  "dump-load",
+  "dump-create",
+  "regex-fancy",
+]
 default = ["default-onig"]
 
 # [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true }
+yaml-rust2 = { version = "0.8", optional = true }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"
@@ -69,7 +69,7 @@ html = ["parsing"]
 # Support for parsing .tmTheme files and .tmPreferences files
 plist-load = ["plist"]
 # Support for parsing .sublime-syntax files
-yaml-load = ["yaml-rust", "parsing"]
+yaml-load = ["yaml-rust2", "parsing"]
 
 default-onig = ["parsing", "default-syntaxes", "default-themes", "html", "plist-load", "yaml-load", "dump-load", "dump-create", "regex-onig"]
 # In order to switch to the fancy-regex engine, disable default features then add the default-fancy feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust2 = { version = "0.8", optional = true }
+yaml-rust2 = { version = "0.8", optional = true, default_features = false }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -5,8 +5,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::ops::DerefMut;
 use std::path::Path;
-use yaml_rust::yaml::Hash;
-use yaml_rust::{ScanError, Yaml, YamlLoader};
+use yaml_rust2::{ScanError, Yaml, YamlLoader, yaml::Hash};
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]


### PR DESCRIPTION
When running [`cargo audit`](https://crates.io/crates/cargo-audit) on this repo, I get a warning that `yaml-rust` is no longer maintained:

```
Crate:     yaml-rust
Version:   0.4.5
Warning:   unmaintained
Title:     yaml-rust is unmaintained.
Date:      2024-03-20
ID:        RUSTSEC-2024-0320
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0320
Dependency tree:
yaml-rust 0.4.5
└── syntect 5.2.0
```

This PR replaces that dependency with [`yaml-rust2`](https://crates.io/crates/yaml-rust2), which does the same thing and has the same API, but is also actively maintained.

Some other warnings popped up as well, but they were related to dev dependencies, so likely not a big deal.