### PR TITLE
docs: Enable `metadata` feature on docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ exclude = [
     "/codecov.yml"
 ]
 
+[package.metadata.docs.rs]
+# Toggle on extra features that aren't on by default
+features = ["metadata"]
+
 [dependencies]
 yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.5.1", optional = true, default-features = false }


### PR DESCRIPTION
It looks like `metadata` is the only feature that isn't on by default aside from features used to toggle the regex backend. This ensures that metadata API bits actually have documentation generated