### PR TITLE
Apply branch alternative's meta_scope to trigger on fail-retry

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1112,20 +1112,27 @@ impl ParseState {
                 let line_ops = if i == 0 {
                     // First buffered line: compose prefix + branch ops + resume.
                     let mut first_line_ops = prefix_ops.clone();
-                    // Re-emit the trigger's pat.scope over [trigger, match_end].
+                    // Re-emit the trigger's pat.scope and the new
+                    // alternative's meta scope ops in the same order
+                    // the non-fail push path uses: clear_scopes and
+                    // meta_scope at `trigger_match_start` (so the
+                    // matched text sees them), then pat.scope at the
+                    // same position, popped at `match_start_pos`.
+                    // meta_content_scope only applies after the
+                    // matched text, so it lands at `match_start_pos`.
+                    if let Some(clear_amount) = context.clear_scopes {
+                        first_line_ops
+                            .push((trigger_match_start, ScopeStackOp::Clear(clear_amount)));
+                    }
+                    for scope in context.meta_scope.iter() {
+                        first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
+                    }
                     for scope in &trigger_pat_scope {
                         first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
                     }
                     if !trigger_pat_scope.is_empty() {
                         first_line_ops
                             .push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
-                    }
-                    // Emit meta scope ops for the new alternative at match_end.
-                    if let Some(clear_amount) = context.clear_scopes {
-                        first_line_ops.push((match_start_pos, ScopeStackOp::Clear(clear_amount)));
-                    }
-                    for scope in context.meta_scope.iter() {
-                        first_line_ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
                     }
                     for scope in context.meta_content_scope.iter() {
                         first_line_ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
@@ -1185,19 +1192,29 @@ impl ParseState {
             // scope whenever alt[0] fails and alt[1..] succeeds,
             // because the original Push/Pop pair was truncated off
             // `ops` together with alt[0]'s subsequent work.
+            //
+            // The new alternative's `clear_scopes` and `meta_scope`
+            // are emitted at `trigger_match_start` *before* the
+            // trigger's `pat.scope`, mirroring the non-fail push path
+            // in `push_meta_ops` (initial phase): meta_scope sits
+            // below the match scope on the stack so the matched text
+            // sees both. Placing them at `match_start_pos` would mean
+            // the trigger character (e.g. `(` of `for (var i = 0; …)`)
+            // never sees the alternative's `meta_scope`. The
+            // `meta_content_scope` legitimately stays at
+            // `match_start_pos` — mcs only applies after the matched
+            // text.
+            if let Some(clear_amount) = context.clear_scopes {
+                ops.push((trigger_match_start, ScopeStackOp::Clear(clear_amount)));
+            }
+            for scope in context.meta_scope.iter() {
+                ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
+            }
             for scope in &trigger_pat_scope {
                 ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
             }
             if !trigger_pat_scope.is_empty() {
                 ops.push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
-            }
-
-            // Emit meta scope ops for the new context at the rewind position.
-            if let Some(clear_amount) = context.clear_scopes {
-                ops.push((match_start_pos, ScopeStackOp::Clear(clear_amount)));
-            }
-            for scope in context.meta_scope.iter() {
-                ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
             }
             for scope in context.meta_content_scope.iter() {
                 ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
@@ -3169,6 +3186,53 @@ contexts:
                     - match: (?=\S)
                       fail: t
                   alt-succeeds:
+                    - match: \S+
+                      scope: ok.test
+                      pop: 1
+                "#,
+        );
+    }
+
+    /// Regression guard for "branch_point fail-retry drops the new
+    /// alternative's `meta_scope` from the trigger character". The
+    /// non-fail push path emits the new context's `meta_scope` at
+    /// `match_start` so the matched text sees it. The same-line
+    /// fail re-emit must do the same — emit `meta_scope` (and any
+    /// `clear_scopes`) at `trigger_match_start`, before the
+    /// trigger's `pat.scope`. Placing them after the match meant
+    /// `for (var i = 0; …)` parsed the `(` with
+    /// `[meta.for.js, punctuation.section.group.begin.js]` instead
+    /// of `[meta.for.js, meta.group.js, punctuation.section.group.begin.js]`,
+    /// failing eight assertions in `syntax_test_js_control.js`.
+    #[test]
+    fn branch_point_fail_retry_applies_meta_scope_to_trigger() {
+        // Mirrors the JS for-loop shape: `\(` triggers a branch with
+        // `pop: 1`; alt 0 fails, alt 1 succeeds; alt 1 has a
+        // `meta_scope` that must wrap the `(` itself.
+        expect_scope_stacks(
+            "(x",
+            &["<meta.group.test>, <punctuation.test>"],
+            r#"
+                name: Branch Meta Scope Test
+                scope: source.test
+                contexts:
+                  main:
+                    - match: ''
+                      push: trigger
+                  trigger:
+                    - match: \(
+                      scope: punctuation.test
+                      branch_point: g
+                      branch:
+                        - alt-fails
+                        - alt-succeeds
+                      pop: 1
+                  alt-fails:
+                    - meta_scope: meta.group.test
+                    - match: (?=\S)
+                      fail: g
+                  alt-succeeds:
+                    - meta_scope: meta.group.test
                     - match: \S+
                       scope: ok.test
                       pop: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -3,12 +3,10 @@ FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
 FAILED testdata/Packages/C#/tests/syntax_test_C#9.cs: 10
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
-FAILED testdata/Packages/D/tests/syntax_test_d.d: 9
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 313
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
-FAILED testdata/Packages/JavaScript/tests/syntax_test_js_control.js: 8
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 274
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.css.erb: 83

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -3,12 +3,10 @@ FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
 FAILED testdata/Packages/C#/tests/syntax_test_C#9.cs: 10
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
-FAILED testdata/Packages/D/tests/syntax_test_d.d: 9
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 313
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
-FAILED testdata/Packages/JavaScript/tests/syntax_test_js_control.js: 8
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 274
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.css.erb: 83


### PR DESCRIPTION
Follow-up to #630 and #636, continuing to chip away at the remaining `syntest` failures tracked in #631.

On a same-line `branch_point` fail-retry, the new alternative's `clear_scopes` and `meta_scope` ops were emitted at `match_start_pos` (after the trigger's match span), so the trigger character never saw them. For JS `for (var i = 0; …)` the `(` parsed with `[meta.for.js, punctuation.section.group.begin.js]` instead of `[meta.for.js, meta.group.js, punctuation.section.group.begin.js]`, losing `meta.group.js` across the entire group.

Mirror the non-fail push path (`push_meta_ops` initial phase): emit `clear_scopes` and `meta_scope` at `trigger_match_start` *before* the trigger's `pat.scope`. `meta_content_scope` legitimately stays at `match_start_pos` — mcs only applies after the matched text.

Impact: D `d.d` 9 → **0**, JS `js_control.js` 8 → **0**, Haskell `haskell.hs` 313 → 271 (both backends).

Captures `branch_point_fail_retry_applies_meta_scope_to_trigger`.

Refs: #631