### PR TITLE
add Typst as Project to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [The Way](https://github.com/out-of-cheese-error/the-way), a code snippets manager for your terminal that uses `syntect`for highlighting.
 - [Broot](https://github.com/Canop/broot), a terminal file manager, uses `syntect` for file previews.
 - [Rusty Slider](https://ollej.github.io/rusty-slider/), a markdown slideshow presentation application, uses `syntect` for code blocks.
+- [Typst](https://github.com/typst/typst), a typesetting system and LaTeX alternative, uses `syntect` for highlighting code blocks.
 - [bingus-blog](https://git.slonk.ing/slonk/bingus-blog), a blog software written in Rust, uses `syntect` for fenced code blocks.
 - [BugStalker](https://github.com/godzie44/BugStalker/), modern debugger for Linux x86-64. Written in Rust for Rust programs.
 - [Yazi](https://github.com/sxyazi/yazi), blazing fast terminal file manager based on async I/O, uses `syntect` for text file previews.


### PR DESCRIPTION
[Typst](https://github.com/typst/typst) is a very popular project (> 35k stars on GitHub) which uses syntect.

This PR adds it to the list in the Readme.