### PR TITLE
Add theme accessor to Highlighter

### DIFF
--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -299,6 +299,12 @@ impl<'a> Highlighter<'a> {
         }
     }
 
+    /// Access the highlighter's theme
+    #[inline]
+    pub fn theme(&self) -> &'a Theme {
+        self.theme
+    }
+
     /// The default style in the absence of any matched rules.
     /// Basically what plain text gets highlighted as.
     pub fn get_default(&self) -> Style {


### PR DESCRIPTION
This allows access to the current theme's background/foreground/selection/... colours without storing a second reference to the theme (see [this use case](https://github.com/kas-gui/kas/blob/master/crates/kas-widgets/src/edit/highlight/syntect.rs)).

The disadvantage would be that it locks `Highlighter` into storing a `Theme` reference. I could amend this to return `&Theme` if preferred (a shorter lifetime).