### PR TITLE
[ReadMe Update] - Two projects (Bolt and  tokio-cassandra) are now not available and one new one is added "pysyntect".

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -226,7 +226,6 @@ Characters of comment:                 41099
 Below is a list of projects using Syntect, in approximate order by how long they've been using `syntect` (feel free to send PRs to add to this list):
 
 - [bat](https://github.com/sharkdp/bat), a `cat(1)` clone, uses `syntect` for syntax highlighting.
-- [Bolt](https://github.com/hiro-codes/bolt), a desktop application for building and testing APIs, uses `syntect` for syntax highlighting. 
 - [catmark](https://github.com/bestouff/catmark), a console markdown printer, uses `syntect` for code blocks.
 - [Cobalt](https://github.com/cobalt-org/cobalt.rs), a static site generator that uses `syntect` for highlighting code snippets.
 - [crowbook](https://github.com/lise-henry/crowbook), a Markdown book generator, uses `syntect` for code blocks.
@@ -236,7 +235,6 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [mdcat](https://github.com/lunaryorn/mdcat), a console markdown printer, uses `syntect` for code blocks.
 - [Scribe](https://github.com/jmacdonald/scribe), a Rust text editor framework which uses `syntect` for highlighting.
 - [syntect_server](https://github.com/sourcegraph/syntect_server), an HTTP server for syntax highlighting.
-- [tokio-cassandra](https://github.com/nhellwig/tokio-cassandra), CQL shell in Rust, uses `syntect` for shell colouring.
 - [xi-editor](https://github.com/google/xi-editor), a text editor in Rust which uses `syntect` for highlighting.
 - [Zola](https://github.com/getzola/zola), a static site generator that uses `syntect` for highlighting code snippets.
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.

--- a/Readme.md
+++ b/Readme.md
@@ -243,6 +243,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [bingus-blog](https://git.slonk.ing/slonk/bingus-blog), a blog software written in Rust, uses `syntect` for fenced code blocks.
 - [BugStalker](https://github.com/godzie44/BugStalker/), modern debugger for Linux x86-64. Written in Rust for Rust programs.
 - [Yazi](https://github.com/sxyazi/yazi), blazing fast terminal file manager based on async I/O, uses `syntect` for text file previews.
+- [Pysyntect](https://github.com/spyder-ide/pysyntect), Python bindings for the Syntect library.
 
 
 ## License and Acknowledgements


### PR DESCRIPTION
Since two of the projects mentioned in section are now not available (may be their authors deleted cause of some reasons.), now so their links are not accessible now. This PR remove those projects links and also added a new one python library "pysyntect" made by creator of "spyder-ide".
I hope it is helpful.