### PR TITLE
Syntest visibility and v2 clear_scopes parity

### DIFF
--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -36,15 +36,45 @@ pub enum SyntaxTestHeaderError {
 pub enum SyntaxTestFileResult {
     FailedAssertions(usize, usize),
     Success(usize),
+    /// File declares a non-scope Sublime test variant (reindent,
+    /// reindent-unchanged, partial-symbols, …) — captured as the
+    /// modifier between `SYNTAX TEST` and the quoted syntax file.
+    /// syntect doesn't implement those test kinds, so the file is
+    /// skipped without contributing to failures or exit status.
+    Skipped(String),
 }
 
+// The header-line shape Sublime Text accepts is:
+//   <testtoken_start> SYNTAX TEST [<modifier>] "<syntax_file>" [<testtoken_end> [<free-form tail>]]
+//
+// * `testtoken_start` is the line's comment marker (e.g. `//`, `#`,
+//   `/*`, `<!--`, `T:` for MultiMarkdown). Matched lazily so
+//   zero-whitespace separators like `T:SYNTAX TEST …` work; without
+//   laziness a greedy `\S+` would swallow `T:SYNTAX` and never find
+//   the literal `SYNTAX`.
+// * Optional `modifier` (`reindent`, `reindent-unchanged`,
+//   `partial-symbols`, future variants) sits between `SYNTAX TEST`
+//   and the quoted path. Capturing is unrestricted — any non-quote
+//   non-whitespace token counts — so we don't need to track
+//   Sublime's evolving modifier list here. A present modifier is
+//   the signal that the file is not a scope test (see
+//   `SyntaxTestFileResult::Skipped`).
+// * `testtoken_end` is the matching closing comment marker for
+//   block-comment syntaxes (`*/`, `-->`, `%>`, `}}`, …). Restricted
+//   to punctuation-only so alphabetic tails like `dotnet` in
+//   `#! SYNTAX TEST "…" dotnet run` don't get mis-captured.
+// * The trailing `(?:\s.*)?$` absorbs whatever follows the (optional)
+//   testtoken_end — shebang-style instructions like `dotnet run`
+//   go here and are ignored.
 pub static SYNTAX_TEST_HEADER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
         r#"(?xm)
-        ^(?P<testtoken_start>\s*\S+)
-        \s+SYNTAX\sTEST\s+
+        ^(?P<testtoken_start>\s*\S+?)
+        \s*SYNTAX\sTEST\s+
+        (?:(?P<modifier>[^\s"]+)\s+)?
         "(?P<syntax_file>[^"]+)"
-        \s*(?P<testtoken_end>\S+)?$
+        (?:\s+(?P<testtoken_end>[^\s\w]+))?
+        (?:\s.*)?$
     "#,
     )
     .unwrap()
@@ -312,6 +342,14 @@ fn test_file(
     let testtoken_start = captures.name("testtoken_start").unwrap().as_str();
     let testtoken_end = captures.name("testtoken_end").map(|c| c.as_str());
     let syntax_file = captures.name("syntax_file").unwrap().as_str();
+
+    // Non-scope Sublime test variants (reindent, reindent-unchanged,
+    // partial-symbols, …) carry a modifier between `SYNTAX TEST` and
+    // the quoted syntax file. syntect doesn't implement those kinds
+    // of tests, so bow out before touching the parser.
+    if let Some(modifier) = captures.name("modifier").map(|c| c.as_str()) {
+        return Ok(SyntaxTestFileResult::Skipped(modifier.to_owned()));
+    }
 
     // find the relevant syntax definition to parse the file with - case is important!
     if !out_opts.summary {
@@ -609,25 +647,43 @@ fn test_file(
     // Flush any remaining buffered messages at EOF — parsing is done
     flush_pending_messages(&mut pending_messages, out_opts.summary);
 
-    let res = if assertion_failures > 0 {
+    if assertion_failures > 0 {
         Ok(SyntaxTestFileResult::FailedAssertions(
             assertion_failures,
             total_assertions,
         ))
     } else {
         Ok(SyntaxTestFileResult::Success(total_assertions))
-    };
+    }
+}
 
+fn report_file_result(
+    path: &Path,
+    result: &Result<SyntaxTestFileResult, SyntaxTestHeaderError>,
+    out_opts: OutputOptions,
+) {
     if out_opts.summary {
-        if let Ok(SyntaxTestFileResult::FailedAssertions(failures, _)) = res {
-            // Don't print total assertion count so that diffs don't pick up new succeeding tests
-            println!("FAILED {}: {}", path.display(), failures);
+        // Don't print total assertion count so that diffs don't pick up new succeeding tests
+        match result {
+            Ok(SyntaxTestFileResult::FailedAssertions(failures, _)) => {
+                println!("FAILED {}: {}", path.display(), failures);
+            }
+            Err(SyntaxTestHeaderError::MalformedHeader) => {
+                println!("FAILED {}: malformed header", path.display());
+            }
+            Err(SyntaxTestHeaderError::SyntaxDefinitionNotFound) => {
+                println!("FAILED {}: syntax definition not found", path.display());
+            }
+            // Skipped files (non-scope variants like reindent /
+            // partial-symbols) don't contribute to the baseline:
+            // silent in summary mode so `known_syntest_failures.txt`
+            // stays focused on actual scope-test failures.
+            Ok(SyntaxTestFileResult::Skipped(_)) => {}
+            Ok(SyntaxTestFileResult::Success(_)) => {}
         }
     } else {
-        println!("{:?}", res);
+        println!("{:?}", result);
     }
-
-    res
 }
 
 fn main() {
@@ -721,6 +777,7 @@ fn recursive_walk(ss: &SyntaxSet, path: &str, out_opts: OutputOptions) -> i32 {
             eprintln!("PANIC while testing {}", path.display());
             Ok(SyntaxTestFileResult::FailedAssertions(1, 1))
         });
+        report_file_result(path, &result, out_opts);
         let elapsed = start.elapsed();
         if out_opts.time {
             let ms = (elapsed.as_secs() * 1_000) + elapsed.subsec_millis() as u64;

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1356,7 +1356,16 @@ impl ParseState {
                     // Each deeper context's scopes are popped in
                     // top-to-bottom order: meta_content_scope first
                     // (pushed after its own meta_scope, hence above on
-                    // the stack), then meta_scope.
+                    // the stack), then meta_scope, then any Restore
+                    // paired with that context's own `clear_scopes`
+                    // (mirrors the push order Clear → meta_scope → mcs
+                    // in reverse). Without the Restore, a `pop: N`
+                    // from the top that also unwinds a deeper context
+                    // with `clear_scopes` leaves the originally cleared
+                    // atoms orphaned — observed on Python f/t-string
+                    // interpolation close, where `f-string-replacement-end`
+                    // fires `pop: 2` that also pops
+                    // `f-string-replacement-meta`.
                     for depth in 1..pop_count {
                         let level_idx = stack_len - 1 - depth;
                         let ctx = syntax_set.get_context(&self.stack[level_idx].context)?;
@@ -1371,6 +1380,9 @@ impl ParseState {
                         }
                         if !ctx.meta_scope.is_empty() {
                             ops.push((index, ScopeStackOp::Pop(ctx.meta_scope.len())));
+                        }
+                        if ctx.clear_scopes.is_some() {
+                            ops.push((index, ScopeStackOp::Restore));
                         }
                     }
                 }
@@ -1405,9 +1417,16 @@ impl ParseState {
                     // `meta.mapping.value.json` atoms in nested JSON objects.
                     // add each context's meta scope
                     if version >= 2 {
-                        // v2: For push with multiple contexts, only apply
-                        // clear_scopes from the last (topmost) context, not
-                        // sum all of them.
+                        // Push: emit Clear for every pushed context that has
+                        // `clear_scopes`, at its own index position in the
+                        // push order — same as v1. Sublime permits at most
+                        // one `clear_scopes` per push list, but when it sits
+                        // on a non-topmost entry (e.g. Python's
+                        // `f-string-replacement-meta` at index 0 of a
+                        // 3-context push) restricting to `i == last_idx`
+                        // silently drops it, leaking the parent's
+                        // `meta_content_scope` atoms into interpolation
+                        // content.
                         //
                         // Single-context `set:` with clear_scopes on the
                         // target: emit Clear here — before target.meta_scope
@@ -1430,13 +1449,11 @@ impl ParseState {
                         // eat-whitespace-then-pop]` relies on Clear eating
                         // the last-pushed mcs atom, which Restore then
                         // replaces when eat-whitespace-then-pop pops.
-                        let last_idx = context_refs.len().saturating_sub(1);
                         let single_context_set_clear = is_set && context_refs.len() == 1;
-                        for (i, r) in context_refs.iter().enumerate() {
+                        for r in context_refs.iter() {
                             let ctx = r.resolve(syntax_set)?;
 
-                            let emit_clear_here =
-                                (!is_set && i == last_idx) || single_context_set_clear;
+                            let emit_clear_here = !is_set || single_context_set_clear;
                             if emit_clear_here {
                                 if let Some(clear_amount) = ctx.clear_scopes {
                                     ops.push((index, ScopeStackOp::Clear(clear_amount)));

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1538,13 +1538,22 @@ impl ParseState {
                             // the cleared stack); re-emitting here would
                             // double-push onto clear_stack and cause Pop
                             // underflow when the context unwinds.
-                            let last_idx = context_refs.len().saturating_sub(1);
+                            //
+                            // Clear is emitted per-context (not only for the
+                            // topmost) because `clear_scopes` on a non-topmost
+                            // context is a real pattern: Bash's
+                            // `set: [def-function-body, def-function-params,
+                            // def-function-name]` has `clear_scopes: 1` on
+                            // def-function-params (middle). Each Clear is
+                            // placed just before that context's own mcs/ms
+                            // pushes so it strips the previous iteration's
+                            // last-pushed atom, matching Sublime's semantics.
                             let single_context_set_clear = is_set && context_refs.len() == 1;
                             let mut prev_embed_scope_replaces = false;
-                            for (i, r) in context_refs.iter().enumerate() {
+                            for r in context_refs.iter() {
                                 let ctx = r.resolve(syntax_set)?;
 
-                                if is_set && i == last_idx && !single_context_set_clear {
+                                if is_set && !single_context_set_clear {
                                     if let Some(clear_amount) = ctx.clear_scopes {
                                         ops.push((index, ScopeStackOp::Clear(clear_amount)));
                                     }
@@ -5180,67 +5189,74 @@ contexts:
     }
 
     #[test]
-    fn v2_set_clear_scopes_only_from_last_context() {
-        // Kills: L1029 replace && with || / == with != in push_meta_ops
-        // In v2, clear_scopes during a set should only apply from the last
-        // context, and only when `is_set` is true AND `i == last_idx`.
+    fn v2_set_clear_scopes_applies_from_every_context() {
+        // v2: when `set:` lists multiple contexts, `clear_scopes` on any of
+        // them — not just the topmost — applies at that context's own
+        // position in the stack. The canonical real-world case is Bash's
+        //   set: [def-function-body, def-function-params, def-function-name]
+        // where `def-function-params` (the middle context) carries
+        // `clear_scopes: 1`. The Clear strips the atom that the preceding
+        // context's meta_content_scope just pushed, matching Sublime
+        // Text's observed behaviour. Previously this test guessed
+        // Sublime pinned Clear to the topmost context only; running real
+        // v2 syntaxes (Bash function definitions, among others) refuted
+        // that guess.
         let syntax_str = r#"
-name: V2ClearLast
+name: V2ClearMid
 scope: source.v2clear
 version: 2
 contexts:
   main:
     - meta_scope: meta.main.v2clear
     - match: 'GO'
-      set: [ctx-b, ctx-a]
-  ctx-a:
-    - meta_scope: meta.a.v2clear
+      set: [ctx-bottom, ctx-middle, ctx-top]
+  ctx-bottom:
+    - meta_content_scope: mcs.bottom.v2clear
+  ctx-middle:
+    - clear_scopes: 1
+    - meta_content_scope: mcs.middle.v2clear
+  ctx-top:
+    - meta_content_scope: mcs.top.v2clear
     - match: '\w+'
-      scope: word.a.v2clear
-  ctx-b:
-    - clear_scopes: true
-    - meta_scope: meta.b.v2clear
-    - match: '\w+'
-      scope: word.b.v2clear
+      scope: word.top.v2clear
       pop: true
 "#;
         let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
         let ss = link(syntax);
         let mut state = ParseState::new(&ss.syntaxes()[0]);
         let raw_ops = ops(&mut state, "GO hello\n", &ss);
-
-        // ctx-a is last in the set stack (top of stack), and it has no
-        // clear_scopes.  ctx-b has clear_scopes but is NOT the last context
-        // in v2.  If the condition is inverted (|| instead of &&), clear_scopes
-        // would incorrectly apply from ctx-b.
         let states = stack_states(raw_ops);
-        // "hello" matches in ctx-a (top of stack), which should have meta.a
+
+        // "hello" matches in ctx-top. At that point ctx-middle's
+        // clear_scopes: 1 must have stripped ctx-bottom's
+        // meta_content_scope atom.
         let hello_states: Vec<_> = states
             .iter()
-            .filter(|s| s.contains("word.a.v2clear"))
+            .filter(|s| s.contains("word.top.v2clear"))
             .collect();
         assert!(
             !hello_states.is_empty(),
-            "expected word.a.v2clear, got states: {:?}",
+            "expected word.top.v2clear, got states: {:?}",
             states
         );
-        // meta.a should be present (not cleared), since ctx-a is top and has
-        // no clear_scopes of its own
-        assert!(
-            hello_states.iter().any(|s| s.contains("meta.a.v2clear")),
-            "meta.a should be present since ctx-a (last) has no clear_scopes: {:?}",
-            hello_states
-        );
-        // source.v2clear must also be present — if clear_scopes from ctx-b
-        // fires incorrectly (mutations on L1029: && → || or == → !=), the
-        // root scope would be cleared.
-        assert!(
-            hello_states
-                .iter()
-                .any(|s| s.contains("source.v2clear")),
-            "source.v2clear should not be cleared (clear_scopes should only apply from last context): {:?}",
-            hello_states
-        );
+        for s in &hello_states {
+            assert!(
+                !s.contains("mcs.bottom.v2clear"),
+                "ctx-bottom's mcs should have been cleared by ctx-middle's \
+                 clear_scopes: 1 before ctx-top's match, got: {:?}",
+                s
+            );
+            assert!(
+                s.contains("mcs.middle.v2clear"),
+                "ctx-middle's mcs should be on the stack during ctx-top's match, \
+                 got: {:?}",
+                s
+            );
+        }
+
+        // Reaching this point without a panic proves the Restore emitted on
+        // ctx-middle's pop didn't underflow the clear_stack — the
+        // regression the Bash `func () {}` minimal reproducer uncovered.
     }
 
     #[test]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1757,12 +1757,18 @@ impl ParseState {
             let level = &self.stack[self.stack.len() - 1];
             let ctx = syntax_set.get_context(&level.context)?;
 
-            // Pop meta_content_scope
+            // Pop meta_content_scope.  If the context below has
+            // embed_scope_replaces (it's a v2 embed_scope wrapper), the top
+            // context is the embedded syntax's main — whose mcs was never
+            // pushed on the way in — so skip the pop here too.  Gating this
+            // on `current_syntax_version >= 2` would be wrong: the version
+            // is read from the top context (the embedded syntax), but
+            // embed_scope_replaces is set only by the v2 host syntax.  A v2
+            // host embedding a v1 grammar (e.g. Rails HTML embedding Ruby)
+            // would otherwise Pop a scope that was never pushed, misaligning
+            // every scope below until the escape closes.
             if !ctx.meta_content_scope.is_empty() {
-                // v2: check if context below has embed_scope_replaces
-                let version = self.current_syntax_version(syntax_set);
-                let skip = version >= 2
-                    && self.stack.len() >= 2
+                let skip = self.stack.len() >= 2
                     && syntax_set
                         .get_context(&self.stack[self.stack.len() - 2].context)
                         .map(|c| c.embed_scope_replaces)
@@ -5311,6 +5317,95 @@ contexts:
         assert!(
             final_scopes.iter().any(|s| s.contains("source.v2skip")),
             "source.v2skip should remain on stack after all ops, got: {:?}",
+            final_scopes
+        );
+    }
+
+    #[test]
+    fn v2_host_embedding_v1_guest_skips_meta_content_pop_on_escape() {
+        // Regression for the Rails html.erb syntest cluster: when a v2 host
+        // uses `embed:` + `embed_scope:` to pull in a v1 guest grammar (e.g.
+        // Rails/HTML embedding Ruby), `embed_scope_replaces` is set on the
+        // wrapper context. On escape, the embedded guest's meta_content_scope
+        // must be skipped — it was never pushed on the way in.
+        //
+        // The exec_escape skip logic was gated on
+        // `current_syntax_version() >= 2`, which reads the version from the
+        // top-of-stack context. That is the *guest* (Ruby, v1), not the host,
+        // so the gate evaluated false and a spurious Pop fired for a scope
+        // that was never pushed, misaligning every scope on the stack for
+        // the remainder of the host context.
+        use crate::parsing::ScopeStack;
+
+        let host = SyntaxDefinition::load_from_str(
+            r#"
+name: V2HostV1Guest
+scope: source.v2host
+file_extensions: [v2host]
+version: 2
+contexts:
+  main:
+    - match: '<<'
+      embed: scope:source.v1guest
+      embed_scope: meta.embedded.v2host
+      escape: '>>'
+      escape_captures:
+        0: punctuation.end.v2host
+    - match: '\w+'
+      scope: word.v2host
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        // Guest omits `version:` — defaults to 1. Its `scope:` lands in the
+        // main context's meta_content_scope (source.v1guest), which the
+        // v2 embed_scope_replaces suppresses on push. The escape must
+        // symmetrically suppress it on pop.
+        let guest = SyntaxDefinition::load_from_str(
+            r#"
+name: V1Guest
+scope: source.v1guest
+file_extensions: [v1guest]
+contexts:
+  main:
+    - match: '\w+'
+      scope: keyword.v1guest
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(host);
+        builder.add(guest);
+        let ss = builder.build();
+
+        let syntax = ss.find_syntax_by_name("V2HostV1Guest").unwrap();
+        let mut state = ParseState::new(syntax);
+        let raw_ops = state.parse_line("<<x>> hello\n", &ss).unwrap().ops;
+
+        // Before the fix, the escape emits a Pop for guest main's mcs even
+        // though it was never pushed. Subsequent Pops then strip scopes
+        // that should have survived. Applying the op stream must not fail,
+        // and source.v2host must remain on the stack at the end.
+        let mut scope_stack = ScopeStack::new();
+        for (_, op) in &raw_ops {
+            scope_stack.apply(op).expect(
+                "applying op stream must succeed — a spurious Pop indicates the skip was gated \
+                 on the guest's syntax version instead of the embed_scope_replaces flag",
+            );
+        }
+        let final_scopes: Vec<String> = scope_stack
+            .as_slice()
+            .iter()
+            .map(|s| format!("{:?}", s))
+            .collect();
+        assert!(
+            final_scopes.iter().any(|s| s.contains("source.v2host")),
+            "source.v2host should remain after escape; got: {:?}",
             final_scopes
         );
     }

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -2921,9 +2921,12 @@ mod tests {
     }
 
     #[test]
-    fn v2_push_multiple_clear_scopes_only_last_applies() {
-        // Per Sublime docs (v2): when pushing multiple contexts, only the last (topmost) context's
-        // clear_scopes is applied. In v1, each context's clear_scopes is applied individually.
+    fn v2_push_multiple_clear_scopes_each_applies() {
+        // v2 push emits `Clear` for every pushed context that has
+        // `clear_scopes`, at that context's index position in the push
+        // order — same as v1. Python's f/t-string interpolation relies on
+        // this: `clear_scopes: 1` sits on `f-string-replacement-meta` at
+        // index 0 of a 3-context push, not on the topmost entry.
         use crate::parsing::ParseState;
 
         let v2_syntax = SyntaxDefinition::load_from_str(
@@ -2963,26 +2966,20 @@ mod tests {
         let mut state = ParseState::new(syntax);
         let ops = state.parse_line("go\n", &ss).unwrap().ops;
 
-        // Count Clear ops in the result
         let clear_ops: Vec<_> = ops
             .iter()
-            .filter(|(_, op)| matches!(op, ScopeStackOp::Clear(_)))
+            .filter_map(|(_, op)| match op {
+                ScopeStackOp::Clear(a) => Some(*a),
+                _ => None,
+            })
             .collect();
 
-        // v2: only ctx_b's clear_scopes (TopN(2)) should apply — exactly ONE Clear op
+        // Both ctx_a (TopN(1)) and ctx_b (TopN(2)) apply, in push order.
         assert_eq!(
-            clear_ops.len(),
-            1,
-            "v2: push [ctx_a, ctx_b] should produce exactly ONE Clear op (from ctx_b only); \
-             got: {:?}",
+            clear_ops,
+            vec![ClearAmount::TopN(1), ClearAmount::TopN(2)],
+            "v2: push [ctx_a(1), ctx_b(2)] should emit Clear(1) then Clear(2); got: {:?}",
             clear_ops
-        );
-
-        // That one Clear should be from ctx_b (TopN(2)), not ctx_a (TopN(1))
-        assert!(
-            matches!(clear_ops[0].1, ScopeStackOp::Clear(ClearAmount::TopN(2))),
-            "v2: the single Clear should be TopN(2) from ctx_b; got: {:?}",
-            clear_ops[0].1
         );
 
         // v1: both ctx_a and ctx_b apply their clear_scopes — two Clear ops
@@ -3034,6 +3031,121 @@ mod tests {
             "v1: push [ctx_a, ctx_b] should produce TWO Clear ops (one per context); \
              got: {:?}",
             v1_clear_ops
+        );
+    }
+
+    #[test]
+    fn v2_push_deeper_clear_scopes_applies_and_restores() {
+        // Pins the invariant Python f/t-string interpolation relies on:
+        // a multi-context push where a non-topmost entry carries
+        // `clear_scopes`. The Clear must fire when that entry is pushed,
+        // and a paired Restore must fire when it is popped — even when the
+        // pop reaches it via `pop: N` from a shallower context.
+        //
+        // Shape:
+        //   main mcs = "m.outer string.outer"
+        //   push  = [wrap(clear_scopes: 1, meta_scope: m.wrap), body]
+        //   body  = matches 'x' with `pop: 2` (unwinds body + wrap together,
+        //           exercising the deeper-context Restore path).
+        use crate::parsing::{ParseState, ScopeStack};
+
+        let syntax = SyntaxDefinition::load_from_str(
+            r#"
+            name: V2DeeperClear
+            scope: source.deeperclear
+            file_extensions: [v2dc]
+            version: 2
+            contexts:
+              main:
+                - meta_content_scope: m.outer string.outer
+                - match: 'go'
+                  push:
+                    - wrap
+                    - body
+              wrap:
+                - clear_scopes: 1
+                - meta_scope: m.wrap
+                - include: immediately-pop
+              immediately-pop:
+                - match: ''
+                  pop: 1
+              body:
+                - match: 'x'
+                  scope: word.x
+                  pop: 2
+            "#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(syntax);
+        let ss = builder.build();
+        let sref = ss.find_syntax_by_name("V2DeeperClear").unwrap();
+
+        // Scope stack at each position through "go x y\n".
+        let mut state = ParseState::new(sref);
+        let mut stack = ScopeStack::new();
+        let mut scopes_at = |line: &str, cols: &[usize]| -> Vec<Vec<String>> {
+            let ops = state.parse_line(line, &ss).unwrap().ops;
+            let mut out = vec![Vec::new(); cols.len()];
+            let mut next_op = 0;
+            for (i, _) in line.char_indices() {
+                while next_op < ops.len() && ops[next_op].0 <= i {
+                    stack.apply(&ops[next_op].1).unwrap();
+                    next_op += 1;
+                }
+                if let Some(pos) = cols.iter().position(|c| *c == i) {
+                    out[pos] = stack.as_slice().iter().map(|s| s.build_string()).collect();
+                }
+            }
+            while next_op < ops.len() {
+                stack.apply(&ops[next_op].1).unwrap();
+                next_op += 1;
+            }
+            out
+        };
+
+        // col 3 = 'x' inside the push — must see m.outer, m.wrap, word.x,
+        // but NOT string.outer (cleared by wrap's clear_scopes: 1).
+        // col 5 = 'y' (any trailing byte) after the pop — string.outer
+        // must be back (Restore restored the cleared atom).
+        let line = "go x y\n";
+        let scopes = scopes_at(line, &[3, 5]);
+
+        let at_x = &scopes[0];
+        assert!(
+            at_x.iter().any(|s| s == "m.outer"),
+            "'x' should carry m.outer; got {:?}",
+            at_x
+        );
+        assert!(
+            at_x.iter().any(|s| s == "m.wrap"),
+            "'x' should carry m.wrap from the pushed wrap meta_scope; got {:?}",
+            at_x
+        );
+        assert!(
+            !at_x.iter().any(|s| s == "string.outer"),
+            "'x' should NOT carry string.outer (cleared by wrap.clear_scopes: 1); got {:?}",
+            at_x
+        );
+
+        let at_y = &scopes[1];
+        assert!(
+            at_y.iter().any(|s| s == "m.outer"),
+            "'y' should carry m.outer after pop; got {:?}",
+            at_y
+        );
+        assert!(
+            at_y.iter().any(|s| s == "string.outer"),
+            "'y' should carry string.outer after pop (Restore must fire); got {:?}",
+            at_y
+        );
+        assert!(
+            !at_y.iter().any(|s| s == "m.wrap"),
+            "'y' should NOT carry m.wrap after pop; got {:?}",
+            at_y
         );
     }
 

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,12 +1,48 @@
 loading syntax definitions from testdata/Packages
+FAILED testdata/Packages/ASP/syntax_test_asp.asp: 1003
+FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 855
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
+FAILED testdata/Packages/C#/tests/syntax_test_C#12.cs: 41
+FAILED testdata/Packages/C#/tests/syntax_test_C#8.cs: 714
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 2595
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure_old.clj: 182
+FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
+FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
+FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
+FAILED testdata/Packages/Go/tests/syntax_test_go.go: 16772
+FAILED testdata/Packages/Go/tests/syntax_test_template.html: 258
+FAILED testdata/Packages/Go/tests/syntax_test_template.yaml: 81
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
+FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
+FAILED testdata/Packages/JavaScript/tests/syntax_test_jsx.jsx: 277
+FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
+FAILED testdata/Packages/Lua/tests/syntax_test_lua.lua: 1451
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 4749
+FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 74
+FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 210
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-exiting with code 2
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_conflicts.re: 1
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 29
+FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 27
+FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 9604
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
+FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
+FAILED testdata/Packages/YAML/tests/syntax_test_flow-plain.yaml: 220
+FAILED testdata/Packages/YAML/tests/syntax_test_flow.yaml: 413
+FAILED testdata/Packages/YAML/tests/syntax_test_types.yaml: 635
+exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -7,30 +7,21 @@ FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
-FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
-FAILED testdata/Packages/JavaScript/tests/syntax_test_jsx.jsx: 277
-FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
-FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 83
+FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 432
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 27
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 6081
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
-FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 28
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,20 +1,14 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 1003
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 855
-FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
-FAILED testdata/Packages/C#/tests/syntax_test_C#12.cs: 41
-FAILED testdata/Packages/C#/tests/syntax_test_C#8.cs: 714
+FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
+FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 1078
+FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 2595
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure_old.clj: 182
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Go/tests/syntax_test_go.go: 16772
-FAILED testdata/Packages/Go/tests/syntax_test_template.html: 258
-FAILED testdata/Packages/Go/tests/syntax_test_template.yaml: 81
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
@@ -25,24 +19,18 @@ FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
-FAILED testdata/Packages/Lua/tests/syntax_test_lua.lua: 1451
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 4749
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 74
-FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 210
-FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 83
+FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_conflicts.re: 1
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 29
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 432
 FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 27
 FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 9604
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 6081
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
 FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
-FAILED testdata/Packages/YAML/tests/syntax_test_flow-plain.yaml: 220
-FAILED testdata/Packages/YAML/tests/syntax_test_flow.yaml: 413
-FAILED testdata/Packages/YAML/tests/syntax_test_types.yaml: 635
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -7,9 +7,6 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.css.erb: 83
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 86
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 264
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.js.erb: 37
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.sql.erb: 8
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 exiting with code 2

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -7,30 +7,22 @@ FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
-FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
-FAILED testdata/Packages/JavaScript/tests/syntax_test_jsx.jsx: 277
-FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 1
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
-FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 83
+FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 432
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 28
 FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 6081
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
-FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,20 +1,14 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 1003
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 855
-FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
-FAILED testdata/Packages/C#/tests/syntax_test_C#12.cs: 41
-FAILED testdata/Packages/C#/tests/syntax_test_C#8.cs: 714
+FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
+FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 1078
+FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 2595
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure_old.clj: 182
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Go/tests/syntax_test_go.go: 16772
-FAILED testdata/Packages/Go/tests/syntax_test_template.html: 258
-FAILED testdata/Packages/Go/tests/syntax_test_template.yaml: 81
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
@@ -25,24 +19,18 @@ FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
-FAILED testdata/Packages/Lua/tests/syntax_test_lua.lua: 1451
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 74
-FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 210
-FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 83
+FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_conflicts.re: 1
-FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 29
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 432
 FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
 FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 9604
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 6081
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
 FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
-FAILED testdata/Packages/YAML/tests/syntax_test_flow-plain.yaml: 220
-FAILED testdata/Packages/YAML/tests/syntax_test_flow.yaml: 413
-FAILED testdata/Packages/YAML/tests/syntax_test_types.yaml: 635
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,11 +1,48 @@
 loading syntax definitions from testdata/Packages
+FAILED testdata/Packages/ASP/syntax_test_asp.asp: 1003
+FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 855
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 206
+FAILED testdata/Packages/C#/tests/syntax_test_C#12.cs: 41
+FAILED testdata/Packages/C#/tests/syntax_test_C#8.cs: 714
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 2595
+FAILED testdata/Packages/Clojure/tests/syntax_test_clojure_old.clj: 182
+FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
+FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
+FAILED testdata/Packages/Erlang/syntax_test_erlang.erl: 2466
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
+FAILED testdata/Packages/Go/tests/syntax_test_go.go: 16772
+FAILED testdata/Packages/Go/tests/syntax_test_template.html: 258
+FAILED testdata/Packages/Go/tests/syntax_test_template.yaml: 81
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
+FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 1398
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
+FAILED testdata/Packages/JavaScript/tests/syntax_test_jsx.jsx: 277
+FAILED testdata/Packages/JavaScript/tests/syntax_test_tsx.tsx: 380
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 224
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.xparse.tex: 1
+FAILED testdata/Packages/Lua/tests/syntax_test_lua.lua: 1451
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
+FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 2393
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 74
+FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 210
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-exiting with code 2
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_conflicts.re: 1
+FAILED testdata/Packages/Regular Expressions/tests/syntax_test_regexp.re: 29
+FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
+FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.rs: 4
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 9604
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_symbol.bash: 1
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 3359
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_symbol.zsh: 1
+FAILED testdata/Packages/TOML/tests/syntax_test_scopes.toml: 10
+FAILED testdata/Packages/YAML/tests/syntax_test_flow-plain.yaml: 220
+FAILED testdata/Packages/YAML/tests/syntax_test_flow.yaml: 413
+FAILED testdata/Packages/YAML/tests/syntax_test_types.yaml: 635
+exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -7,8 +7,5 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 271
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js.js: 7
 FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
 FAILED testdata/Packages/Python/tests/syntax_test_scope_tstrings.py: 228
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.css.erb: 83
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 264
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.js.erb: 37
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.sql.erb: 8
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 exiting with code 2


### PR DESCRIPTION
Stacked on #640. **Isolated diff:** https://github.com/stefanobaghino/syntect/compare/631-rails-html-erb-failures...631-syntest-adjustments

Three commits:

1. **Syntest harness visibility** — every test-file outcome reaches `--summary`. Previously-silent parse-error and scope-stack-error files now surface.
2. **v2 multi-context push `clear_scopes` parity** — `push_meta_ops` gated `Clear` emission on `i == last_idx`, silently dropping `clear_scopes` from non-topmost contexts. Fixes Python f/t-string interpolation.
3. **v2 multi-context set `clear_scopes` parity** — same root cause in the `set` arm. Fixes Bash `def-function` scope-stack error.

Commit 1 un-masked the parse-error bailouts that 2 and 3 then address. Per-commit impact numbers in each commit body; baseline deltas in `testdata/known_syntest_failures*.txt`.

Refs: #631
