### PR TITLE
fix(sublime-syntax): catch backslash pattern

### DIFF
--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -241,6 +241,9 @@ where
 
         last_was_escape = c == '\\' && !last_was_escape;
     }
+    if last_was_escape {
+        reg_str.push('\\');
+    }
     reg_str
 }
 

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -1319,4 +1319,25 @@ mod tests {
         println!("{:?}", valid_indexes);
         assert_eq!(valid_indexes, [0, 1, 5, 6]);
     }
+
+    #[test]
+    fn error_loading_syntax_with_unescaped_backslash() {
+        let load_err = SyntaxDefinition::load_from_str(
+            r#"
+            name: Unescaped Backslash
+            scope: source.c
+            file_extensions: [test]
+            contexts:
+              main:
+                - match: '\'
+            "#,
+            false,
+            None,
+        )
+        .unwrap_err();
+        match load_err {
+            ParseSyntaxError::RegexCompileError(bad_regex, _) => assert_eq!(bad_regex, r"\"),
+            _ => panic!("Unexpected error: {load_err}"),
+        }
+    }
 }


### PR DESCRIPTION
Fixes #547.
