### PR TITLE
Restrict non-consuming pop loop guard to pop:1

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -669,9 +669,17 @@ impl ParseState {
                         min_start = match_start;
 
                         let consuming = match_end > start;
+                        // A non-consuming `pop: N` after a non-consuming push
+                        // only loops when N == 1 — that restores the exact
+                        // pre-push stack, so the push rule fires again. With
+                        // N >= 2 the stack drops strictly below the pre-push
+                        // depth, so the outer context no longer has the same
+                        // trigger in scope (e.g. Haskell's `immediately-pop2`
+                        // as the fallback branch alternative for
+                        // `declaration-type-end`).
                         pop_would_loop = check_pop_loop
                             && !consuming
-                            && matches!(match_pat.operation, MatchOperation::Pop(_));
+                            && matches!(match_pat.operation, MatchOperation::Pop(1));
 
                         let push_too_deep = matches!(
                             match_pat.operation,
@@ -2518,6 +2526,53 @@ contexts:
         let line = "hello";
         let expect = ["<source.test>, <test.matched>"];
         expect_scope_stacks(line, &expect, syntax);
+    }
+
+    #[test]
+    fn non_consuming_pop_n_below_pre_push_depth_is_not_a_loop() {
+        // Mirror of the Haskell `declaration-type-end` branch where the
+        // fallback alternative is `immediately-pop2` (empty match with
+        // `pop: 2`). The outer wrapper's meta_scope must come off when
+        // the pop-2 fallback fires — pre-fix, the loop guard flagged
+        // any non-consuming `pop` after a non-consuming push as
+        // looping, so the parser advanced one char past the branch and
+        // the pop-2 fired at the wrong column, leaving the wrapper's
+        // scope covering the trailing `y` token.
+        let syntax = r#"
+name: test
+scope: source.test
+contexts:
+  main:
+    - match: open
+      scope: test.open
+      push: wrapper
+    - match: y
+      scope: test.main.y
+    - match: z
+      scope: test.main.z
+  wrapper:
+    - meta_scope: test.wrapper
+    - match: ""
+      branch_point: fallback
+      branch:
+        - try
+        - give-up
+  try:
+    - match: x
+      scope: test.try.match
+    - match: (?=y)
+      fail: fallback
+  give-up:
+    - match: ""
+      pop: 2
+"#;
+        // With the fix, `give-up` fires pop-2 at column 4 (the fail
+        // position), unwinding both `give-up` and `wrapper`; `y` is
+        // then scoped by `main`'s rule. Without the fix, would_loop
+        // advanced start past column 4, the pop-2 fired at column 5,
+        // and `y` stayed inside the wrapper and never matched
+        // `test.main.y`.
+        expect_scope_stacks("openyz", &["<source.test>, <test.main.y>"], syntax);
     }
 
     #[test]

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -8,10 +8,9 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 141
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
-FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -8,10 +8,9 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 141
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
-FAILED testdata/Packages/JavaScript/tests/syntax_test_js_class.js: 4
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 1
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1


### PR DESCRIPTION
Stacked on #643. **Isolated diff:** https://github.com/stefanobaghino/syntect/compare/631-haskell-quasi-quote...631-haskell-decl-data-pop

## Summary

`find_best_match`'s `pop_would_loop` guard (`src/parsing/parser.rs`) flagged *any* non-consuming `Pop` after a non-consuming push as looping, but `pop: N` with N ≥ 2 drops the stack strictly below the pre-push depth — the outer context no longer has the same trigger in scope, so no loop is possible. Restrict the guard to `Pop(1)`.

## Impact

- `Packages/Haskell/tests/syntax_test_haskell.hs`: **141 → 72**. Closes Cluster B: `meta.declaration.data` from the enclosing `constructors` `meta_content_scope` no longer leaks past Haskell's `declaration-type-end` branch (alt[1] = `pop: 2` on `::`). Covers `func :: Type` after a data decl, `var = Con` assignments, and the multi-function-list shape.
- `Packages/JavaScript/tests/syntax_test_js_class.js`: leaves the baseline entirely (4 assertions, same `pop-N-after-non-consuming-push` shape).

No other baseline entries change.

## What's left for Haskell 72

- Cluster C — function-identifier / operator scoping around `(<:>)` and comma-separated function lists (~43 lines). PR #643's body mis-described this as "class-context type-parens"; actual failures are function-identifier scopes.
- Cluster A — `keyword.declaration.{data,type}` missing on context-qualified decls with `=>` (~22 lines).
- Cluster D — string-continuation + operator edge cases (~7 lines).

## Tests

New regression `non_consuming_pop_n_below_pre_push_depth_is_not_a_loop` in `src/parsing/parser.rs`, next to the existing `can_parse_non_consuming_pop_that_would_loop*` cases.

Refs: #631
