### PR TITLE
ci: check with many different feature sets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,3 +106,17 @@ jobs:
     - name: Docs
       run: |
         cargo doc
+
+  check-feature-powerset:
+    name: Check feature powerset
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack
+    # Ensure that `cargo check` works across many different feature sets
+    - name: Check feature powerset
+      run: |
+        cargo hack --feature-powerset --depth=2 --features=regex-fancy --exclude-features=regex-onig check


### PR DESCRIPTION
Uses the `cargo hack` command mentioned originally in https://github.com/trishume/syntect/pull/587#issuecomment-3034616172 to automatically ensure that `cargo check` works across many of the different feature sets possible with this crate

I opted to add it as a separate job to try and keep things relatively fast

Also worth noting that I used the `taiki-e/install-action` to install `cargo-hack`. taiki-e is the author of `cargo-hack` so trust for one means a good deal of trust in the other I suppose