### PR TITLE
deps: Update fancy-regex to v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,18 +60,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -352,12 +352,13 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { version = "0.16.1", optional = true }
+fancy-regex = { version = "0.16.2", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { version = "0.11", optional = true }
+fancy-regex = { version = "0.16.1", optional = true }
 walkdir = "2.0"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.3", optional = true }

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -211,7 +211,9 @@ mod regex_impl {
 
     impl Regex {
         pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error + Send + Sync + 'static>> {
-            let result = fancy_regex::Regex::new(regex_str);
+            let result = fancy_regex::RegexBuilder::new(regex_str)
+                .oniguruma_mode(true)
+                .build();
             match result {
                 Ok(regex) => Ok(Regex { regex }),
                 Err(error) => Err(Box::new(error)),


### PR DESCRIPTION
Updates `fancy-regex` to the latest version. It's not part of the public API, so no breaking change :partying_face:

This change looks like it makes the following `bat` syntaxes compile successfully with `fancy-regex` as the backend (verified by generating `two-face`'s dumps):

- `syntaxes/02_Extra/LiveScript.sublime-syntax`
- `syntaxes/02_Extra/SCSS_Sass/Syntaxes/Sass.sublime-syntax`
- `syntaxes/02_Extra/cmd-help/syntaxes/cmd-help.sublime-syntax`

while the following still fail:

- `syntaxes/02_Extra/Assembly (ARM).sublime-syntax`
- `syntaxes/02_Extra/Elixir/Regular Expressions (Elixir).sublime-syntax`
- `syntaxes/02_Extra/JavaScript (Babel).sublime-syntax`
- `syntaxes/02_Extra/PowerShell.sublime-syntax`
- `syntaxes/02_Extra/SLS/SLS.sublime-syntax`
- `syntaxes/02_Extra/VimHelp.sublime-syntax`