### PR TITLE
Prepare for a 5.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## [Version 5.3.0](https://github.com/trishume/syntect/compare/v5.2.0...v5.3.0) (UNRELEASED)
+
+### Improvements
+
+- Add `HighlightLines::from_state()` constructor [#569]
+
+### Fixes
+
+- Ignore UTF-8 BOM on syntax detection [#530]
+- Escape CSS class names [#539]
+- Avoid an infinite loop when a syntax definition continually pushes contexts without consuming any input [#597]
+- Return an error when a syntax definition contains an unescaped trailing backslash instead of panicking at runtime [#548]
+
+### Dependencies
+
+- Replace `bitflags` with a manual implementation [#590]
+- Update `public-api` to work with new lockfile versions [#591]
+- Update `thiserror` to v2 [#594]
+- Update `fancy-regex` to `0.16.2` [#596]
+- Bump `rust_onig` version to avoid build failures on newer GCC versions [#584]
+
+## Docs
+
+- Add various projects to the README showcase:
+  - `BugStalker` [#533]
+  - `Yazi` [#543]
+  - `bingus-blog` [#534]
+  - `CodeSnap.nvim` [#553]
+  - `television` [#571]
+  - `code-to-pdf` [#579]
+  - `Comrak` [#581]
+- Deprecate `syntect::parsing::SCOPE_REPO` for removal [#580]
+
+### Other
+
+- Format with `rustfmt` [#528]
+- Bump nightly toolchain version to fix a test build failure [#542]
+- Remove unused import in yaml load test [#531]
+- Use `BufWriter` to improve unoptimized serialization perf [#554]
+- Commit `Cargo.lock` to avoid flaky CI issues [#567]
+- Switch from `expect-test` to `insta` [#568] then later to `public-api`'s `snapshot-testing` support [#595]
+- Speed up unittest runtime [#577] [#598]
+- Fix new clippy lints [#585]
+- Use `cargo-hack` to check many different features in CI [#593]
+
+[#528]: https://github.com/trishume/syntect/pull/528
+[#530]: https://github.com/trishume/syntect/pull/530
+[#531]: https://github.com/trishume/syntect/pull/531
+[#533]: https://github.com/trishume/syntect/pull/533
+[#534]: https://github.com/trishume/syntect/pull/534
+[#539]: https://github.com/trishume/syntect/pull/539
+[#542]: https://github.com/trishume/syntect/pull/542
+[#543]: https://github.com/trishume/syntect/pull/543
+[#548]: https://github.com/trishume/syntect/pull/548
+[#553]: https://github.com/trishume/syntect/pull/553
+[#554]: https://github.com/trishume/syntect/pull/554
+[#567]: https://github.com/trishume/syntect/pull/567
+[#568]: https://github.com/trishume/syntect/pull/568
+[#569]: https://github.com/trishume/syntect/pull/569
+[#571]: https://github.com/trishume/syntect/pull/571
+[#577]: https://github.com/trishume/syntect/pull/577
+[#579]: https://github.com/trishume/syntect/pull/579
+[#580]: https://github.com/trishume/syntect/pull/580
+[#581]: https://github.com/trishume/syntect/pull/581
+[#584]: https://github.com/trishume/syntect/pull/584
+[#585]: https://github.com/trishume/syntect/pull/585
+[#590]: https://github.com/trishume/syntect/pull/590
+[#591]: https://github.com/trishume/syntect/pull/591
+[#593]: https://github.com/trishume/syntect/pull/593
+[#594]: https://github.com/trishume/syntect/pull/594
+[#595]: https://github.com/trishume/syntect/pull/595
+[#596]: https://github.com/trishume/syntect/pull/596
+[#597]: https://github.com/trishume/syntect/pull/597
+[#598]: https://github.com/trishume/syntect/pull/598
+
 ## [Version 5.2.0](https://github.com/trishume/syntect/compare/v5.1.0...v5.2.0) (2024-02-07)
 
 ### Improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,12 +378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,18 +412,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -599,6 +575,12 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
@@ -1101,7 +1083,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "walkdir",
- "yaml-rust2",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1512,13 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
-name = "yaml-rust2"
-version = "0.10.4"
+name = "yaml-rust"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
- "arraydeque",
- "hashlink",
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 features = ["metadata"]
 
 [dependencies]
-yaml-rust = { package = "yaml-rust2", version = "0.10.4", optional = true, default-features = false }
+yaml-rust = { version = "0.4.5", optional = true }
 onig = { version = "6.5.1", optional = true, default-features = false }
 fancy-regex = { version = "0.16.2", optional = true }
 walkdir = "2.0"

--- a/Readme.md
+++ b/Readme.md
@@ -20,10 +20,10 @@ I consider this project mostly complete, I still maintain it and review PRs, but
 
 ## Getting Started
 
-`syntect` is [available on crates.io](https://crates.io/crates/syntect). You can install it by adding this line to your `Cargo.toml`:
+`syntect` is [available on crates.io](https://crates.io/crates/syntect). You can add it to your `Cargo.toml` with the following command
 
-```toml
-syntect = "5.0"
+```bash
+cargo add syntect
 ```
 
 After that take a look at the [documentation](https://docs.rs/syntect) and the [examples](https://github.com/trishume/syntect/tree/master/examples).

--- a/tests/snapshots/public-api.txt
+++ b/tests/snapshots/public-api.txt
@@ -892,13 +892,13 @@ impl core::panic::unwind_safe::UnwindSafe for syntect::parsing::ParseScopeError
 pub syntect::parsing::ParseSyntaxError::BadFileRef
 pub syntect::parsing::ParseSyntaxError::EmptyFile
 pub syntect::parsing::ParseSyntaxError::InvalidScope(syntect::parsing::ParseScopeError)
-pub syntect::parsing::ParseSyntaxError::InvalidYaml(yaml_rust2::scanner::ScanError)
+pub syntect::parsing::ParseSyntaxError::InvalidYaml(yaml_rust::scanner::ScanError)
 pub syntect::parsing::ParseSyntaxError::MainMissing
 pub syntect::parsing::ParseSyntaxError::MissingMandatoryKey(&'static str)
 pub syntect::parsing::ParseSyntaxError::RegexCompileError(alloc::string::String, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>)
 pub syntect::parsing::ParseSyntaxError::TypeMismatch
-impl core::convert::From<yaml_rust2::scanner::ScanError> for syntect::parsing::ParseSyntaxError
-pub fn syntect::parsing::ParseSyntaxError::from(source: yaml_rust2::scanner::ScanError) -> Self
+impl core::convert::From<yaml_rust::scanner::ScanError> for syntect::parsing::ParseSyntaxError
+pub fn syntect::parsing::ParseSyntaxError::from(source: yaml_rust::scanner::ScanError) -> Self
 impl core::error::Error for syntect::parsing::ParseSyntaxError
 pub fn syntect::parsing::ParseSyntaxError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
 impl core::fmt::Debug for syntect::parsing::ParseSyntaxError


### PR DESCRIPTION
Resolves #599

Updated the changelog with the new changes, tweaked the installation docs on the readme, and reverted the breaking change with `yaml-rust` -> `yaml-rust2` with it being part of the public API

I don't think that there were any changes that would require updating the embedded syntax/theme/metadata assets