### PR TITLE
deps: switch `serde_json` to an optional dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ flate2 = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 once_cell = "1.8"
 thiserror = "1.0"
 
@@ -44,6 +44,7 @@ rustup-toolchain = "0.1.5"
 rustdoc-json = "0.8.8"
 public-api = "0.33.1"
 insta = "1.42.0"
+serde_json = "1.0"
 
 [features]
 
@@ -58,7 +59,7 @@ regex-onig = ["onig"]
 parsing = ["regex-syntax", "fnv", "dump-create", "dump-load"]
 
 # Support for .tmPreferenes metadata files (indentation, comment syntax, etc)
-metadata = ["parsing", "plist-load"]
+metadata = ["parsing", "plist-load", "dep:serde_json"]
 
 # Enables inclusion of the default syntax packages.
 default-syntaxes = ["parsing", "dump-load"]
@@ -67,7 +68,7 @@ default-themes = ["dump-load"]
 
 html = ["parsing"]
 # Support for parsing .tmTheme files and .tmPreferences files
-plist-load = ["plist"]
+plist-load = ["plist", "dep:serde_json"]
 # Support for parsing .sublime-syntax files
 yaml-load = ["yaml-rust", "parsing"]
 


### PR DESCRIPTION
Moves the `serde_json` dep behind the features where it gets used

```bash
$ rg serde_json::
# behind the metadata feature
src/lib.rs
85:    ParseMetadata(#[from] serde_json::Error),

# behind the plist-load feature
src/highlighting/settings.rs
6:pub use serde_json::Value as Settings;

# behind the metadata feature
src/parsing/metadata.rs
20:type Dict = serde_json::Map<String, Settings>;
180:    match serde_json::from_value::<ShellVars>(vars) {
261:            serde_json::from_value(settings.into()).map_err(|e| format!("{}: {:?}", path, e))?;
438:        Ok(serde_json::from_value(contents)?)

# only used in tests
src/parsing/regex.rs
281:        let pattern: Regex = serde_json::from_str("\"just a string\"").unwrap();
283:        let back_to_str = serde_json::to_string(&pattern).unwrap();
```