### PR TITLE
Close fancy-regex / Oniguruma baseline gap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,8 +322,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
-source = "git+https://github.com/fancy-regex/fancy-regex?branch=find_not_empty#b8cd8fc1f296be10b4cca3c82efd183b747639ed"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust2 = { version = "0.10.4", optional = true, default-features = false }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { git = "https://github.com/fancy-regex/fancy-regex", branch = "find_not_empty", optional = true }
+fancy-regex = { version = "0.18.0", optional = true }
 walkdir = "2.5"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.8", optional = true }

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -12,14 +12,13 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1


### PR DESCRIPTION
Bumps the `fancy-regex` git dep to `fancy-regex/fancy-regex` `main` now that fancy-regex/fancy-regex#242 and #245 have landed, closing the three remaining divergences between `testdata/known_syntest_failures.txt` and `testdata/known_syntest_failures_fancy.txt` — the two baselines are now byte-for-byte identical.

Restores a green `master` after the `find_not_empty` fancy-regex branch was removed.

Refs: #631