### PR TITLE
refactor: add convenience `HighlightLines::from_state` constructor

### DIFF
--- a/src/easy.rs
+++ b/src/easy.rs
@@ -84,6 +84,20 @@ impl<'a> HighlightLines<'a> {
             HighlightIterator::new(&mut self.highlight_state, &ops[..], line, &self.highlighter);
         Ok(iter.collect())
     }
+
+    /// This starts again from a previous state, useful for highlighting a file incrementally for
+    /// which you've cached the highlight and parse state.
+    pub fn from_state(
+        theme: &'a Theme,
+        highlight_state: HighlightState,
+        parse_state: ParseState,
+    ) -> HighlightLines<'a> {
+        HighlightLines {
+            highlighter: Highlighter::new(theme),
+            parse_state,
+            highlight_state,
+        }
+    }
 }
 
 /// Convenience struct containing everything you need to highlight a file

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -377,7 +377,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "default-syntaxes")]
+    #[cfg(all(feature = "default-syntaxes", feature = "default-themes"))]
     #[test]
     fn can_start_again_from_previous_state() {
         let ss = SyntaxSet::load_defaults_nonewlines();

--- a/src/easy.rs
+++ b/src/easy.rs
@@ -98,6 +98,11 @@ impl<'a> HighlightLines<'a> {
             highlight_state,
         }
     }
+
+    /// Returns the current highlight and parse states, useful for caching and incremental highlighting.
+    pub fn state(self) -> (HighlightState, ParseState) {
+        (self.highlight_state, self.parse_state)
+    }
 }
 
 /// Convenience struct containing everything you need to highlight a file
@@ -370,5 +375,39 @@ mod tests {
             let all_ops = ops.iter().map(|t| &t.1);
             assert_eq!(all_ops.count(), iterated_ops.len() - 1); // -1 because we want to ignore the NOOP
         }
+    }
+
+    #[cfg(feature = "default-syntaxes")]
+    #[test]
+    fn can_start_again_from_previous_state() {
+        let ss = SyntaxSet::load_defaults_nonewlines();
+        let ts = ThemeSet::load_defaults();
+        let mut highlighter = HighlightLines::new(
+            ss.find_syntax_by_extension("py").unwrap(),
+            &ts.themes["base16-ocean.dark"],
+        );
+
+        let lines = ["\"\"\"", "def foo():", "\"\"\""];
+
+        let highlighted_first_line = highlighter
+            .highlight_line(lines[0], &ss)
+            .expect("#[cfg(test)]");
+
+        let (highlight_state, parse_state) = highlighter.state();
+
+        let mut other_highlighter = HighlightLines::from_state(
+            &ts.themes["base16-ocean.dark"],
+            highlight_state,
+            parse_state,
+        );
+
+        let highlighted_second_line = other_highlighter
+            .highlight_line(lines[1], &ss)
+            .expect("#[cfg(test)]");
+
+        // Check that the second line is highlighted correctly (i.e. as a docstring)
+        // using the first line's previous state
+        assert!(highlighted_second_line.len() == 1);
+        assert!(highlighted_second_line[0].0 == highlighted_first_line[0].0);
     }
 }

--- a/tests/snapshots/public_api__public_api.snap
+++ b/tests/snapshots/public_api__public_api.snap
@@ -30,6 +30,7 @@ pub fn syntect::easy::HighlightLines<'a>::from_state(theme: &'a syntect::highlig
 pub fn syntect::easy::HighlightLines<'a>::highlight<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>
 pub fn syntect::easy::HighlightLines<'a>::highlight_line<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> core::result::Result<alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>, syntect::Error>
 pub fn syntect::easy::HighlightLines<'a>::new(syntax: &syntect::parsing::SyntaxReference, theme: &'a syntect::highlighting::Theme) -> syntect::easy::HighlightLines<'a>
+pub fn syntect::easy::HighlightLines<'a>::state(self) -> (syntect::highlighting::HighlightState, syntect::parsing::ParseState)
 impl<'a> !core::marker::Send for syntect::easy::HighlightLines<'a>
 impl<'a> !core::marker::Sync for syntect::easy::HighlightLines<'a>
 impl<'a> core::marker::Unpin for syntect::easy::HighlightLines<'a>

--- a/tests/snapshots/public_api__public_api.snap
+++ b/tests/snapshots/public_api__public_api.snap
@@ -26,6 +26,7 @@ impl<'a> core::panic::unwind_safe::RefUnwindSafe for syntect::easy::HighlightFil
 impl<'a> core::panic::unwind_safe::UnwindSafe for syntect::easy::HighlightFile<'a>
 pub struct syntect::easy::HighlightLines<'a>
 impl<'a> syntect::easy::HighlightLines<'a>
+pub fn syntect::easy::HighlightLines<'a>::from_state(theme: &'a syntect::highlighting::Theme, highlight_state: syntect::highlighting::HighlightState, parse_state: syntect::parsing::ParseState) -> syntect::easy::HighlightLines<'a>
 pub fn syntect::easy::HighlightLines<'a>::highlight<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>
 pub fn syntect::easy::HighlightLines<'a>::highlight_line<'b>(&mut self, line: &'b str, syntax_set: &syntect::parsing::SyntaxSet) -> core::result::Result<alloc::vec::Vec<(syntect::highlighting::Style, &'b str)>, syntect::Error>
 pub fn syntect::easy::HighlightLines<'a>::new(syntax: &syntect::parsing::SyntaxReference, theme: &'a syntect::highlighting::Theme) -> syntect::easy::HighlightLines<'a>


### PR DESCRIPTION
This PR adds a convenience method to easily be able to reinstantiate a `HighlightLines` object from a previous state the user might have cached.