### PR TITLE
tests: Use `insta` instead of `expect-test` for public API test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,32 +289,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
-name = "dissimilar"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "expect-test"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
-dependencies = [
- "dissimilar",
- "once_cell",
-]
 
 [[package]]
 name = "fancy-regex"
@@ -374,6 +376,18 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "similar",
 ]
 
 [[package]]
@@ -765,6 +779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,11 +813,11 @@ dependencies = [
  "bincode",
  "bitflags",
  "criterion",
- "expect-test",
  "fancy-regex",
  "flate2",
  "fnv",
  "getopts",
+ "insta",
  "once_cell",
  "onig",
  "plist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ pretty_assertions = "0.6"
 rustup-toolchain = "0.1.5"
 rustdoc-json = "0.8.8"
 public-api = "0.33.1"
-expect-test = "1.4.1"
+insta = "1.42.0"
 
 [features]
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -24,5 +24,5 @@ fn public_api() {
         .unwrap();
 
     // Assert that the public API looks correct
-    expect_test::expect_file!["public-api.txt"].assert_eq(&public_api.to_string());
+    insta::assert_snapshot!(public_api);
 }

--- a/tests/snapshots/public_api__public_api.snap
+++ b/tests/snapshots/public_api__public_api.snap
@@ -1,3 +1,7 @@
+---
+source: tests/public_api.rs
+expression: public_api
+---
 pub mod syntect
 pub mod syntect::dumps
 pub fn syntect::dumps::dump_binary<T: serde::ser::Serialize>(o: &T) -> alloc::vec::Vec<u8>


### PR DESCRIPTION
The failure in https://github.com/trishume/syntect/actions/runs/12734263547/job/35491626740?pr=565 (for https://github.com/trishume/syntect/pull/565) was too verbose and not very friendly.

Let's switch to `insta` which has a better way to deal with snapshots.

Marking as Draft until I have had time to do some more experiments. And to give others a chance to give feedback on the change as such.