### PR TITLE
Use engine FIND_NOT_EMPTY flag on scope-only match patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,9 +322,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+version = "0.17.0"
+source = "git+https://github.com/fancy-regex/fancy-regex?branch=find_not_empty#b8cd8fc1f296be10b4cca3c82efd183b747639ed"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust2 = { version = "0.10.4", optional = true, default-features = false }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { version = "0.16.2", optional = true }
+fancy-regex = { git = "https://github.com/fancy-regex/fancy-regex", branch = "find_not_empty", optional = true }
 walkdir = "2.5"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.8", optional = true }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -612,7 +612,7 @@ impl ParseState {
             let mut esc_regions = Region::new();
             if entry
                 .regex
-                .search(line, start, line.len(), Some(&mut esc_regions))
+                .search(line, start, line.len(), Some(&mut esc_regions), true)
             {
                 let (esc_start, _esc_end) = esc_regions.pos(0).unwrap();
                 if esc_start < search_end {
@@ -762,8 +762,12 @@ impl ParseState {
             }
             _ => (match_pat.regex(), true),
         };
+        // Only `MatchOperation::None` patterns must avoid zero-length matches; every other
+        // operation legitimately needs them (lookaheads with branch/fail, empty patterns with
+        // pop/set, etc.). The regex engine handles this via its `FIND_NOT_EMPTY` option.
+        let allow_empty = !matches!(match_pat.operation, MatchOperation::None);
         // print!("  executing regex: {:?} at pos {} on line {}", regex.regex_str(), start, line);
-        let matched = regex.search(line, start, search_end, Some(regions));
+        let matched = regex.search(line, start, search_end, Some(regions), allow_empty);
 
         if matched {
             let (match_start, match_end) = regions.pos(0).unwrap();
@@ -2464,6 +2468,74 @@ contexts:
 
         let line = "foo::bar::* xxx";
         let expect = ["<source.test>, <test.good>"];
+        expect_scope_stacks(line, &expect, syntax);
+    }
+
+    /// Ruby's `?\u{012ACF 0gxs}`: `\h{0,6}` can match zero-width at the
+    /// space. Without the `FIND_NOT_EMPTY` engine option, the zero-width
+    /// match wins and hides the later non-empty match of `0`, which then
+    /// falls through to the `\S` fallback. With the option on
+    /// `MatchOperation::None` patterns, the engine retries past the
+    /// zero-width position and matches `0` as `number.hex`.
+    #[test]
+    fn scope_only_pattern_that_matches_zero_width_finds_later_non_empty() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: \h{0,6}
+      scope: number.hex
+    - match: \S
+      scope: invalid.illegal
+"#;
+
+        let line = "012ACF 0gxs";
+        let expect = [
+            "<source.test>, <number.hex>",      // "012ACF" and "0"
+            "<source.test>, <invalid.illegal>", // "g", "x", "s"
+        ];
+        expect_scope_stacks(line, &expect, syntax);
+    }
+
+    /// Cabal's `\|\||&&||!` operator regex has a stray empty alternative
+    /// between `&&` and `!`. Under leftmost-first matching the empty alt
+    /// wins zero-width at the `!` position. With `FIND_NOT_EMPTY`, the
+    /// engine rejects the empty alt and matches `!` via the real
+    /// alternative.
+    #[test]
+    fn scope_only_pattern_with_middle_empty_alt_matches_bang() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: \|\||&&||!
+      scope: keyword.operator
+"#;
+        let line = "!";
+        let expect = ["<source.test>, <keyword.operator>"];
+        expect_scope_stacks(line, &expect, syntax);
+    }
+
+    /// Rust's `prelude_types: (?x:|Box|Option|…)` puts a `|` before every
+    /// alternative, including the first. Under leftmost-first the leading
+    /// empty alt wins zero-width at every position, so `\b(?x:|Box|Vec)\b`
+    /// never matches `Box` or `Vec`. With `FIND_NOT_EMPTY`, the engine
+    /// rejects the zero-width alt and matches `Vec` via the real
+    /// alternative.
+    #[test]
+    fn scope_only_pattern_with_leading_empty_alt_in_group_matches_name() {
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: \b(?x:|Box|Vec)\b
+      scope: support.type
+"#;
+        let line = "Vec";
+        let expect = ["<source.test>, <support.type>"];
         expect_scope_stacks(line, &expect, syntax);
     }
 

--- a/src/parsing/regex.rs
+++ b/src/parsing/regex.rs
@@ -12,6 +12,16 @@ use std::sync::OnceLock;
 pub struct Regex {
     regex_str: String,
     regex: OnceLock<regex_impl::Regex>,
+    /// Lazily-compiled variant that won't match zero-length strings.
+    /// Used for `MatchOperation::None` patterns, where a zero-width match
+    /// would stall the parser at the same position.
+    ///
+    /// `None` means the pattern can only ever match zero-width, so compiling with
+    /// the engine's `FIND_NOT_EMPTY` option fails (fancy-regex reports
+    /// `PatternCanNeverMatch`). In that case searches return no match, which is
+    /// what the parser wants — a scope-only pattern that can only match
+    /// zero-width would stall.
+    regex_not_empty: OnceLock<Option<regex_impl::Regex>>,
 }
 
 /// A region contains text positions for capture groups in a match result.
@@ -29,6 +39,7 @@ impl Regex {
         Self {
             regex_str,
             regex: OnceLock::new(),
+            regex_not_empty: OnceLock::new(),
         }
     }
 
@@ -53,6 +64,12 @@ impl Regex {
     /// the [`Region`] to be reused between searches, which makes a significant performance
     /// difference.
     ///
+    /// When `allow_empty` is `false`, zero-length matches are rejected by the engine itself.
+    /// Pass `false` for match patterns whose operation does not push, set, pop, or embed a
+    /// context, to prevent the parser from stalling at the same position. Pass `true` in every
+    /// other situation (lookaheads used with branch/fail, empty patterns used with pop/set,
+    /// escape patterns, variable-substitution helpers, etc.).
+    ///
     /// [`Region`]: struct.Region.html
     pub fn search(
         &self,
@@ -60,15 +77,29 @@ impl Regex {
         begin: usize,
         end: usize,
         region: Option<&mut Region>,
+        allow_empty: bool,
     ) -> bool {
-        self.regex()
-            .search(text, begin, end, region.map(|r| &mut r.region))
+        if allow_empty {
+            return self
+                .regex()
+                .search(text, begin, end, region.map(|r| &mut r.region));
+        }
+        match self.regex_not_empty() {
+            Some(regex) => regex.search(text, begin, end, region.map(|r| &mut r.region)),
+            None => false,
+        }
     }
 
     fn regex(&self) -> &regex_impl::Regex {
         self.regex.get_or_init(|| {
             regex_impl::Regex::new(&self.regex_str).expect("regex string should be pre-tested")
         })
+    }
+
+    fn regex_not_empty(&self) -> Option<&regex_impl::Regex> {
+        self.regex_not_empty
+            .get_or_init(|| regex_impl::Regex::new_find_not_empty(&self.regex_str).ok())
+            .as_ref()
     }
 }
 
@@ -77,6 +108,7 @@ impl Clone for Regex {
         Regex {
             regex_str: self.regex_str.clone(),
             regex: OnceLock::new(),
+            regex_not_empty: OnceLock::new(),
         }
     }
 }
@@ -158,6 +190,21 @@ mod regex_impl {
             }
         }
 
+        pub fn new_find_not_empty(
+            regex_str: &str,
+        ) -> Result<Regex, Box<dyn Error + Send + Sync + 'static>> {
+            let result = onig::Regex::with_options(
+                regex_str,
+                RegexOptions::REGEX_OPTION_CAPTURE_GROUP
+                    | RegexOptions::REGEX_OPTION_FIND_NOT_EMPTY,
+                Syntax::default(),
+            );
+            match result {
+                Ok(regex) => Ok(Regex { regex }),
+                Err(error) => Err(Box::new(error)),
+            }
+        }
+
         pub fn is_match(&self, text: &str) -> bool {
             self.regex
                 .match_with_options(text, 0, SearchOptions::SEARCH_OPTION_NONE, None)
@@ -213,6 +260,19 @@ mod regex_impl {
         pub fn new(regex_str: &str) -> Result<Regex, Box<dyn Error + Send + Sync + 'static>> {
             let result = fancy_regex::RegexBuilder::new(regex_str)
                 .oniguruma_mode(true)
+                .build();
+            match result {
+                Ok(regex) => Ok(Regex { regex }),
+                Err(error) => Err(Box::new(error)),
+            }
+        }
+
+        pub fn new_find_not_empty(
+            regex_str: &str,
+        ) -> Result<Regex, Box<dyn Error + Send + Sync + 'static>> {
+            let result = fancy_regex::RegexBuilder::new(regex_str)
+                .oniguruma_mode(true)
+                .find_not_empty(true)
                 .build();
             match result {
                 Ok(regex) => Ok(Regex { regex }),

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -431,7 +431,7 @@ mod tests {
         let r = Regex::new(r"(\\\[\]\(\))(b)(c)(d)(e)".into());
         let s = r"\[]()bcde";
         let mut region = Region::new();
-        let matched = r.search(s, 0, s.len(), Some(&mut region));
+        let matched = r.search(s, 0, s.len(), Some(&mut region), true);
         assert!(matched);
 
         let regex_with_refs = pat.regex_with_refs(&region, s);

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -243,7 +243,7 @@ impl SyntaxSet {
         let s = s.strip_prefix("\u{feff}").unwrap_or(s); // Strip UTF-8 BOM
         let cache = self.first_line_cache();
         for &(ref reg, i) in cache.regexes.iter().rev() {
-            if reg.search(s, 0, s.len(), None) {
+            if reg.search(s, 0, s.len(), None, true) {
                 return Some(&self.syntaxes[i]);
             }
         }

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -370,7 +370,7 @@ impl SyntaxDefinition {
             // Thanks @wbond for letting me know this is the correct way to check for captures
             has_captures = state
                 .backref_regex
-                .search(&regex_str, 0, regex_str.len(), None);
+                .search(&regex_str, 0, regex_str.len(), None, true);
             // In Sublime Text, `pop: N` + `embed:` pops N contexts then pushes
             // the embedded syntax with escape priority.
             if get_key(map, "embed", Some).is_ok() {
@@ -451,7 +451,7 @@ impl SyntaxDefinition {
         let escape_has_captures =
             state
                 .backref_regex
-                .search(&escape_regex_str, 0, escape_regex_str.len(), None);
+                .search(&escape_regex_str, 0, escape_regex_str.len(), None, true);
 
         let escape_captures = if let Ok(cap_map) = get_key(map, "escape_captures", |x| x.as_hash())
         {
@@ -566,10 +566,13 @@ impl SyntaxDefinition {
         let mut result = String::new();
         let mut index = 0;
         let mut region = Region::new();
-        while state
-            .variable_regex
-            .search(raw_regex, index, raw_regex.len(), Some(&mut region))
-        {
+        while state.variable_regex.search(
+            raw_regex,
+            index,
+            raw_regex.len(),
+            Some(&mut region),
+            true,
+        ) {
             let (begin, end) = region.pos(0).unwrap();
 
             result.push_str(&raw_regex[index..begin]);
@@ -727,7 +730,7 @@ fn re_resolve_variables(raw_regex: &str, state: &ReResolveState<'_>) -> String {
     let mut region = Region::new();
     while state
         .variable_regex
-        .search(raw_regex, index, raw_regex.len(), Some(&mut region))
+        .search(raw_regex, index, raw_regex.len(), Some(&mut region), true)
     {
         let (begin, end) = region.pos(0).unwrap();
         result.push_str(&raw_regex[index..begin]);

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -5,7 +5,6 @@ FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/D/tests/syntax_test_d.d: 9
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_cabal.cabal: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 313
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
@@ -17,13 +16,5 @@ FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 94
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 273
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.js.erb: 37
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.sql.erb: 8
-FAILED testdata/Packages/Ruby/syntax_test_ruby.rb: 1
-FAILED testdata/Packages/Rust/tests/syntax_test_closures.rs: 6
-FAILED testdata/Packages/Rust/tests/syntax_test_enum.rs: 6
-FAILED testdata/Packages/Rust/tests/syntax_test_generics.rs: 12
-FAILED testdata/Packages/Rust/tests/syntax_test_identifiers.rs: 1
-FAILED testdata/Packages/Rust/tests/syntax_test_macros.rs: 3
-FAILED testdata/Packages/Rust/tests/syntax_test_struct.rs: 3
-FAILED testdata/Packages/Rust/tests/syntax_test_types.rs: 15
 FAILED testdata/Packages/SQL/tests/syntax/syntax_test_tsql.sql: 4918
 exiting with code 2

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -5,7 +5,6 @@ FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/D/tests/syntax_test_d.d: 9
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_cabal.cabal: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 313
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
@@ -16,13 +15,5 @@ FAILED testdata/Packages/Rails/tests/syntax_test_rails.css.erb: 83
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 273
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.js.erb: 37
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.sql.erb: 8
-FAILED testdata/Packages/Ruby/syntax_test_ruby.rb: 1
-FAILED testdata/Packages/Rust/tests/syntax_test_closures.rs: 6
-FAILED testdata/Packages/Rust/tests/syntax_test_enum.rs: 6
-FAILED testdata/Packages/Rust/tests/syntax_test_generics.rs: 12
-FAILED testdata/Packages/Rust/tests/syntax_test_identifiers.rs: 1
-FAILED testdata/Packages/Rust/tests/syntax_test_macros.rs: 3
-FAILED testdata/Packages/Rust/tests/syntax_test_struct.rs: 3
-FAILED testdata/Packages/Rust/tests/syntax_test_types.rs: 15
 FAILED testdata/Packages/SQL/tests/syntax/syntax_test_tsql.sql: 4918
 exiting with code 2

--- a/tests/snapshots/public-api.txt
+++ b/tests/snapshots/public-api.txt
@@ -1072,7 +1072,7 @@ impl syntect::parsing::Regex
 pub fn syntect::parsing::Regex::is_match(&self, text: &str) -> bool
 pub fn syntect::parsing::Regex::new(regex_str: alloc::string::String) -> Self
 pub fn syntect::parsing::Regex::regex_str(&self) -> &str
-pub fn syntect::parsing::Regex::search(&self, text: &str, begin: usize, end: usize, region: core::option::Option<&mut syntect::parsing::Region>) -> bool
+pub fn syntect::parsing::Regex::search(&self, text: &str, begin: usize, end: usize, region: core::option::Option<&mut syntect::parsing::Region>, allow_empty: bool) -> bool
 pub fn syntect::parsing::Regex::try_compile(regex_str: &str) -> core::option::Option<alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>>
 impl core::clone::Clone for syntect::parsing::Regex
 pub fn syntect::parsing::Regex::clone(&self) -> Self


### PR DESCRIPTION
Follow-up to #630 chipping away at the remaining `syntest` failures tracked in #631. Supersedes #624, #632, #633, and #634 per https://github.com/trishume/syntect/pull/634#issuecomment-4246441608.

## Approach

Scope-only (`MatchOperation::None`) match patterns can silently stall the parser when the regex matches zero-width at the current position. Instead of working around this with regex preprocessing (#632, #633) or a retry loop (#634), push the constraint down to the regex engine itself: compile a second variant of each regex with `FIND_NOT_EMPTY` and use it only for `None`-operation matches. Every other operation (`Push`, `Set`, `Pop`, `Embed`, `Branch`, `Fail`) legitimately needs zero-width matches and continues to use the regular variant.

- **Oniguruma**: native `REGEX_OPTION_FIND_NOT_EMPTY`.
- **fancy-regex**: `RegexBuilder::find_not_empty(true)`, from fancy-regex/fancy-regex#240.

Cargo.toml points the `fancy-regex` dep at that PR's `find_not_empty` branch temporarily (`b8cd8fc1`). Once #240 lands and is released, a follow-up flips it back to a published version.

## Public API

`Regex::search` gains an `allow_empty: bool` parameter. Acceptable for the 6.0.0 milestone.

## Impact

Both backends now produce identical results on the affected files:

| File | Before | After |
|---|---:|---:|
| `Haskell/tests/syntax_test_cabal.cabal` | 1 | **0** |
| `Ruby/syntax_test_ruby.rb` | 1 | **0** |
| `Rust/tests/syntax_test_closures.rs` | 6 | **0** |
| `Rust/tests/syntax_test_enum.rs` | 6 | **0** |
| `Rust/tests/syntax_test_generics.rs` | 12 | **0** |
| `Rust/tests/syntax_test_identifiers.rs` | 1 | **0** |
| `Rust/tests/syntax_test_macros.rs` | 3 | **0** |
| `Rust/tests/syntax_test_struct.rs` | 3 | **0** |
| `Rust/tests/syntax_test_types.rs` | 15 | **0** |

48 assertion failures closed on both Oniguruma and fancy-regex.

## Tests

Three regression tests:

- `scope_only_pattern_that_matches_zero_width_finds_later_non_empty` — Ruby `\h{0,6}` at space hiding later `0`.
- `scope_only_pattern_with_leading_empty_alt_in_group_matches_name` — Rust `(?x:|Box|Vec)`.
- `scope_only_pattern_with_middle_empty_alt_matches_bang` — Cabal `\|\||&&||!`.

All three pass on both backends.

## Merge order

Draft until fancy-regex/fancy-regex#240 merges and is released. Then the Cargo.toml dep gets flipped back to a published version in a follow-up.

Refs: #631