### PR TITLE
.gitattributes: Use `linguist-language=Text` not `...=txt`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,4 +30,4 @@ testdata/*                              linguist-vendored
 *.png                         binary
 *.tex                                   diff=tex
 *.pdf                         binary    diff=astextplain
-*.snap                                  linguist-language=txt
+*.snap                                  linguist-language=Text


### PR DESCRIPTION
`Text` is the [canonical name](https://github.com/github-linguist/linguist/blob/1b43482ac6ab97394a70946cb041f3fa5f3284b5/lib/linguist/languages.yml#L7624) and `txt` currently renders like non-text.