### PR TITLE
Speed up unittests runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,12 @@ default = ["default-onig"]
 # [profile.release]
 # debug = true
 
+[profile.dev.package]
+aho-corasick.opt-level = 2
+fancy-regex.opt-level = 2
+regex-automata.opt-level = 2
+regex-syntax.opt-level = 2
+
 [lib]
 bench = false
 

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -390,11 +390,12 @@ impl<'a> Highlighter<'a> {
 mod tests {
     use super::*;
     use crate::highlighting::{Color, FontStyle, Style, ThemeSet};
-    use crate::parsing::{ParseState, ScopeStack, SyntaxSet};
+    use crate::parsing::{ParseState, ScopeStack};
+    use crate::utils::testdata;
 
     #[test]
     fn can_parse() {
-        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ps = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
             ParseState::new(syntax)
@@ -433,7 +434,7 @@ mod tests {
 
     #[test]
     fn can_parse_with_highlight_state_from_cache() {
-        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ps = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ps
                 .find_syntax_by_scope(Scope::new("source.python").unwrap())
@@ -606,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_ranges() {
-        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ps = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ps.find_syntax_by_name("Ruby on Rails").unwrap();
             ParseState::new(syntax)

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -743,12 +743,12 @@ mod tests {
     use crate::parsing::ScopeStackOp::{Clear, Pop, Push, Restore};
     use crate::parsing::{Scope, ScopeStack, SyntaxSet, SyntaxSetBuilder};
     use crate::util::debug_print_ops;
+    use crate::utils::testdata;
 
     const TEST_SYNTAX: &str = include_str!("../../testdata/parser_tests.sublime-syntax");
-
     #[test]
     fn can_parse_simple() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ss.find_syntax_by_name("Ruby on Rails").unwrap();
             ParseState::new(syntax)
@@ -784,7 +784,7 @@ mod tests {
 
     #[test]
     fn can_parse_yaml() {
-        let ps = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ps = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ps.find_syntax_by_name("YAML").unwrap();
             ParseState::new(syntax)
@@ -816,7 +816,7 @@ mod tests {
 
     #[test]
     fn can_parse_includes() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ss.find_syntax_by_name("HTML (Rails)").unwrap();
             ParseState::new(syntax)
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn can_parse_backrefs() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ss.find_syntax_by_name("Ruby on Rails").unwrap();
             ParseState::new(syntax)
@@ -900,7 +900,7 @@ mod tests {
 
     #[test]
     fn can_parse_preprocessor_rules() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ss.find_syntax_by_name("C").unwrap();
             ParseState::new(syntax)
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn can_parse_issue25() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let mut state = {
             let syntax = ss.find_syntax_by_name("C").unwrap();
             ParseState::new(syntax)
@@ -993,7 +993,7 @@ mod tests {
 
     #[test]
     fn can_compare_parse_states() {
-        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let ss = &*testdata::PACKAGES_SYN_SET;
         let syntax = ss.find_syntax_by_name("Java").unwrap();
         let mut state1 = ParseState::new(syntax);
         let mut state2 = ParseState::new(syntax);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,3 +9,16 @@ use walkdir::WalkDir;
 pub fn walk_dir<P: AsRef<Path>>(folder: P) -> WalkDir {
     WalkDir::new(folder).follow_links(true)
 }
+
+#[cfg(all(test, feature = "parsing"))]
+pub mod testdata {
+    use std::sync::LazyLock;
+
+    use crate::parsing::SyntaxSet;
+
+    /// The [`SyntaxSet`] loaded from the `testdata/Packages` folder
+    ///
+    /// Shared here to avoid re-doing a particularly costly construction in various tests
+    pub static PACKAGES_SYN_SET: LazyLock<SyntaxSet> =
+        LazyLock::new(|| SyntaxSet::load_from_folder("testdata/Packages").unwrap());
+}


### PR DESCRIPTION
Originally motivated by this comment:

https://github.com/trishume/syntect/blob/7fe13c0fd53cdfa0f9fea1aa14c5ba37f81d8b71/.github/workflows/CI.yml#L90-L91

Two changes

## d0c2431a159a86d4ae1001083b7d4cd7fa1c0c9b | Bump some deps dev `opt-level`

bumps up the `dev` profile opt-level for a few deps that were picked up when looking at a profile of some of the slower tests

## 96b0d19cf331d539434cfb71151f37610c49abb2 | Share testdata/Packages syntax set loading

shares the initialization of tests' various `"testdata/Packages"` syntax sets. This

### a) avoids doing common intensive work

but more importantly

### b) avoids some `SyntaxSet` loading pathological behavior

where loading a syntax set from a folder across N threads locks in way that's akin to sequentially loading the syntax sets from a single thread. Running the tests before this PR generally give that impression since they peg a bit above 1 CPU core for most of the duration even though each unittest runs in a separate thread. I'm assuming this is from different stages of loading syntax sets grabbing a process-wide lock

Here's a profile of said behavior demostrated by plopping the following code in `lib.rs` and running `cargo test --no-default-features --features=default-fancy slow`

https://share.firefox.dev/43NTvYw

```rust
#[cfg(test)]
mod slow {
    use crate::parsing::SyntaxSet;

    #[test]
    fn slow1() {
        SyntaxSet::load_from_folder("testdata/Packages").unwrap();
    }

    #[test]
    fn slow2() {
        SyntaxSet::load_from_folder("testdata/Packages").unwrap();
    }

    #[test]
    fn slow3() {
        SyntaxSet::load_from_folder("testdata/Packages").unwrap();
    }

    #[test]
    fn slow4() {
        SyntaxSet::load_from_folder("testdata/Packages").unwrap();
    }
}
```

You can see the staggered chunks of execution time. It's usually just compiling regexes which is no surprise

![image](https://github.com/user-attachments/assets/5de4ef54-8f40-42b8-ab26-75d9c1254d4e)

---

Anyhoo, here is the improvement when running unittests with the `default-fancy` feature on my laptop

| what | unittest run-time | % change from `master` |
:--: | --: | --: |
| `master` | 258.53s | -0.0% |
| just d0c2431a159a86d4ae1001083b7d4cd7fa1c0c9b | 57.91s | -77.6% |
| both commits | 22.69s | -91.2% |

`release` unittest runtimes drop from 35s to 12s for me as well :rocket: 