### PR TITLE
dumps/serialize_to_writer: insert BufWriter to speed up serialization

### DIFF
--- a/src/dumps.rs
+++ b/src/dumps.rs
@@ -123,7 +123,7 @@ fn serialize_to_writer_impl<T: Serialize, W: Write>(
     use_compression: bool,
 ) -> Result<()> {
     if use_compression {
-        let mut encoder = ZlibEncoder::new(output, Compression::best());
+        let mut encoder = std::io::BufWriter::new(ZlibEncoder::new(output, Compression::best()));
         serialize_into(&mut encoder, to_dump)
     } else {
         serialize_into(output, to_dump)


### PR DESCRIPTION
By buffering bincode's output prior to compression, we can achieve a ~30x speedup of syntect in debug builds (such as used in `cargo test`s by default) on a single `SyntaxSetBuilder::build()` call. For Tock's `license-checker` [1] crate using `syntect`, this brings overall test times down from ~75s to 4s on an i7-1360P. This change does not affect release builds much, bringing an individual test down from 0.17 to 0.13 seconds.

[1]: https://github.com/tock/tock/tree/a109dd65fb269479ca4fa020af0a54da740eca28/tools/license-checker