### PR TITLE
chore: use yaml-rust2 instead of unmaintained yaml-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true }
+yaml-rust = { version = "0.9.0", optional = true, package = "yaml-rust2", default-features = false }
 onig = { version = "6.0", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"


### PR DESCRIPTION
Supersedes #544.

Uses `yaml-rust2` instead of `yaml-rust` which is unmaintained.