### PR TITLE
Add optional support sublime color scheme files via external crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ default-syntaxes = ["parsing", "dump-load"]
 default-themes = ["dump-load"]
 
 # Support for parsing .sublime-color-scheme files
-sublime-color-scheme = ["sublime-color-scheme"]
+sublime-color-scheme = ["dep:sublime-color-scheme"]
 
 html = ["parsing"]
 # Support for parsing .tmTheme files and .tmPreferences files


### PR DESCRIPTION
It's been a while for any movement on issue #244, So I've come here to discuss adding a optional dependency on [`sublime-color-scheme`](https://crates.io/crates/sublime-color-scheme) crate to add the ability to parse `.sublime-color-scheme` files to syntect.

Any feedback is greatly appreciated!

Resolves #244

## Results

I've tested with a couple themes that use the `sublime-color-scheme` file format with great results taken from my [comment](https://github.com/trishume/syntect/issues/244#issuecomment-2696313343) on the issue:

### Kanagawa
![Image](https://github.com/user-attachments/assets/f34925bd-ea3d-4142-84ed-50c7cef9586e)

### Catppuccin
![Image](https://github.com/user-attachments/assets/b95d17f7-63b7-43c4-81e1-4e460ad6f20d)

### Nord
![Image](https://github.com/user-attachments/assets/193c8455-c9db-4612-af9d-d0ffe676d673)

### Monokai
![Image](https://github.com/user-attachments/assets/3173f010-0fbe-4fad-ae37-f67ae39b0ede)

### Gruvbox Material
![Image](https://github.com/user-attachments/assets/ec813c8d-3919-4cbb-8e51-3f57063f69a9)

