### PR TITLE
Add zsh-patina to list of projects using syntect

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -250,7 +250,7 @@ Below is a list of projects using Syntect, in approximate order by how long they
 - [CodeSnap.nvim](https://github.com/mistricky/codesnap.nvim), snapshot plugin for Neovim, that uses `syntect` for code syntax highlighting.
 - [code-to-pdf](https://github.com/Tommypop2/code-to-pdf), a tool that generates a syntax-highlighted PDF of a directory
 - [Comrak](https://github.com/kivikakk/comrak), a CommonMark parser and formatter that uses `syntect` for highlighting code blocks.
-
+- [zsh-patina](https://github.com/michel-kraemer/zsh-patina), a blazingly fast Zsh syntax highlighter.
 
 ## License and Acknowledgements
 


### PR DESCRIPTION
This pull request adds [zsh-patina](https://github.com/michel-kraemer/zsh-patina) to the list of projects using syntect.

zsh-patina is a Zsh plugin using `syntect` for syntax highlighting of commands while they are being entered.

Thank you so much for your work! Without `syntect`, zsh-patina would not have been possible! 🤗