### PR TITLE
Drop cur meta_scope on pop + embed match text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,8 +322,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
-source = "git+https://github.com/fancy-regex/fancy-regex?branch=find_not_empty#b8cd8fc1f296be10b4cca3c82efd183b747639ed"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust2 = { version = "0.10.4", optional = true, default-features = false }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { git = "https://github.com/fancy-regex/fancy-regex", branch = "find_not_empty", optional = true }
+fancy-regex = { version = "0.18.0", optional = true }
 walkdir = "2.5"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.8", optional = true }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1722,6 +1722,50 @@ impl ParseState {
                 } else {
                     MatchOperation::Push(contexts.clone())
                 };
+                if pop_count > 0 {
+                    // ST-observed divergence from plain `pop + set:`: on
+                    // `pop + embed:` the trigger match's text sees **neither**
+                    // `cur_context.meta_scope` nor `cur_context.meta_content_scope`.
+                    // Both are suppressed on match text, then never restored
+                    // — the embed replaces cur entirely. The probe lives at
+                    // the top of `v2_pop_embed_suppresses_cur_meta_scope_on_match`.
+                    //
+                    // Emit those Pops ourselves in the initial phase, then pass
+                    // a scope-stripped cur_context through to the recursive
+                    // Set-semantic logic so its `num_to_pop` in the non-initial
+                    // phase does not double-count these atoms (they are already
+                    // off the stack). clear_scopes, with_prototype, and other
+                    // fields are preserved on the stripped context — only the
+                    // meta-scope vectors differ.
+                    //
+                    // Observed divergence on `<jsp:declaration>`'s `>`:
+                    // syntect was producing
+                    //   [..., meta.tag.jsp.declaration.begin.html,
+                    //        meta.tag.jsp.declaration.begin.html,
+                    //        punctuation.definition.tag.end.html]
+                    // because the rule's explicit
+                    //   scope: meta.tag.jsp.declaration.begin.html
+                    //          punctuation.definition.tag.end.html
+                    // was re-adding the atom that ST drops through the embed.
+                    if initial {
+                        if !cur_context.meta_content_scope.is_empty() {
+                            ops.push((
+                                index,
+                                ScopeStackOp::Pop(cur_context.meta_content_scope.len()),
+                            ));
+                        }
+                        if !cur_context.meta_scope.is_empty() {
+                            ops.push((index, ScopeStackOp::Pop(cur_context.meta_scope.len())));
+                        }
+                    }
+                    let stripped = Context {
+                        meta_scope: Vec::new(),
+                        meta_content_scope: Vec::new(),
+                        ..cur_context.clone()
+                    };
+                    return self
+                        .push_meta_ops(initial, index, &stripped, &synthetic, syntax_set, ops);
+                }
                 return self.push_meta_ops(
                     initial,
                     index,
@@ -6218,5 +6262,117 @@ contexts:
                 stack_str
             );
         }
+    }
+
+    #[test]
+    fn v2_pop_embed_suppresses_cur_meta_scope_on_match() {
+        // `pop: N + embed:` trigger text must NOT carry the popped context's
+        // `meta_scope` through, unlike `pop: N + set:` which preserves both
+        // cur's and target's meta_scope on the match. Probe against ST confirms:
+        //
+        //   <tag>hi</tag>            (pop+embed)
+        //   col 4 '>'                -> ['source.host', 'end.scope']            (cur ms gone)
+        //   col 5 'h' (body)         -> ['source.host', 'embed.scope', 'guest.meta']
+        //
+        //   <tag>after               (pop+set — contrast)
+        //   col 4 '>'                -> ['source.host', 'meta.a', 'after.meta', 'end.scope']
+        //
+        // Without this guard, syntect emitted
+        //   [source.host, meta.a, meta.a, end.scope]
+        // because the rule's explicit scope atom shadowed cur.meta_scope onto
+        // itself on the trigger text — observed as 5 duplicated
+        // `meta.tag.jsp.*.begin.html` atoms on `<jsp:declaration>`/ expression/
+        // scriptlet's `>` in `syntax_test_jsp.jsp`.
+        let host = SyntaxDefinition::load_from_str(
+            r#"
+name: PopEmbedHost
+scope: source.popembed
+file_extensions: [popembed]
+version: 2
+contexts:
+  main:
+    - match: '<tag'
+      scope: begin.scope
+      push: tag-attrs
+  tag-attrs:
+    - meta_include_prototype: false
+    - meta_scope: meta.a
+    - match: '>'
+      scope: meta.a end.scope
+      pop: 1
+      embed: scope:source.popembedguest
+      embed_scope: embed.scope
+      escape: '(?=</tag)'
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+        let guest = SyntaxDefinition::load_from_str(
+            r#"
+name: PopEmbedGuest
+scope: source.popembedguest
+version: 2
+hidden: true
+contexts:
+  main:
+    - meta_scope: guest.meta
+    - match: '\w+'
+      scope: word.guest
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(host);
+        builder.add(guest);
+        let ss = builder.build();
+        let syntax = ss.find_syntax_by_name("PopEmbedHost").unwrap();
+        let mut state = ParseState::new(syntax);
+        let ops = state.parse_line("<tag>hi</tag>\n", &ss).unwrap().ops;
+
+        // Walk (range, op) pairs; after applying each op, snapshot the stack
+        // keyed by the character position we're at. The `>` match occupies
+        // col 4, so we expect the post-op snapshot at that position to have
+        // exactly ONE `meta.a` atom, not two.
+        use crate::easy::ScopeRangeIterator;
+        let line = "<tag>hi</tag>\n";
+        let mut stack = ScopeStack::new();
+        let mut at_gt: Option<Vec<String>> = None;
+        for (range, op) in ScopeRangeIterator::new(&ops, line) {
+            stack.apply(op).expect("op stream must apply cleanly");
+            // Capture the stack state for the character range covering the `>`
+            // trigger (col 4..5, the match text of the pop+embed rule).
+            if range.start <= 4 && 4 < range.end {
+                at_gt = Some(
+                    stack
+                        .as_slice()
+                        .iter()
+                        .map(|s| format!("{:?}", s))
+                        .collect(),
+                );
+            }
+        }
+        let at_gt = at_gt.expect("range covering `>` must exist in op stream");
+        let meta_a_count = at_gt.iter().filter(|s| s.contains("meta.a")).count();
+        assert_eq!(
+            meta_a_count, 1,
+            "match text of pop+embed must carry exactly one `meta.a` atom \
+             (from the rule's explicit scope); cur_context.meta_scope must \
+             not stack a second copy on top. Got stack: {:?}",
+            at_gt
+        );
+        // And `end.scope` must be the top of the stack (the match's second
+        // explicit atom) — if the ordering shifted we'd see a different trailer.
+        assert!(
+            at_gt
+                .last()
+                .map(|s| s.contains("end.scope"))
+                .unwrap_or(false),
+            "stack top on `>` must be `end.scope`, got: {:?}",
+            at_gt
+        );
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1598,6 +1598,21 @@ impl ParseState {
                             }
                         }
 
+                        // `pop: N + set:` with clear_scopes on the leaving
+                        // context: restore the cleared atoms BEFORE the
+                        // compound Pop so num_to_pop finds the popped frames'
+                        // full meta_content_scope on the scope stack. Without
+                        // this, Pop eats atoms from below the popped range —
+                        // observed on Batch File `cmd-set-quoted-value-inner-end`
+                        // (`clear_scopes: 1`) firing `pop: 2, set: ignored-tail-outer`,
+                        // which otherwise drops `meta.command.set.dosbatch` from
+                        // the trailing content of every `set "var"=...` line.
+                        let restore_before_pop =
+                            is_set && set_pop_count > 1 && cur_context.clear_scopes.is_some();
+                        if restore_before_pop {
+                            ops.push((index, ScopeStackOp::Restore));
+                        }
+
                         // do all the popping as one operation
                         if num_to_pop > 0 {
                             ops.push((index, ScopeStackOp::Pop(num_to_pop)));
@@ -1607,7 +1622,7 @@ impl ParseState {
                         // cur.meta_scope and the initial phase's target.meta_scope
                         // push have been popped off. The restored atoms land below
                         // the target's upcoming meta_scope / meta_content_scope push.
-                        if is_set && cur_context.clear_scopes.is_some() {
+                        if is_set && cur_context.clear_scopes.is_some() && !restore_before_pop {
                             ops.push((index, ScopeStackOp::Restore));
                         }
 
@@ -5477,6 +5492,85 @@ contexts:
                 .any(|s| s.contains("meta.function.v2settargetclear")),
             "meta.function must be restored after params-body pops, got trailing states: {:?}",
             after_inner_close
+        );
+    }
+
+    #[test]
+    fn pop_n_set_with_cur_clear_scopes_restores_before_popping_deeper_frames() {
+        // `pop: N + set: X` fired from a context that itself declares
+        // `clear_scopes` at the context level: the deeper popped frame's
+        // meta_content_scope is partly on the live scope stack and partly
+        // in `clear_stack` (stripped by cur's Clear on entry). Emitting the
+        // compound Pop before Restore makes Pop eat atoms from below the
+        // intended popped range, dropping the outer frame's meta_scope.
+        // Shape mirrors Batch File's `cmd-set-quoted-value-inner-end`
+        // (`clear_scopes: 1`) firing `pop: 2, set: ignored-tail-outer` below
+        // a `cmd-set-quoted-value-inner` that carries a 2-atom
+        // meta_content_scope.
+        let syntax_str = r#"
+name: PopNSetClear
+scope: source.popnsetclear
+version: 2
+contexts:
+  main:
+    - match: 'a'
+      scope: p.a
+      push: [outer, middle]
+
+  outer:
+    - meta_scope: outer.test
+    - match: 'z'
+      pop: 1
+
+  middle:
+    - meta_content_scope: mid1.test mid2.test
+    - match: 'b'
+      scope: p.b
+      push: top
+
+  top:
+    - clear_scopes: 1
+    - match: 'c'
+      scope: p.c
+      pop: 2
+      set: target
+
+  target:
+    - meta_scope: target.test
+    - match: 'd'
+      scope: p.d
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+        let raw_ops = ops(&mut state, "abcd", &ss);
+        let states = stack_states(raw_ops);
+
+        // The scope stack state recorded on the `d` token (in `target`):
+        // must contain `outer.test` (outer's meta_scope still on the stack)
+        // and `target.test` (target's meta_scope, pushed by the pop:2+set:)
+        // and must NOT contain `mid1.test` or `mid2.test` (middle was popped
+        // by pop:2 and its meta_content_scope atoms — one live, one in
+        // clear_stack — should both be gone).
+        let d_state = states
+            .iter()
+            .find(|s| s.contains("p.d"))
+            .unwrap_or_else(|| panic!("expected a state containing `p.d`, got: {:?}", states));
+        assert!(
+            d_state.contains("outer.test"),
+            "outer.test must survive pop:2+set: (it sits below the popped range): {}",
+            d_state
+        );
+        assert!(
+            d_state.contains("target.test"),
+            "target.test must be on the stack (target was pushed by set:): {}",
+            d_state
+        );
+        assert!(
+            !d_state.contains("mid1.test") && !d_state.contains("mid2.test"),
+            "middle's meta_content_scope atoms must not linger after pop:2+set:, \
+             including the atom that was in clear_stack: {}",
+            d_state
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -194,20 +194,34 @@ type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefau
 /// before any inner group). Empty captures are skipped because they'd
 /// otherwise sort a Pop before its Push. The returned ops are already
 /// position-ordered and safe to append to a parser ops vec.
+///
+/// Each capture's `(cap_start, cap_end)` is clipped to the outer match
+/// range `regions.pos(0)` so a group matching inside a `(?=...)` /
+/// `(?<=...)` whose own span extends past the consumed range still
+/// colours the overlap (the boundary char) and nothing beyond it. This
+/// mirrors Sublime Text; without the clip, a lookahead-internal
+/// `captures:` entry leaked scope over unmatched trailing chars or was
+/// silently dropped upstream in `parse_captures`.
 fn build_capture_ops(capture_map: &CaptureMapping, regions: &Region) -> Vec<(usize, ScopeStackOp)> {
     let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
+    let (match_start, match_end) = match regions.pos(0) {
+        Some(bounds) => bounds,
+        None => return Vec::new(),
+    };
     for &(cap_index, ref scopes) in capture_map.iter() {
         if let Some((cap_start, cap_end)) = regions.pos(cap_index) {
-            if cap_start == cap_end {
+            let clipped_start = cap_start.max(match_start);
+            let clipped_end = cap_end.min(match_end);
+            if clipped_start >= clipped_end {
                 continue;
             }
             for scope in scopes.iter() {
                 map.push((
-                    (cap_start, -((cap_end - cap_start) as i32)),
+                    (clipped_start, -((clipped_end - clipped_start) as i32)),
                     ScopeStackOp::Push(*scope),
                 ));
             }
-            map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
+            map.push(((clipped_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
         }
     }
     map.sort_by(|a, b| a.0.cmp(&b.0));
@@ -5224,6 +5238,75 @@ contexts:
         assert_eq!(
             first_word_pos, 0,
             "word.consuming must start at position 0 (consuming pop should not be treated as loop)"
+        );
+    }
+
+    #[test]
+    fn captures_clipped_to_match_bounds_when_group_extends_past_match_end() {
+        // Repro of a C# generic-function-call divergence against ST.
+        // Rule shape: a consumed identifier, then a lookahead containing
+        // a capturing group whose match extends *past* the outer rule's
+        // consumed end, then a second consumed group starting at the
+        // same column where the lookahead began. `captures: 2:` targets
+        // the lookahead-internal group. ST clips each captures:N span
+        // to the rule's match bounds and only colours the overlap —
+        // which here is the single consumed char at the match-end
+        // boundary. Syntect used to colour the full group-2 range,
+        // emitting a Pop past match_end and leaving the scope active
+        // over chars the match never consumed.
+        let syntax_str = r#"
+name: CapturesClip
+scope: source.capclip
+contexts:
+  main:
+    - match: '(foo)(?=(barrr)baz)(bar)'
+      captures:
+        1: captured-foo.capclip
+        2: lookahead-group.capclip
+        3: consumed-bar.capclip
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+        let raw_ops = ops(&mut state, "foobarrrbaz\n", &ss);
+
+        // The rule consumes "foobar" — match_start=0, match_end=6.
+        // Group 2's own range (the lookahead match "barrr") extends to
+        // column 8. Every op emitted by the captures application must
+        // sit within [match_start, match_end]; anything at col 7+ means
+        // the lookahead-internal group's span leaked past the match.
+        // match_start=0, match_end=6 (rule consumes "foobar"). Group 2's
+        // own range (the lookahead match "barrr") extends to col 8.
+        //
+        // After the fix we expect:
+        //   * `lookahead-group.capclip` Pushed at col 3 (cap_start of
+        //     group 2, which overlaps the consumed region).
+        //   * The matching Pop no later than col 6 (clipped to match_end).
+        //   * No op at col 7 or 8 — anything there means the lookahead
+        //     range leaked past the match.
+        let lookahead_pushes: Vec<usize> = raw_ops
+            .iter()
+            .filter_map(|(pos, op)| match op {
+                ScopeStackOp::Push(s) if format!("{:?}", s).contains("lookahead-group") => {
+                    Some(*pos)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lookahead_pushes,
+            vec![3],
+            "`captures: 2:` (lookahead-internal group) must Push the \
+             clipped scope at match_start=3; raw_ops={:?}",
+            raw_ops
+        );
+        let match_end = 6;
+        let past_match: Vec<_> = raw_ops.iter().filter(|(pos, _)| *pos > match_end).collect();
+        assert!(
+            past_match.is_empty(),
+            "No capture op should sit past match_end={}; found {:?}",
+            match_end,
+            past_match
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -157,6 +157,14 @@ struct BranchPoint {
     /// ESCAPE …`, every non-whitespace before the `LIKE` fires
     /// `else-pop` in the escape-alternative, derailing the stack).
     prefix_ops: Vec<(usize, ScopeStackOp)>,
+    /// Capture Push/Pop ops emitted alongside the branch_point match's
+    /// `pat_scope`. Re-emitted on fail-retry between the pat_scope
+    /// Push and Pop so captures like `keyword.declaration.data.haskell`
+    /// on the first capture group of `(data)(?:\s+(family|instance))?`
+    /// survive a branch swap — without this, a `data CtxCls ctx => …`
+    /// (where alt[0] `data-signature` fails into alt[1] `data-context`)
+    /// drops the keyword scope from the `data` token.
+    capture_ops: Vec<(usize, ScopeStackOp)>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -179,6 +187,35 @@ struct RegexMatch<'a> {
 
 /// Maps the pattern to the start index, which is -1 if not found.
 type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefault<FnvHasher>>;
+
+/// Build the ordered Push/Pop ops for a match's `captures:` mapping over
+/// its regex `regions`. Captures can appear in arbitrary source order
+/// (e.g. `((bob)|(hi))*` matching `hibob` — the outer group must Push
+/// before any inner group). Empty captures are skipped because they'd
+/// otherwise sort a Pop before its Push. The returned ops are already
+/// position-ordered and safe to append to a parser ops vec.
+fn build_capture_ops(
+    capture_map: &CaptureMapping,
+    regions: &Region,
+) -> Vec<(usize, ScopeStackOp)> {
+    let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
+    for &(cap_index, ref scopes) in capture_map.iter() {
+        if let Some((cap_start, cap_end)) = regions.pos(cap_index) {
+            if cap_start == cap_end {
+                continue;
+            }
+            for scope in scopes.iter() {
+                map.push((
+                    (cap_start, -((cap_end - cap_start) as i32)),
+                    ScopeStackOp::Push(*scope),
+                ));
+            }
+            map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
+        }
+    }
+    map.sort_by(|a, b| a.0.cmp(&b.0));
+    map.into_iter().map(|((i, _), op)| (i, op)).collect()
+}
 
 // To understand the implementation of this, here's an introduction to how
 // Sublime Text syntax definitions work.
@@ -873,6 +910,11 @@ impl ParseState {
                     escape_stack_snapshot: self.escape_stack.clone(),
                     pop_count,
                     prefix_ops: ops.clone(),
+                    capture_ops: pat
+                        .captures
+                        .as_ref()
+                        .map(|m| build_capture_ops(m, &reg_match.regions))
+                        .unwrap_or_default(),
                 };
                 self.branch_points.push(bp);
                 // When pop_count > 0 (pop + branch), use Set semantics to
@@ -902,31 +944,12 @@ impl ParseState {
         for s in &pat.scope {
             ops.push((match_start, ScopeStackOp::Push(*s)));
         }
-        if let Some(ref capture_map) = pat.captures {
-            // captures could appear in an arbitrary order, have to produce ops in right order
-            // ex: ((bob)|(hi))* could match hibob in wrong order, and outer has to push first
-            // we don't have to handle a capture matching multiple times, Sublime doesn't
-            let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
-            for &(cap_index, ref scopes) in capture_map.iter() {
-                if let Some((cap_start, cap_end)) = reg_match.regions.pos(cap_index) {
-                    // marking up empty captures causes pops to be sorted wrong
-                    if cap_start == cap_end {
-                        continue;
-                    }
-                    for scope in scopes.iter() {
-                        map.push((
-                            (cap_start, -((cap_end - cap_start) as i32)),
-                            ScopeStackOp::Push(*scope),
-                        ));
-                    }
-                    map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
-                }
-            }
-            map.sort_by(|a, b| a.0.cmp(&b.0));
-            for ((index, _), op) in map.into_iter() {
-                ops.push((index, op));
-            }
-        }
+        let capture_ops = pat
+            .captures
+            .as_ref()
+            .map(|m| build_capture_ops(m, &reg_match.regions))
+            .unwrap_or_default();
+        ops.extend(capture_ops.iter().cloned());
         if !pat.scope.is_empty() {
             ops.push((match_end, ScopeStackOp::Pop(pat.scope.len())));
         }
@@ -1113,6 +1136,7 @@ impl ParseState {
         let match_start_pos = bp.match_start;
         let trigger_match_start = bp.trigger_match_start;
         let trigger_pat_scope = bp.pat_scope.clone();
+        let trigger_capture_ops = bp.capture_ops.clone();
         let stack_snapshot = bp.stack_snapshot.clone();
         let proto_starts_snapshot = bp.proto_starts_snapshot.clone();
         let first_line_snapshot = bp.first_line_snapshot;
@@ -1209,6 +1233,10 @@ impl ParseState {
                     for scope in &trigger_pat_scope {
                         first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
                     }
+                    // See matching comment in the same-line branch below —
+                    // re-emit the trigger match's captures inside the
+                    // pat_scope brackets so they survive the branch swap.
+                    first_line_ops.extend(trigger_capture_ops.iter().cloned());
                     if !trigger_pat_scope.is_empty() {
                         first_line_ops
                             .push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
@@ -1292,6 +1320,12 @@ impl ParseState {
             for scope in &trigger_pat_scope {
                 ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
             }
+            // Captures emitted alongside the original pat.scope (e.g.
+            // `keyword.declaration.data.haskell` on the first capture of
+            // `(data)(?:\s+(family|instance))?`) were truncated off with
+            // alt[0]'s ops. Re-emit them inside the pat_scope brackets so
+            // the keyword scope survives the branch swap.
+            ops.extend(trigger_capture_ops.iter().cloned());
             if !trigger_pat_scope.is_empty() {
                 ops.push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
             }
@@ -3487,6 +3521,51 @@ contexts:
                   alt-fails:
                     - match: (?=\S)
                       fail: t
+                  alt-succeeds:
+                    - match: \S+
+                      scope: ok.test
+                      pop: 1
+                "#,
+        );
+    }
+
+    /// Regression guard for "branch_point fail-retry drops the
+    /// trigger match's `captures:` scopes". The non-fail path emits
+    /// capture Push/Pop ops inside the pat_scope brackets; the
+    /// same-line fail re-emit must do the same — otherwise the
+    /// inner capture scopes are truncated off `ops` together with
+    /// alt[0]'s subsequent work and never replayed. Observed on
+    /// Haskell's `data CtxCls ctx => ModId.QTyCls`, where the
+    /// `(data)(?:\s+(family|instance))?` branch_point match's first
+    /// capture `keyword.declaration.data.haskell` was dropped from
+    /// the `data` token whenever `data-signature` failed into
+    /// `data-context` — 22 assertion failures in
+    /// `syntax_test_haskell.hs`.
+    #[test]
+    fn branch_point_capture_scopes_survive_fail_retry() {
+        // The `(word)\s` branch_point match carries both `scope:`
+        // and `captures:`. Alt[0] fails on the `!` lookahead,
+        // forcing replay into alt[1]. `inner.capture` on the first
+        // capture group must remain on the stack over `word`.
+        expect_scope_stacks(
+            "word !",
+            &["<outer.match>, <inner.capture>"],
+            r#"
+                name: Branch Capture Re-emit Test
+                scope: source.test
+                contexts:
+                  main:
+                    - match: (word)\s
+                      scope: outer.match
+                      captures:
+                        1: inner.capture
+                      branch_point: bp
+                      branch:
+                        - alt-fails
+                        - alt-succeeds
+                  alt-fails:
+                    - match: (?=!)
+                      fail: bp
                   alt-succeeds:
                     - match: \S+
                       scope: ok.test

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -162,7 +162,7 @@ struct BranchPoint {
     /// Push and Pop so captures like `keyword.declaration.data.haskell`
     /// on the first capture group of `(data)(?:\s+(family|instance))?`
     /// survive a branch swap — without this, a `data CtxCls ctx => …`
-    /// (where alt[0] `data-signature` fails into alt[1] `data-context`)
+    /// (where `alt[0]` `data-signature` fails into `alt[1]` `data-context`)
     /// drops the keyword scope from the `data` token.
     capture_ops: Vec<(usize, ScopeStackOp)>,
 }
@@ -194,10 +194,7 @@ type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefau
 /// before any inner group). Empty captures are skipped because they'd
 /// otherwise sort a Pop before its Push. The returned ops are already
 /// position-ordered and safe to append to a parser ops vec.
-fn build_capture_ops(
-    capture_map: &CaptureMapping,
-    regions: &Region,
-) -> Vec<(usize, ScopeStackOp)> {
+fn build_capture_ops(capture_map: &CaptureMapping, regions: &Region) -> Vec<(usize, ScopeStackOp)> {
     let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
     for &(cap_index, ref scopes) in capture_map.iter() {
         if let Some((cap_start, cap_end)) = regions.pos(cap_index) {

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -611,16 +611,22 @@ impl SyntaxDefinition {
 
     fn parse_captures(
         map: &Hash,
-        regex_str: &str,
+        _regex_str: &str,
         state: &mut ParserState<'_>,
     ) -> Result<CaptureMapping, ParseSyntaxError> {
-        let valid_indexes = get_consuming_capture_indexes(regex_str);
+        // Accept every numeric capture entry. Groups inside lookarounds are
+        // kept — `build_capture_ops` clips each capture's span to the rule's
+        // consumed match range at parse time, mirroring Sublime Text. An
+        // earlier version filtered lookaround-internal indices here on the
+        // assumption "those scopes are not applied," which produced silent
+        // drops for valid rules like C#'s generic function-call pattern.
         let mut captures = Vec::new();
         for (key, value) in map.iter() {
             if let (Some(key_int), Some(val_str)) = (key.as_i64(), value.as_str()) {
-                if valid_indexes.contains(&(key_int as usize)) {
-                    captures.push((key_int as usize, str_to_scopes(val_str, state.scope_repo)?));
+                if key_int < 0 {
+                    continue;
                 }
+                captures.push((key_int as usize, str_to_scopes(val_str, state.scope_repo)?));
             }
         }
         Ok(captures)
@@ -942,101 +948,6 @@ impl RegexRewriterForNoNewlines<'_> {
             }
         }
         String::from_utf8(result).unwrap()
-    }
-}
-
-fn get_consuming_capture_indexes(regex: &str) -> Vec<usize> {
-    let parser = ConsumingCaptureIndexParser {
-        parser: Parser::new(regex.as_bytes()),
-    };
-    parser.get_consuming_capture_indexes()
-}
-
-struct ConsumingCaptureIndexParser<'a> {
-    parser: Parser<'a>,
-}
-
-impl ConsumingCaptureIndexParser<'_> {
-    /// Find capture groups which are not inside lookarounds.
-    ///
-    /// If, in a YAML syntax definition, a scope stack is applied to a capture group inside a
-    /// lookaround, (i.e. "captures:\n x: scope.stack goes.here", where "x" is the number of a
-    /// capture group in a lookahead/behind), those those scopes are not applied, so no need to
-    /// even parse them.
-    fn get_consuming_capture_indexes(mut self) -> Vec<usize> {
-        let mut result = Vec::new();
-        let mut stack = Vec::new();
-        let mut cap_num = 0;
-        let mut in_lookaround = false;
-        stack.push(in_lookaround);
-        result.push(cap_num);
-
-        while let Some(c) = self.parser.peek() {
-            match c {
-                b'\\' => {
-                    self.parser.next();
-                    self.parser.next();
-                }
-                b'[' => {
-                    self.parser.parse_character_class();
-                }
-                b'(' => {
-                    self.parser.next();
-                    // add the current lookaround state to the stack so we can just pop at a closing paren
-                    stack.push(in_lookaround);
-                    if let Some(c2) = self.parser.peek() {
-                        if c2 != b'?' {
-                            // simple numbered capture group
-                            cap_num += 1;
-                            // if we are not currently in a lookaround,
-                            // add this capture group number to the valid ones
-                            if !in_lookaround {
-                                result.push(cap_num);
-                            }
-                        } else {
-                            self.parser.next();
-                            if let Some(c3) = self.parser.peek() {
-                                self.parser.next();
-                                if c3 == b'=' || c3 == b'!' {
-                                    // lookahead
-                                    in_lookaround = true;
-                                } else if c3 == b'<' {
-                                    if let Some(c4) = self.parser.peek() {
-                                        if c4 == b'=' || c4 == b'!' {
-                                            self.parser.next();
-                                            // lookbehind
-                                            in_lookaround = true;
-                                        }
-                                    }
-                                } else if c3 == b'P' {
-                                    if let Some(c4) = self.parser.peek() {
-                                        if c4 == b'<' {
-                                            // named capture group
-                                            cap_num += 1;
-                                            // if we are not currently in a lookaround,
-                                            // add this capture group number to the valid ones
-                                            if !in_lookaround {
-                                                result.push(cap_num);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                b')' => {
-                    if let Some(value) = stack.pop() {
-                        in_lookaround = value;
-                    }
-                    self.parser.next();
-                }
-                _ => {
-                    self.parser.next();
-                }
-            }
-        }
-        result
     }
 }
 
@@ -1578,33 +1489,6 @@ mod tests {
         assert_eq!(&rewrite(r"ab(?:\n)?"), r"ab(?:$|)");
         assert_eq!(&rewrite(r"(?<!\n)ab"), r"(?<!$)ab");
         assert_eq!(&rewrite(r"(?<=\n)ab"), r"(?<=$)ab");
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_regex() {
-        let regex = "hello(test)(?=(world))(foo(?P<named>bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 3, 4]);
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_regex2() {
-        let regex = "hello(test)[(?=tricked](foo(bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 2, 3]);
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_nested_regex() {
-        let regex = "hello(test)(?=(world(?!(te(?<=(st))))))(foo(bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 5, 6]);
     }
 
     #[test]

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,8 +1,6 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
@@ -17,7 +15,6 @@ FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -7,7 +7,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,6 +1,5 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 74
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -8,7 +8,7 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,8 +1,6 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
@@ -17,7 +15,6 @@ FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -7,7 +7,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,6 +1,5 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 74
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -8,7 +8,7 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -12,14 +12,13 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1


### PR DESCRIPTION
Stacked on #648. **Isolated diff:** https://github.com/stefanobaghino/syntect/compare/631-captures-clip-to-match...631-jsp-pop-embed-meta-scope-dedup

See the commit body (`a7965fd`) for root cause and fix sketch. ST ground truth was probed via a minimal sublime-syntax probe; the `pop: N + embed:` trigger text drops both cur.meta_scope and cur.meta_content_scope, unlike plain `pop: N + set:`.

## Impact

`testdata/known_syntest_failures{,_fancy}.txt`:

- `Packages/Java/tests/syntax_test_jsp.jsp`: 44 → 39

The 5 cleared assertions are the `- meta.tag.jsp meta.tag.jsp` negatives on `<jsp:declaration>` / `<jsp:expression>` / `<jsp:scriptlet>`'s `>` trigger. The remaining 39 are three unrelated root causes (missing Java rules after `<%`, missing `meta.statement.loop.for.java` meta_scope on a CDATA-wrapped `for` loop) — not addressed here, separate follow-ups.

## Tests

`v2_pop_embed_suppresses_cur_meta_scope_on_match` in `src/parsing/parser.rs`. Fails pre-fix (observed stack has two `meta.a` atoms); passes post-fix (one). The test also pins the stack-top ordering invariant.

Refs: #631