### PR TITLE
Replace unmaintained `yaml-rust` dependency with `yaml-rust2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +423,18 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -574,12 +598,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
@@ -1082,7 +1100,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "walkdir",
- "yaml-rust",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1493,12 +1511,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml-rust2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
- "linked-hash-map",
+ "arraydeque",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 features = ["metadata"]
 
 [dependencies]
-yaml-rust = { version = "0.4.5", optional = true }
+yaml-rust = { package = "yaml-rust2", version = "0.10.4", optional = true, default-features = false }
 onig = { version = "6.5.1", optional = true, default-features = false }
 fancy-regex = { version = "0.11", optional = true }
 walkdir = "2.0"

--- a/tests/snapshots/public-api.txt
+++ b/tests/snapshots/public-api.txt
@@ -892,13 +892,13 @@ impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParseScopeError
 pub syntect::parsing::ParseSyntaxError::BadFileRef
 pub syntect::parsing::ParseSyntaxError::EmptyFile
 pub syntect::parsing::ParseSyntaxError::InvalidScope(syntect::parsing::ParseScopeError)
-pub syntect::parsing::ParseSyntaxError::InvalidYaml(yaml_rust::scanner::ScanError)
+pub syntect::parsing::ParseSyntaxError::InvalidYaml(yaml_rust2::scanner::ScanError)
 pub syntect::parsing::ParseSyntaxError::MainMissing
 pub syntect::parsing::ParseSyntaxError::MissingMandatoryKey(&'static str)
 pub syntect::parsing::ParseSyntaxError::RegexCompileError(alloc::string::String, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>)
 pub syntect::parsing::ParseSyntaxError::TypeMismatch
-impl core::convert::From<yaml_rust::scanner::ScanError> for syntect::parsing::ParseSyntaxError
-pub fn syntect::parsing::ParseSyntaxError::from(source: yaml_rust::scanner::ScanError) -> Self
+impl core::convert::From<yaml_rust2::scanner::ScanError> for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::from(source: yaml_rust2::scanner::ScanError) -> Self
 impl core::error::Error for syntect::parsing::ParseSyntaxError
 pub fn syntect::parsing::ParseSyntaxError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for syntect::parsing::ParseSyntaxError


### PR DESCRIPTION
Replace the unmaintained `yaml-rust` dependency with `yaml-rust2`, as recommended by [RUSTSEC-2024-0320](https://rustsec.org/advisories/RUSTSEC-2024-0320).

Even though the [dependency is renamed in `Cargo.toml`](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml), the public API still changes as can be seen in the updated `tests/snapshots/public-api.txt`.

Supersedes #544 (has merge conflicts) and #555 (fails CI).