### PR TITLE
deps: Update thiserror to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "walkdir",
  "yaml-rust",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", optional = true }
 once_cell = "1.8"
-thiserror = "1.0"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = [ "html_reports" ] }


### PR DESCRIPTION
This is a re-up of #566 with the minimal changes required to update `thiserror`