### PR TITLE
Turn off GitHub syntax highlighting of `.snap` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,4 @@ testdata/*                              linguist-vendored
 *.png                         binary
 *.tex                                   diff=tex
 *.pdf                         binary    diff=astextplain
+*.snap                                  linguist-language=txt


### PR DESCRIPTION
Workaround for https://github.com/mitsuhiko/insta/issues/780 and the confusing diff in https://github.com/trishume/syntect/pull/585/files#diff-f3d28a949326c02c2b2c85c024a030561f3b2521457621bb2550792460c3a2ec.

Before:
![image](https://github.com/user-attachments/assets/ad2a7f3d-8681-421d-bce4-4f5fb4f2b6cb)

After:
![image](https://github.com/user-attachments/assets/e3093eb4-51fd-48c6-b573-3dd3527a3c63)
