### PR TITLE
Refresh post-replay shadow and stack_before snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,8 +322,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
-source = "git+https://github.com/fancy-regex/fancy-regex?branch=find_not_empty#b8cd8fc1f296be10b4cca3c82efd183b747639ed"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["metadata"]
 [dependencies]
 yaml-rust2 = { version = "0.10.4", optional = true, default-features = false }
 onig = { version = "6.5.1", optional = true, default-features = false }
-fancy-regex = { git = "https://github.com/fancy-regex/fancy-regex", branch = "find_not_empty", optional = true }
+fancy-regex = { version = "0.18.0", optional = true }
 walkdir = "2.5"
 regex-syntax = { version = "0.8", optional = true }
 plist = { version = "1.8", optional = true }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -278,6 +278,7 @@ fn get_line_assertion_details<'a>(
 fn process_assertions(
     assertion: &AssertionRange<'_>,
     test_against_line_scopes: &[ScopedText],
+    next_line_scopes: Option<&[ScopedText]>,
 ) -> Vec<RangeTestResult> {
     // format the scope selector to include a space at the beginning, because, currently, ScopeSelector expects excludes to begin with " -"
     // and they are sometimes in the syntax test as ^^^-comment, for example
@@ -301,16 +302,59 @@ fn process_assertions(
         };
         results.push(result);
     }
-    // don't ignore assertions after the newline, they should be treated as though they are asserting against the newline
+    // Past-EOL columns: ST's `view.text_point(row, col)` overflows into the
+    // next row when `col` exceeds the current line's char count, so its
+    // syntax-test framework evaluates past-EOL assertions against the
+    // corresponding column on the line below. Mirror that here when we have
+    // the next line's scopes; otherwise fall back to the last char's scope.
     let last = test_against_line_scopes.last().unwrap();
-    if last.char_start + last.text_len < assertion.end_char {
-        let match_value = selector.does_match(last.scope.as_slice());
-        let result = RangeTestResult {
-            column_begin: max(last.char_start + last.text_len, assertion.begin_char),
-            column_end: assertion.end_char,
-            success: match_value.is_some(),
-        };
-        results.push(result);
+    let last_end = last.char_start + last.text_len;
+    if last_end < assertion.end_char {
+        let past_eol_begin = max(last_end, assertion.begin_char);
+        let past_eol_end = assertion.end_char;
+        if let Some(next_scopes) = next_line_scopes.filter(|s| !s.is_empty()) {
+            // Wrap formula: position `col` past EOL of a line of total length
+            // `last_end` (chars including trailing `\n`) lands on column
+            // `col - last_end` of the next line.
+            let wrap_begin = past_eol_begin - last_end;
+            let wrap_end = past_eol_end - last_end;
+            let mut covered = wrap_begin;
+            for scoped_text in next_scopes
+                .iter()
+                .skip_while(|s| s.char_start + s.text_len <= wrap_begin)
+                .take_while(|s| s.char_start < wrap_end)
+            {
+                let next_begin = max(scoped_text.char_start, wrap_begin);
+                let next_end = min(scoped_text.char_start + scoped_text.text_len, wrap_end);
+                let match_value = selector.does_match(scoped_text.scope.as_slice());
+                results.push(RangeTestResult {
+                    column_begin: next_begin + last_end,
+                    column_end: next_end + last_end,
+                    success: match_value.is_some(),
+                });
+                covered = next_end;
+            }
+            // Wrap target extends past the next line's content too — recursive
+            // wrap is not yet implemented; fall back to the next line's last
+            // scope so the assertion still gets a defined verdict instead of
+            // silently passing.
+            if covered < wrap_end {
+                let next_last = next_scopes.last().unwrap();
+                let match_value = selector.does_match(next_last.scope.as_slice());
+                results.push(RangeTestResult {
+                    column_begin: covered + last_end,
+                    column_end: past_eol_end,
+                    success: match_value.is_some(),
+                });
+            }
+        } else {
+            let match_value = selector.does_match(last.scope.as_slice());
+            results.push(RangeTestResult {
+                column_begin: past_eol_begin,
+                column_end: past_eol_end,
+                success: match_value.is_some(),
+            });
+        }
     }
     results
 }
@@ -368,7 +412,14 @@ fn test_file(
 
     let mut current_line_number = 1;
     let mut test_against_line_number = 1;
-    let mut scopes_on_line_being_tested = Vec::new();
+    let mut scopes_on_line_being_tested: Vec<ScopedText> = Vec::new();
+    // Scopes of the first line that follows the current target line. ST's
+    // syntax-test framework evaluates past-EOL assertion columns against the
+    // corresponding column on the next line (because `text_point(row, col)`
+    // overflows into the next row when `col` exceeds the row's length); we
+    // mirror that by remembering the next line's scopes once and feeding
+    // them into `process_assertions`. Reset whenever the target line changes.
+    let mut next_target_line_scopes: Option<Vec<ScopedText>> = None;
     let mut previous_non_assertion_line = line.to_string();
 
     let mut assertion_failures: usize = 0;
@@ -383,61 +434,21 @@ fn test_file(
 
     loop {
         // over lines of file, starting with the header line
-        let mut line_only_has_assertion = false;
-        let mut line_has_assertion = false;
-        if let Some(assertion) = get_line_assertion_details(testtoken_start, testtoken_end, &line) {
-            // `@+` and `>` lines are annotation-only (reference labels / reference
-            // assertions). They must be recognised so they do not drive
-            // `test_against_line_number`, but we do not yet implement
-            // cross-line label lookups, so no scope checks run here.
-            let mut current_assertion_failures: usize = 0;
-            if !assertion.is_reference {
-                let result = process_assertions(&assertion, &scopes_on_line_being_tested);
-                total_assertions += assertion.end_char - assertion.begin_char;
-                for failure in result.iter().filter(|r| !r.success) {
-                    let length = failure.column_end - failure.column_begin;
-                    let text: String = previous_non_assertion_line
-                        .chars()
-                        .skip(failure.column_begin)
-                        .take(length)
-                        .collect();
-                    pending_messages.push(BufferedFailureMessage {
-                        selector_text: assertion.scope_selector_text.trim().to_string(),
-                        assertion_line_number: current_line_number,
-                        test_against_line_number,
-                        column_begin: failure.column_begin,
-                        column_end: failure.column_end,
-                        text,
-                        scope: scopes_on_line_being_tested
-                            .iter()
-                            .find(|s| s.char_start + s.text_len > failure.column_begin)
-                            .unwrap_or_else(|| scopes_on_line_being_tested.last().unwrap())
-                            .scope
-                            .clone(),
-                    });
-                    assertion_failures += failure.column_end - failure.column_begin;
-                    current_assertion_failures += failure.column_end - failure.column_begin;
-                }
-                // Buffer this assertion for re-evaluation if backtracking replays the target line
-                if let Some(idx) = current_test_line_buffer_idx {
-                    if let Some(ref mut data) = parsed_line_buffer[idx].non_assertion_data {
-                        data.assertions.push(BufferedAssertion {
-                            begin_char: assertion.begin_char,
-                            end_char: assertion.end_char,
-                            scope_selector_text: assertion.scope_selector_text.to_string(),
-                            assertion_line_number: current_line_number,
-                        });
-                        data.assertion_failures += current_assertion_failures;
-                    }
-                }
-            } // end `if !assertion.is_reference`
-            line_only_has_assertion = assertion.is_pure_assertion_line;
-            line_has_assertion = true;
-        }
+        let assertion_opt = get_line_assertion_details(testtoken_start, testtoken_end, &line);
+        let line_has_assertion = assertion_opt.is_some();
+        let line_only_has_assertion = assertion_opt
+            .as_ref()
+            .map(|a| a.is_pure_assertion_line)
+            .unwrap_or(false);
+
+        // Parse first so the just-parsed scopes are available when the
+        // assertion runs immediately after — needed for past-EOL wrap on the
+        // first assertion line after a target.
         if !line_only_has_assertion || parse_test_lines {
             if !line_has_assertion {
                 // ST seems to ignore lines that have assertions when calculating which line the assertion tests against
                 scopes_on_line_being_tested.clear();
+                next_target_line_scopes = None;
                 test_against_line_number = current_line_number;
                 previous_non_assertion_line = line.to_string();
             }
@@ -532,7 +543,12 @@ fn test_file(
                                     // above, so replays never hit reference lines.
                                     is_reference: false,
                                 };
-                                let result = process_assertions(&temp_assertion, &new_scoped);
+                                // Replay path: fall back to the previous
+                                // past-EOL semantics by passing no next-line
+                                // scopes. Replays are rare and per-target;
+                                // recomputing the next line's scopes here
+                                // would require also replaying its ops.
+                                let result = process_assertions(&temp_assertion, &new_scoped, None);
                                 for failure in result.iter().filter(|r| !r.success) {
                                     let length = failure.column_end - failure.column_begin;
                                     let text: String = record
@@ -583,6 +599,13 @@ fn test_file(
                     debug_print_ops(&line, &ops);
                 }
             }
+            // Build the just-parsed line's scopes. For non-assertion (target)
+            // lines they go into `scopes_on_line_being_tested`; for the FIRST
+            // assertion line that follows a target they go into a fresh vec
+            // that becomes `next_target_line_scopes` (used for past-EOL wrap).
+            // Subsequent assertion lines don't need their scopes captured.
+            let capture_for_next_target = line_has_assertion && next_target_line_scopes.is_none();
+            let mut next_target_buffer: Vec<ScopedText> = Vec::new();
             let mut col: usize = 0;
             for (s, op) in ScopeRegionIterator::new(&ops, &line) {
                 if let Err(_) = stack.apply(op) {
@@ -599,17 +622,23 @@ fn test_file(
                     // in this case we don't care about blank tokens
                     continue;
                 }
+                let len = s.chars().count();
+                let scoped = ScopedText {
+                    char_start: col,
+                    text_len: len,
+                    scope: stack.as_slice().to_vec(),
+                };
                 if !line_has_assertion {
                     // if the line has no assertions on it, remember the scopes on the line so we can test against them later
-                    let len = s.chars().count();
-                    scopes_on_line_being_tested.push(ScopedText {
-                        char_start: col,
-                        text_len: len,
-                        scope: stack.as_slice().to_vec(),
-                    });
-                    // TODO: warn when there are duplicate adjacent (non-meta?) scopes, as it is almost always undesired
-                    col += len;
+                    scopes_on_line_being_tested.push(scoped);
+                } else if capture_for_next_target {
+                    next_target_buffer.push(scoped);
                 }
+                // TODO: warn when there are duplicate adjacent (non-meta?) scopes, as it is almost always undesired
+                col += len;
+            }
+            if capture_for_next_target {
+                next_target_line_scopes = Some(next_target_buffer);
             }
 
             // Buffer this parsed line for potential future replay
@@ -630,11 +659,65 @@ fn test_file(
             if !line_has_assertion {
                 current_test_line_buffer_idx = Some(parsed_line_buffer.len() - 1);
             }
+        }
 
-            // Flush buffered failure messages once the parser commits
-            if !state.is_speculative() {
-                flush_pending_messages(&mut pending_messages, out_opts.summary);
+        // Process the assertion (after parsing, so past-EOL wrap can see the
+        // current line's scopes via `next_target_line_scopes`).
+        if let Some(assertion) = assertion_opt {
+            // `@+` and `>` lines are annotation-only (reference labels /
+            // reference assertions). They must be recognised so they do not
+            // drive `test_against_line_number`, but we do not yet implement
+            // cross-line label lookups, so no scope checks run here.
+            let mut current_assertion_failures: usize = 0;
+            if !assertion.is_reference {
+                let result = process_assertions(
+                    &assertion,
+                    &scopes_on_line_being_tested,
+                    next_target_line_scopes.as_deref(),
+                );
+                total_assertions += assertion.end_char - assertion.begin_char;
+                for failure in result.iter().filter(|r| !r.success) {
+                    let length = failure.column_end - failure.column_begin;
+                    let text: String = previous_non_assertion_line
+                        .chars()
+                        .skip(failure.column_begin)
+                        .take(length)
+                        .collect();
+                    pending_messages.push(BufferedFailureMessage {
+                        selector_text: assertion.scope_selector_text.trim().to_string(),
+                        assertion_line_number: current_line_number,
+                        test_against_line_number,
+                        column_begin: failure.column_begin,
+                        column_end: failure.column_end,
+                        text,
+                        scope: scopes_on_line_being_tested
+                            .iter()
+                            .find(|s| s.char_start + s.text_len > failure.column_begin)
+                            .unwrap_or_else(|| scopes_on_line_being_tested.last().unwrap())
+                            .scope
+                            .clone(),
+                    });
+                    assertion_failures += failure.column_end - failure.column_begin;
+                    current_assertion_failures += failure.column_end - failure.column_begin;
+                }
+                // Buffer this assertion for re-evaluation if backtracking replays the target line
+                if let Some(idx) = current_test_line_buffer_idx {
+                    if let Some(ref mut data) = parsed_line_buffer[idx].non_assertion_data {
+                        data.assertions.push(BufferedAssertion {
+                            begin_char: assertion.begin_char,
+                            end_char: assertion.end_char,
+                            scope_selector_text: assertion.scope_selector_text.to_string(),
+                            assertion_line_number: current_line_number,
+                        });
+                        data.assertion_failures += current_assertion_failures;
+                    }
+                }
             }
+        }
+
+        // Flush buffered failure messages once the parser commits
+        if !state.is_speculative() {
+            flush_pending_messages(&mut pending_messages, out_opts.summary);
         }
 
         line.clear();
@@ -922,5 +1005,105 @@ mod tests {
         // marker-boundary requirement).
         let a = details(CC, None, "//   @@@").unwrap();
         assert!(a.is_reference);
+    }
+
+    /// Build a `ScopedText` from a string of space-separated scope atoms.
+    fn st(char_start: usize, text_len: usize, scopes: &str) -> ScopedText {
+        ScopedText {
+            char_start,
+            text_len,
+            scope: scopes
+                .split_whitespace()
+                .map(|s| Scope::new(s).unwrap())
+                .collect(),
+        }
+    }
+    fn assertion_range(begin_char: usize, end_char: usize, sel: &str) -> AssertionRange<'_> {
+        AssertionRange {
+            begin_char,
+            end_char,
+            scope_selector_text: sel,
+            is_pure_assertion_line: true,
+            is_reference: false,
+        }
+    }
+
+    #[test]
+    fn past_eol_negative_assertion_uses_next_line_wrap() {
+        // git_config-shaped: the consumed `\n` of the target line still
+        // carries the parent meta_scope (`meta.section`), but the next line
+        // is a comment whose scope does not include `meta.section`.
+        // Negative past-EOL assertion `- meta.section` must pass.
+        let target = vec![
+            st(0, 1, "text meta.section punctuation.section.brackets.begin"),
+            st(
+                28,
+                1,
+                "text meta.section meta.brackets invalid.illegal.unexpected.eol",
+            ),
+        ];
+        let next = vec![
+            st(0, 1, "text comment.line punctuation.definition.comment"),
+            st(1, 1, "text comment.line"),
+        ];
+        let a = assertion_range(29, 30, "- meta.section");
+        let r = process_assertions(&a, &target, Some(&next));
+        assert_eq!(r.len(), 1);
+        assert!(r[0].success, "expected pass via wrap to next line: {r:?}");
+    }
+
+    #[test]
+    fn past_eol_positive_assertion_matches_next_line_scope() {
+        // Past-EOL assertion expecting `comment.line` finds it on the next
+        // line — both git_config (lines 554-555) and Clojure (line 33) work
+        // this way in ST.
+        let target = vec![
+            st(
+                0,
+                1,
+                "text meta.mapping.value string.quoted.double punctuation.definition.string.end",
+            ),
+            st(81, 1, "text"),
+        ];
+        let next = vec![
+            st(0, 1, "text comment.line punctuation.definition.comment"),
+            st(1, 14, "text comment.line"),
+        ];
+        let a = assertion_range(82, 97, "comment.line");
+        let r = process_assertions(&a, &target, Some(&next));
+        assert!(
+            r.iter().all(|res| res.success),
+            "expected all wrap segments to pass: {r:?}",
+        );
+    }
+
+    #[test]
+    fn past_eol_falls_back_when_next_line_unavailable() {
+        // Without next-line scopes (end-of-file or replay path), keep the
+        // previous behaviour of testing against the last char's scope.
+        let target = vec![st(0, 5, "text constant.numeric"), st(5, 1, "text")];
+        let a_pass = assertion_range(6, 7, "- constant.numeric");
+        let r_pass = process_assertions(&a_pass, &target, None);
+        assert_eq!(r_pass.len(), 1);
+        assert!(r_pass[0].success);
+        let a_fail = assertion_range(6, 7, "constant.numeric");
+        let r_fail = process_assertions(&a_fail, &target, None);
+        assert_eq!(r_fail.len(), 1);
+        assert!(!r_fail[0].success);
+    }
+
+    #[test]
+    fn past_eol_wrap_overshooting_next_line_uses_next_line_last_scope() {
+        // When the wrap target extends past the next line's content too,
+        // fall back to the next line's last scope (recursive wrap is a v2
+        // concern). The verdict must still be defined, not silently skipped.
+        let target = vec![st(0, 1, "text"), st(1, 1, "text")];
+        let next = vec![st(0, 3, "text source.x")];
+        // Wrap range: cols [2, 8) on target → cols [0, 6) on next.
+        // Cols [3, 6) on next overshoot the 3-char `next` and should fall
+        // back to the next-line last scope (`text source.x`).
+        let a = assertion_range(2, 8, "source.x");
+        let r = process_assertions(&a, &target, Some(&next));
+        assert!(r.iter().all(|res| res.success), "got: {r:?}");
     }
 }

--- a/examples/syntest.rs
+++ b/examples/syntest.rs
@@ -458,7 +458,6 @@ fn test_file(
                     current_line_number, stack, state
                 );
             }
-            let stack_before = stack.clone();
             let output = match state.parse_line(&line, ss) {
                 Ok(output) => output,
                 Err(e) => {
@@ -507,6 +506,19 @@ fn test_file(
                 // Reset stack to the state before the first replayed line
                 stack = parsed_line_buffer[start_idx].stack_before.clone();
 
+                // Collect corrected baselines to apply post-loop, since the
+                // mutable record borrow inside the loop forbids touching
+                // sibling buffer entries. After applying replayed[i],
+                // `stack` is the corrected end-of-line for the buffered
+                // record at start_idx + i, i.e. the corrected
+                // start-of-line baseline for record at start_idx + i + 1.
+                // Overwriting that baseline prevents a future replay from
+                // resurrecting any meta_scope the prior replay had unwound
+                // (observed as meta.link.reference.def.markdown leak past
+                // back-to-back Markdown link reference definitions).
+                let buf_len = parsed_line_buffer.len();
+                let mut corrected_baselines: Vec<(usize, ScopeStack)> = Vec::new();
+
                 for (i, replayed_ops) in replayed.iter().enumerate() {
                     let record = &mut parsed_line_buffer[start_idx + i];
                     let has_non_assertion = record.non_assertion_data.is_some();
@@ -526,6 +538,10 @@ fn test_file(
                             });
                             col += len;
                         }
+                    }
+                    let next_idx = start_idx + i + 1;
+                    if next_idx < buf_len {
+                        corrected_baselines.push((next_idx, stack.clone()));
                     }
 
                     if let Some(ref mut data) = record.non_assertion_data {
@@ -590,6 +606,9 @@ fn test_file(
                         }
                     }
                 }
+                for (idx, corrected) in corrected_baselines {
+                    parsed_line_buffer[idx].stack_before = corrected;
+                }
             }
 
             if out_opts.debug && !line_only_has_assertion {
@@ -599,6 +618,11 @@ fn test_file(
                     debug_print_ops(&line, &ops);
                 }
             }
+            // Snapshot the stack now (post-replays, pre-current-ops) — this
+            // becomes the buffered `stack_before` for the current line, so a
+            // future replay covering it resets to the corrected baseline
+            // rather than the stale pre-parse value.
+            let stack_before = stack.clone();
             // Build the just-parsed line's scopes. For non-assertion (target)
             // lines they go into `scopes_on_line_being_tested`; for the FIRST
             // assertion line that follows a target they go into a fresh vec

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -90,6 +90,12 @@ pub struct ParseState {
     /// cross-line `fail` replay. Only the strings are stored; the ops are
     /// returned to callers immediately (same as before).
     pending_lines: Vec<String>,
+    /// Snapshot of `shadow` at the start of each buffered line in
+    /// `pending_lines`. Used by the cross-line-fail replay to restore
+    /// `shadow` to its state at the first replayed line's beginning, so
+    /// the shadow mirrors what the consumer does (reset + apply
+    /// replayed).
+    pending_line_start_shadows: Vec<ScopeStack>,
     /// Corrected ops produced by a cross-line `fail` replay, to be returned
     /// as `ParseLineOutput::replayed` at the end of `parse_line`.
     flushed_ops: Vec<Vec<(usize, ScopeStackOp)>>,
@@ -99,6 +105,17 @@ pub struct ParseState {
     /// strict precedence over normal patterns — it is checked first and can
     /// truncate the search region.
     escape_stack: Vec<EscapeEntry>,
+    /// Mirror of the consumer's scope stack. Updated at `parse_line`
+    /// boundaries (not mid-line) from the returned `ops` and
+    /// `replayed`, mirroring the consumer's behaviour (reset to the
+    /// first-replayed line's start, then apply replayed, then apply
+    /// current ops). `exec_escape` uses it to detect orphan atoms left
+    /// on the consumer's stack by a prior cross-line replay whose
+    /// later same-line fails truncated the owning context out of
+    /// `self.stack` (the Push for the atom is committed in
+    /// `flushed_ops`, so it can't be taken back by `ops.truncate`) —
+    /// and emits a balancing Pop before the normal escape pops.
+    shadow: ScopeStack,
 }
 
 /// A resolved escape pattern from an `embed` operation, stored on the escape stack.
@@ -336,9 +353,11 @@ impl ParseState {
             branch_points: Vec::new(),
             line_number: 0,
             pending_lines: Vec::new(),
+            pending_line_start_shadows: Vec::new(),
             flushed_ops: Vec::new(),
             warnings: Vec::new(),
             escape_stack: Vec::new(),
+            shadow: ScopeStack::new(),
         }
     }
 
@@ -385,18 +404,50 @@ impl ParseState {
         });
         self.line_number += 1;
 
+        // Snapshot the shadow before parsing this line — if the parse ends
+        // with live branch_points we'll buffer this value alongside the
+        // line string so a future cross-line fail can restore the shadow
+        // to "state at start of first replayed line" (mirroring the
+        // consumer's reset behaviour in `syntest`).
+        let shadow_at_start = self.shadow.clone();
+        let pending_lines_before = self.pending_lines.len();
+
         let ops = self.parse_line_inner(line, syntax_set)?;
 
         // Collect any corrected ops produced by a cross-line `fail` during the
         // parse above.  These are stored by `handle_fail` in `self.flushed_ops`.
         let replayed = std::mem::take(&mut self.flushed_ops);
 
+        // Update shadow to reflect consumer's view at end of this line.
+        // The consumer (see `syntest`) resets its scope stack to
+        // `parsed_line_buffer[start_idx].stack_before` when `replayed` is
+        // non-empty, then applies replayed then applies current-line ops.
+        // Mirror that here so `shadow` matches the consumer downstream.
+        if !replayed.is_empty() {
+            let start_idx = pending_lines_before
+                .checked_sub(replayed.len())
+                .unwrap_or(0);
+            if let Some(snap) = self.pending_line_start_shadows.get(start_idx) {
+                self.shadow = snap.clone();
+            }
+            for line_ops in &replayed {
+                for (_, op) in line_ops {
+                    let _ = self.shadow.apply(op);
+                }
+            }
+        }
+        for (_, op) in &ops {
+            let _ = self.shadow.apply(op);
+        }
+
         // Keep the line string for potential future cross-line replay.
         if !self.branch_points.is_empty() {
             self.pending_lines.push(line.to_string());
+            self.pending_line_start_shadows.push(shadow_at_start);
         } else {
             // No active branch points: any buffered strings are stale.
             self.pending_lines.clear();
+            self.pending_line_start_shadows.clear();
         }
 
         let warnings = std::mem::take(&mut self.warnings);
@@ -1956,6 +2007,47 @@ impl ParseState {
         let entry = &self.escape_stack[escape_idx];
         let target_depth = entry.stack_depth;
         let escape_captures = entry.captures.clone();
+
+        // Drain orphan scope atoms left on the consumer's scope stack by
+        // a prior cross-line replay whose later same-line fails
+        // truncated the owning context out of `self.stack` — the Push
+        // was committed to `flushed_ops` and can't be unwound by
+        // `ops.truncate`, so we emit a balancing Pop here. Without this,
+        // e.g. LaTeX `\end{lstlisting}` leaves
+        // `meta.environment.verbatim.lstlisting.latex` on the stack
+        // because a speculative `meta.path.java` atom pushed inside the
+        // embedded Java shifts every subsequent Pop by one.
+        //
+        // `shadow` mirrors what the consumer will actually hold at this
+        // point: end-of-prior-line shadow + ops-so-far on the current
+        // line. `expected_depth` is what the consumer *should* have
+        // based on `self.stack`'s meta_scope / meta_content_scope
+        // contributions (with the v2 `embed_scope_replaces` mcs gating
+        // applied below, matching the pop loop).
+        let mut current_shadow = self.shadow.clone();
+        for (_, op) in ops.iter() {
+            let _ = current_shadow.apply(op);
+        }
+        let consumer_depth = current_shadow.as_slice().len();
+        let expected_depth: usize = {
+            let mut total = 0usize;
+            let mut prev_embed_scope_replaces = false;
+            for lvl in &self.stack {
+                let ctx = syntax_set.get_context(&lvl.context)?;
+                total += ctx.meta_scope.len();
+                if !prev_embed_scope_replaces {
+                    total += ctx.meta_content_scope.len();
+                }
+                prev_embed_scope_replaces = ctx.embed_scope_replaces;
+            }
+            total
+        };
+        if consumer_depth > expected_depth {
+            ops.push((
+                match_start,
+                ScopeStackOp::Pop(consumer_depth - expected_depth),
+            ));
+        }
 
         // Pop all stack levels down to target_depth, emitting proper meta scope pops
         while self.stack.len() > target_depth {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1722,6 +1722,50 @@ impl ParseState {
                 } else {
                     MatchOperation::Push(contexts.clone())
                 };
+                if pop_count > 0 {
+                    // ST-observed divergence from plain `pop + set:`: on
+                    // `pop + embed:` the trigger match's text sees **neither**
+                    // `cur_context.meta_scope` nor `cur_context.meta_content_scope`.
+                    // Both are suppressed on match text, then never restored
+                    // — the embed replaces cur entirely. The probe lives at
+                    // the top of `v2_pop_embed_suppresses_cur_meta_scope_on_match`.
+                    //
+                    // Emit those Pops ourselves in the initial phase, then pass
+                    // a scope-stripped cur_context through to the recursive
+                    // Set-semantic logic so its `num_to_pop` in the non-initial
+                    // phase does not double-count these atoms (they are already
+                    // off the stack). clear_scopes, with_prototype, and other
+                    // fields are preserved on the stripped context — only the
+                    // meta-scope vectors differ.
+                    //
+                    // Observed divergence on `<jsp:declaration>`'s `>`:
+                    // syntect was producing
+                    //   [..., meta.tag.jsp.declaration.begin.html,
+                    //        meta.tag.jsp.declaration.begin.html,
+                    //        punctuation.definition.tag.end.html]
+                    // because the rule's explicit
+                    //   scope: meta.tag.jsp.declaration.begin.html
+                    //          punctuation.definition.tag.end.html
+                    // was re-adding the atom that ST drops through the embed.
+                    if initial {
+                        if !cur_context.meta_content_scope.is_empty() {
+                            ops.push((
+                                index,
+                                ScopeStackOp::Pop(cur_context.meta_content_scope.len()),
+                            ));
+                        }
+                        if !cur_context.meta_scope.is_empty() {
+                            ops.push((index, ScopeStackOp::Pop(cur_context.meta_scope.len())));
+                        }
+                    }
+                    let stripped = Context {
+                        meta_scope: Vec::new(),
+                        meta_content_scope: Vec::new(),
+                        ..cur_context.clone()
+                    };
+                    return self
+                        .push_meta_ops(initial, index, &stripped, &synthetic, syntax_set, ops);
+                }
                 return self.push_meta_ops(
                     initial,
                     index,
@@ -6218,5 +6262,117 @@ contexts:
                 stack_str
             );
         }
+    }
+
+    #[test]
+    fn v2_pop_embed_suppresses_cur_meta_scope_on_match() {
+        // `pop: N + embed:` trigger text must NOT carry the popped context's
+        // `meta_scope` through, unlike `pop: N + set:` which preserves both
+        // cur's and target's meta_scope on the match. Probe against ST confirms:
+        //
+        //   <tag>hi</tag>            (pop+embed)
+        //   col 4 '>'                -> ['source.host', 'end.scope']            (cur ms gone)
+        //   col 5 'h' (body)         -> ['source.host', 'embed.scope', 'guest.meta']
+        //
+        //   <tag>after               (pop+set — contrast)
+        //   col 4 '>'                -> ['source.host', 'meta.a', 'after.meta', 'end.scope']
+        //
+        // Without this guard, syntect emitted
+        //   [source.host, meta.a, meta.a, end.scope]
+        // because the rule's explicit scope atom shadowed cur.meta_scope onto
+        // itself on the trigger text — observed as 5 duplicated
+        // `meta.tag.jsp.*.begin.html` atoms on `<jsp:declaration>`/ expression/
+        // scriptlet's `>` in `syntax_test_jsp.jsp`.
+        let host = SyntaxDefinition::load_from_str(
+            r#"
+name: PopEmbedHost
+scope: source.popembed
+file_extensions: [popembed]
+version: 2
+contexts:
+  main:
+    - match: '<tag'
+      scope: begin.scope
+      push: tag-attrs
+  tag-attrs:
+    - meta_include_prototype: false
+    - meta_scope: meta.a
+    - match: '>'
+      scope: meta.a end.scope
+      pop: 1
+      embed: scope:source.popembedguest
+      embed_scope: embed.scope
+      escape: '(?=</tag)'
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+        let guest = SyntaxDefinition::load_from_str(
+            r#"
+name: PopEmbedGuest
+scope: source.popembedguest
+version: 2
+hidden: true
+contexts:
+  main:
+    - meta_scope: guest.meta
+    - match: '\w+'
+      scope: word.guest
+"#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(host);
+        builder.add(guest);
+        let ss = builder.build();
+        let syntax = ss.find_syntax_by_name("PopEmbedHost").unwrap();
+        let mut state = ParseState::new(syntax);
+        let ops = state.parse_line("<tag>hi</tag>\n", &ss).unwrap().ops;
+
+        // Walk (range, op) pairs; after applying each op, snapshot the stack
+        // keyed by the character position we're at. The `>` match occupies
+        // col 4, so we expect the post-op snapshot at that position to have
+        // exactly ONE `meta.a` atom, not two.
+        use crate::easy::ScopeRangeIterator;
+        let line = "<tag>hi</tag>\n";
+        let mut stack = ScopeStack::new();
+        let mut at_gt: Option<Vec<String>> = None;
+        for (range, op) in ScopeRangeIterator::new(&ops, line) {
+            stack.apply(op).expect("op stream must apply cleanly");
+            // Capture the stack state for the character range covering the `>`
+            // trigger (col 4..5, the match text of the pop+embed rule).
+            if range.start <= 4 && 4 < range.end {
+                at_gt = Some(
+                    stack
+                        .as_slice()
+                        .iter()
+                        .map(|s| format!("{:?}", s))
+                        .collect(),
+                );
+            }
+        }
+        let at_gt = at_gt.expect("range covering `>` must exist in op stream");
+        let meta_a_count = at_gt.iter().filter(|s| s.contains("meta.a")).count();
+        assert_eq!(
+            meta_a_count, 1,
+            "match text of pop+embed must carry exactly one `meta.a` atom \
+             (from the rule's explicit scope); cur_context.meta_scope must \
+             not stack a second copy on top. Got stack: {:?}",
+            at_gt
+        );
+        // And `end.scope` must be the top of the stack (the match's second
+        // explicit atom) — if the ordering shifted we'd see a different trailer.
+        assert!(
+            at_gt
+                .last()
+                .map(|s| s.contains("end.scope"))
+                .unwrap_or(false),
+            "stack top on `>` must be `end.scope`, got: {:?}",
+            at_gt
+        );
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1598,6 +1598,21 @@ impl ParseState {
                             }
                         }
 
+                        // `pop: N + set:` with clear_scopes on the leaving
+                        // context: restore the cleared atoms BEFORE the
+                        // compound Pop so num_to_pop finds the popped frames'
+                        // full meta_content_scope on the scope stack. Without
+                        // this, Pop eats atoms from below the popped range —
+                        // observed on Batch File `cmd-set-quoted-value-inner-end`
+                        // (`clear_scopes: 1`) firing `pop: 2, set: ignored-tail-outer`,
+                        // which otherwise drops `meta.command.set.dosbatch` from
+                        // the trailing content of every `set "var"=...` line.
+                        let restore_before_pop =
+                            is_set && set_pop_count > 1 && cur_context.clear_scopes.is_some();
+                        if restore_before_pop {
+                            ops.push((index, ScopeStackOp::Restore));
+                        }
+
                         // do all the popping as one operation
                         if num_to_pop > 0 {
                             ops.push((index, ScopeStackOp::Pop(num_to_pop)));
@@ -1607,7 +1622,7 @@ impl ParseState {
                         // cur.meta_scope and the initial phase's target.meta_scope
                         // push have been popped off. The restored atoms land below
                         // the target's upcoming meta_scope / meta_content_scope push.
-                        if is_set && cur_context.clear_scopes.is_some() {
+                        if is_set && cur_context.clear_scopes.is_some() && !restore_before_pop {
                             ops.push((index, ScopeStackOp::Restore));
                         }
 
@@ -5477,6 +5492,85 @@ contexts:
                 .any(|s| s.contains("meta.function.v2settargetclear")),
             "meta.function must be restored after params-body pops, got trailing states: {:?}",
             after_inner_close
+        );
+    }
+
+    #[test]
+    fn pop_n_set_with_cur_clear_scopes_restores_before_popping_deeper_frames() {
+        // `pop: N + set: X` fired from a context that itself declares
+        // `clear_scopes` at the context level: the deeper popped frame's
+        // meta_content_scope is partly on the live scope stack and partly
+        // in `clear_stack` (stripped by cur's Clear on entry). Emitting the
+        // compound Pop before Restore makes Pop eat atoms from below the
+        // intended popped range, dropping the outer frame's meta_scope.
+        // Shape mirrors Batch File's `cmd-set-quoted-value-inner-end`
+        // (`clear_scopes: 1`) firing `pop: 2, set: ignored-tail-outer` below
+        // a `cmd-set-quoted-value-inner` that carries a 2-atom
+        // meta_content_scope.
+        let syntax_str = r#"
+name: PopNSetClear
+scope: source.popnsetclear
+version: 2
+contexts:
+  main:
+    - match: 'a'
+      scope: p.a
+      push: [outer, middle]
+
+  outer:
+    - meta_scope: outer.test
+    - match: 'z'
+      pop: 1
+
+  middle:
+    - meta_content_scope: mid1.test mid2.test
+    - match: 'b'
+      scope: p.b
+      push: top
+
+  top:
+    - clear_scopes: 1
+    - match: 'c'
+      scope: p.c
+      pop: 2
+      set: target
+
+  target:
+    - meta_scope: target.test
+    - match: 'd'
+      scope: p.d
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+        let raw_ops = ops(&mut state, "abcd", &ss);
+        let states = stack_states(raw_ops);
+
+        // The scope stack state recorded on the `d` token (in `target`):
+        // must contain `outer.test` (outer's meta_scope still on the stack)
+        // and `target.test` (target's meta_scope, pushed by the pop:2+set:)
+        // and must NOT contain `mid1.test` or `mid2.test` (middle was popped
+        // by pop:2 and its meta_content_scope atoms — one live, one in
+        // clear_stack — should both be gone).
+        let d_state = states
+            .iter()
+            .find(|s| s.contains("p.d"))
+            .unwrap_or_else(|| panic!("expected a state containing `p.d`, got: {:?}", states));
+        assert!(
+            d_state.contains("outer.test"),
+            "outer.test must survive pop:2+set: (it sits below the popped range): {}",
+            d_state
+        );
+        assert!(
+            d_state.contains("target.test"),
+            "target.test must be on the stack (target was pushed by set:): {}",
+            d_state
+        );
+        assert!(
+            !d_state.contains("mid1.test") && !d_state.contains("mid2.test"),
+            "middle's meta_content_scope atoms must not linger after pop:2+set:, \
+             including the atom that was in clear_stack: {}",
+            d_state
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -97,8 +97,12 @@ pub struct ParseState {
     /// replayed).
     pending_line_start_shadows: Vec<ScopeStack>,
     /// Corrected ops produced by a cross-line `fail` replay, to be returned
-    /// as `ParseLineOutput::replayed` at the end of `parse_line`.
+    /// as `ParseLineOutput::replayed` at the end of `parse_line`. When
+    /// populated, entry `i` corresponds to `pending_lines[flushed_ops_start + i]`.
     flushed_ops: Vec<Vec<(usize, ScopeStackOp)>>,
+    /// Pending-lines index that `flushed_ops[0]` maps to when `flushed_ops`
+    /// is non-empty. Reset to `None` between `parse_line` calls.
+    flushed_ops_start: Option<usize>,
     /// Warnings accumulated during parsing, drained into `ParseLineOutput`.
     warnings: Vec<String>,
     /// Active escape patterns from embed operations. The escape regex takes
@@ -355,6 +359,7 @@ impl ParseState {
             pending_lines: Vec::new(),
             pending_line_start_shadows: Vec::new(),
             flushed_ops: Vec::new(),
+            flushed_ops_start: None,
             warnings: Vec::new(),
             escape_stack: Vec::new(),
             shadow: ScopeStack::new(),
@@ -417,6 +422,7 @@ impl ParseState {
         // Collect any corrected ops produced by a cross-line `fail` during the
         // parse above.  These are stored by `handle_fail` in `self.flushed_ops`.
         let replayed = std::mem::take(&mut self.flushed_ops);
+        self.flushed_ops_start = None;
 
         // Update shadow to reflect consumer's view at end of this line.
         // The consumer (see `syntest`) resets its scope stack to
@@ -1033,6 +1039,37 @@ impl ParseState {
         }
     }
 
+    /// Merge a cross-line replay's per-line corrected ops into `flushed_ops`.
+    ///
+    /// Multiple cross-line fails can fire on a single `parse_line` call (e.g.
+    /// Java line 624 with two live branches from line 615, both snapshotted at
+    /// `pending_lines_snapshot_len = 0`). Each fail's replay covers
+    /// `pending_lines[snap..pending_lines.len())`. A naive `extend` leaves
+    /// `flushed_ops` with duplicates — consumers of `ParseLineOutput::replayed`
+    /// index `replayed[i] ↔ pending_lines[i]` by `buf_len - replayed.len()`,
+    /// so duplicates misalign every byte offset.
+    ///
+    /// Composition rule, given current start `a` and new fail's `snap`:
+    /// - `snap <= a`: new fail supersedes everything; replace.
+    /// - `snap > a`: keep `[a..snap)` from prior fails, replace `[snap..N)`.
+    fn merge_flushed(&mut self, snap: usize, new_ops: Vec<Vec<(usize, ScopeStackOp)>>) {
+        match self.flushed_ops_start {
+            None => {
+                self.flushed_ops = new_ops;
+                self.flushed_ops_start = Some(snap);
+            }
+            Some(start) if snap <= start => {
+                self.flushed_ops = new_ops;
+                self.flushed_ops_start = Some(snap);
+            }
+            Some(start) => {
+                let keep = snap - start;
+                self.flushed_ops.truncate(keep);
+                self.flushed_ops.extend(new_ops);
+            }
+        }
+    }
+
     /// Handle a `fail` operation by rewinding to the named branch point.
     /// Returns Ok(true) if backtracking happened (caller should continue from rewound position).
     /// Returns Ok(false) if the fail had no effect.
@@ -1166,7 +1203,7 @@ impl ParseState {
                     };
                     replayed_ops.push(line_ops);
                 }
-                self.flushed_ops.extend(replayed_ops);
+                self.merge_flushed(pending_lines_snapshot_len, replayed_ops);
 
                 // Restart the current line from the beginning under the
                 // restored state.
@@ -1316,9 +1353,7 @@ impl ParseState {
                 };
                 replayed_ops.push(line_ops);
             }
-            // Append (rather than overwrite) in case multiple cross-line fails
-            // fire on the same parse_line call.
-            self.flushed_ops.extend(replayed_ops);
+            self.merge_flushed(pending_lines_snapshot_len, replayed_ops);
 
             // Restart the current line from the beginning.
             ops.clear();
@@ -6466,5 +6501,90 @@ contexts:
             "stack top on `>` must be `end.scope`, got: {:?}",
             at_gt
         );
+    }
+
+    #[test]
+    fn cross_line_multi_fail_deduplicates_flushed_ops() {
+        // Two nested branch_points created on line 1 that both fail on a
+        // later line exercise `handle_fail`'s cross-line path twice on a
+        // single `parse_line` call. Before dedup, each fail `extend`ed
+        // `flushed_ops` with its own replay, so `ParseLineOutput::replayed`
+        // ended up ~2× the pending-lines count — and the consumer (see
+        // `examples/syntest.rs`) paired `replayed[i]` with
+        // `parsed_line_buffer[buf_len - replayed.len() + i]`, sliding ops
+        // from one buffered line onto another's text. That panicked in
+        // `ScopeRegionIterator::next` as "byte index N out of bounds" —
+        // observed originally at `syntax_test_java.java` line 624.
+        let syntax_str = r#"
+name: DedupCrossLine
+scope: source.dup
+contexts:
+  main:
+    - match: 'A'
+      branch_point: bp1
+      branch: [a1, a2]
+  a1:
+    - match: 'B'
+      branch_point: bp2
+      branch: [b1, b2]
+    - match: '(?=FAIL)'
+      fail: bp1
+  a2:
+    - match: '.*'
+      scope: a2.fallback
+      pop: true
+  b1:
+    - match: '\n'
+    - match: '(?=FAIL)'
+      fail: bp2
+    - match: 'XYZ'
+      pop: true
+  b2:
+    - match: '\n'
+    - match: '(?=FAIL)'
+      fail: bp2
+    - match: 'XYZ'
+      pop: true
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+
+        let out1 = state.parse_line("AB\n", &ss).expect("line 1");
+        assert!(out1.replayed.is_empty());
+
+        let out2 = state.parse_line("FOO\n", &ss).expect("line 2");
+        assert!(out2.replayed.is_empty());
+
+        // Line 3 fires `fail: bp2` twice (once for alt[1], once to exhaust)
+        // and then `fail: bp1` — three cross-line fails back-to-back.
+        let out3 = state.parse_line("FAIL\n", &ss).expect("line 3");
+
+        // Invariant: one replayed entry per buffered pending line (2), not
+        // `number_of_fails × pending_lines`.
+        assert_eq!(
+            out3.replayed.len(),
+            2,
+            "expected exactly 2 replayed lines (one per buffered pending line), got {}: {:?}",
+            out3.replayed.len(),
+            out3.replayed,
+        );
+
+        // Panic guard: each `replayed[i]`'s byte offsets must fit within the
+        // corresponding buffered line's length. The original misalignment
+        // paired line 617's ops (77 bytes) with line 609's text (59 bytes).
+        let line_lens = ["AB\n".len(), "FOO\n".len()];
+        for (i, line_ops) in out3.replayed.iter().enumerate() {
+            for (pos, op) in line_ops {
+                assert!(
+                    *pos <= line_lens[i],
+                    "replayed[{}] op past EOL: pos={} line_len={} op={:?}",
+                    i,
+                    pos,
+                    line_lens[i],
+                    op,
+                );
+            }
+        }
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -446,12 +446,6 @@ impl ParseState {
         });
         self.line_number += 1;
 
-        // Snapshot the shadow before parsing this line — if the parse ends
-        // with live branch_points we'll buffer this value alongside the
-        // line string so a future cross-line fail can restore the shadow
-        // to "state at start of first replayed line" (mirroring the
-        // consumer's reset behaviour in `syntest`).
-        let shadow_at_start = self.shadow.clone();
         let pending_lines_before = self.pending_lines.len();
 
         let ops = self.parse_line_inner(line, syntax_set)?;
@@ -466,6 +460,16 @@ impl ParseState {
         // `parsed_line_buffer[start_idx].stack_before` when `replayed` is
         // non-empty, then applies replayed then applies current-line ops.
         // Mirror that here so `shadow` matches the consumer downstream.
+        //
+        // While re-applying replays, also overwrite each buffered line's
+        // pending_line_start_shadows entry with the corrected baseline.
+        // Without this, a later replay covering this same line would reset
+        // shadow to a stale snapshot captured before the prior replay's
+        // correction landed, causing scope leaks (e.g.
+        // meta.link.reference.def.markdown persisting past back-to-back
+        // Markdown link reference definitions, since each LRD's correction
+        // arrives in the *next* line's parse_line and the snapshot for
+        // that next line was captured from the buggy uncorrected stack).
         if !replayed.is_empty() {
             let start_idx = pending_lines_before
                 .checked_sub(replayed.len())
@@ -473,12 +477,26 @@ impl ParseState {
             if let Some(snap) = self.pending_line_start_shadows.get(start_idx) {
                 self.shadow = snap.clone();
             }
-            for line_ops in &replayed {
+            for (i, line_ops) in replayed.iter().enumerate() {
                 for (_, op) in line_ops {
                     let _ = self.shadow.apply(op);
                 }
+                // After applying replayed[i], shadow == start of buffered
+                // line (start_idx + i + 1). Overwrite that snapshot so the
+                // next replay covering it starts from the corrected
+                // baseline rather than the stale one captured pre-replay.
+                let next_idx = start_idx + i + 1;
+                if next_idx < self.pending_line_start_shadows.len() {
+                    self.pending_line_start_shadows[next_idx] = self.shadow.clone();
+                }
             }
         }
+
+        // Snapshot the shadow now (post-replays, pre-current-ops) — this
+        // becomes the baseline for the next line if the current line ends
+        // with live branch_points and gets buffered for future replay.
+        let shadow_at_start_corrected = self.shadow.clone();
+
         for (_, op) in &ops {
             let _ = self.shadow.apply(op);
         }
@@ -486,7 +504,8 @@ impl ParseState {
         // Keep the line string for potential future cross-line replay.
         if !self.branch_points.is_empty() {
             self.pending_lines.push(line.to_string());
-            self.pending_line_start_shadows.push(shadow_at_start);
+            self.pending_line_start_shadows
+                .push(shadow_at_start_corrected);
         } else {
             // No active branch points: any buffered strings are stale.
             self.pending_lines.clear();
@@ -6904,6 +6923,79 @@ contexts:
             pushes_variable,
             "line 1 replayed ops should still push variable.k.rp; got {:?}",
             line1_ops,
+        );
+    }
+
+    /// Two back-to-back link reference definitions followed by a
+    /// paragraph: each LRD's chain is closed by the *next* line's parse
+    /// emitting a `Pop` against the LRD's `meta_scope` via
+    /// `flushed_ops`. Without snapshot-drift correction, the
+    /// pre-correction `pending_line_start_shadows` (and the consumer's
+    /// `parsed_line_buffer[i].stack_before`) used by the second
+    /// replay's stack-reset still reflected the first LRD's leftover
+    /// `meta.link.reference.def.markdown` push, so the corrected line
+    /// 4 ops re-applied that scope onto a stale baseline — leaking it
+    /// into the paragraph and on through the rest of the file.
+    /// Sized 408 chars / 88 assertions in
+    /// `syntax_test_markdown.md`.
+    #[test]
+    fn back_to_back_lrds_clear_meta_scope_via_corrected_baseline() {
+        use crate::parsing::SyntaxSet;
+        let ss = SyntaxSet::load_from_folder("testdata/Packages").unwrap();
+        let syntax = ss
+            .find_syntax_by_path("Packages/Markdown/Markdown.sublime-syntax")
+            .unwrap();
+        let mut state = ParseState::new(syntax);
+
+        // Mirror the syntest consumer's stack-tracking with the
+        // snapshot-drift correction the bug requires.
+        struct Record {
+            stack_before: ScopeStack,
+        }
+        let mut buffer: Vec<Record> = Vec::new();
+        let mut stack = ScopeStack::new();
+
+        for line in ["[foo]: first\n", "[foo]: second\n", "bar\n"] {
+            let out = state.parse_line(line, &ss).expect("parse");
+            if !out.replayed.is_empty() {
+                let buf_len = buffer.len();
+                let start_idx = buf_len - out.replayed.len();
+                stack = buffer[start_idx].stack_before.clone();
+                let mut corrected: Vec<(usize, ScopeStack)> = Vec::new();
+                for (i, replayed_ops) in out.replayed.iter().enumerate() {
+                    for (_, op) in replayed_ops {
+                        let _ = stack.apply(op);
+                    }
+                    let next_idx = start_idx + i + 1;
+                    if next_idx < buf_len {
+                        corrected.push((next_idx, stack.clone()));
+                    }
+                }
+                for (idx, c) in corrected {
+                    buffer[idx].stack_before = c;
+                }
+            }
+            let stack_before = stack.clone();
+            for (_, op) in &out.ops {
+                let _ = stack.apply(op);
+            }
+            buffer.push(Record { stack_before });
+        }
+
+        let lrd = Scope::new("meta.link.reference.def.markdown").unwrap();
+        let leaked = stack.as_slice().contains(&lrd);
+        assert!(
+            !leaked,
+            "meta.link.reference.def.markdown leaked past back-to-back \
+             LRDs into 'bar' paragraph; consumer stack at end: {:?}",
+            stack,
+        );
+        let shadow_leaked = state.shadow.as_slice().contains(&lrd);
+        assert!(
+            !shadow_leaked,
+            "syntect shadow disagrees with corrected consumer stack; \
+             shadow at end: {:?}",
+            state.shadow,
         );
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -194,20 +194,34 @@ type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefau
 /// before any inner group). Empty captures are skipped because they'd
 /// otherwise sort a Pop before its Push. The returned ops are already
 /// position-ordered and safe to append to a parser ops vec.
+///
+/// Each capture's `(cap_start, cap_end)` is clipped to the outer match
+/// range `regions.pos(0)` so a group matching inside a `(?=...)` /
+/// `(?<=...)` whose own span extends past the consumed range still
+/// colours the overlap (the boundary char) and nothing beyond it. This
+/// mirrors Sublime Text; without the clip, a lookahead-internal
+/// `captures:` entry leaked scope over unmatched trailing chars or was
+/// silently dropped upstream in `parse_captures`.
 fn build_capture_ops(capture_map: &CaptureMapping, regions: &Region) -> Vec<(usize, ScopeStackOp)> {
     let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
+    let (match_start, match_end) = match regions.pos(0) {
+        Some(bounds) => bounds,
+        None => return Vec::new(),
+    };
     for &(cap_index, ref scopes) in capture_map.iter() {
         if let Some((cap_start, cap_end)) = regions.pos(cap_index) {
-            if cap_start == cap_end {
+            let clipped_start = cap_start.max(match_start);
+            let clipped_end = cap_end.min(match_end);
+            if clipped_start >= clipped_end {
                 continue;
             }
             for scope in scopes.iter() {
                 map.push((
-                    (cap_start, -((cap_end - cap_start) as i32)),
+                    (clipped_start, -((clipped_end - clipped_start) as i32)),
                     ScopeStackOp::Push(*scope),
                 ));
             }
-            map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
+            map.push(((clipped_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
         }
     }
     map.sort_by(|a, b| a.0.cmp(&b.0));
@@ -5224,6 +5238,75 @@ contexts:
         assert_eq!(
             first_word_pos, 0,
             "word.consuming must start at position 0 (consuming pop should not be treated as loop)"
+        );
+    }
+
+    #[test]
+    fn captures_clipped_to_match_bounds_when_group_extends_past_match_end() {
+        // Repro of a C# generic-function-call divergence against ST.
+        // Rule shape: a consumed identifier, then a lookahead containing
+        // a capturing group whose match extends *past* the outer rule's
+        // consumed end, then a second consumed group starting at the
+        // same column where the lookahead began. `captures: 2:` targets
+        // the lookahead-internal group. ST clips each captures:N span
+        // to the rule's match bounds and only colours the overlap —
+        // which here is the single consumed char at the match-end
+        // boundary. Syntect used to colour the full group-2 range,
+        // emitting a Pop past match_end and leaving the scope active
+        // over chars the match never consumed.
+        let syntax_str = r#"
+name: CapturesClip
+scope: source.capclip
+contexts:
+  main:
+    - match: '(foo)(?=(barrr)baz)(bar)'
+      captures:
+        1: captured-foo.capclip
+        2: lookahead-group.capclip
+        3: consumed-bar.capclip
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+        let raw_ops = ops(&mut state, "foobarrrbaz\n", &ss);
+
+        // The rule consumes "foobar" — match_start=0, match_end=6.
+        // Group 2's own range (the lookahead match "barrr") extends to
+        // column 8. Every op emitted by the captures application must
+        // sit within [match_start, match_end]; anything at col 7+ means
+        // the lookahead-internal group's span leaked past the match.
+        // match_start=0, match_end=6 (rule consumes "foobar"). Group 2's
+        // own range (the lookahead match "barrr") extends to col 8.
+        //
+        // After the fix we expect:
+        //   * `lookahead-group.capclip` Pushed at col 3 (cap_start of
+        //     group 2, which overlaps the consumed region).
+        //   * The matching Pop no later than col 6 (clipped to match_end).
+        //   * No op at col 7 or 8 — anything there means the lookahead
+        //     range leaked past the match.
+        let lookahead_pushes: Vec<usize> = raw_ops
+            .iter()
+            .filter_map(|(pos, op)| match op {
+                ScopeStackOp::Push(s) if format!("{:?}", s).contains("lookahead-group") => {
+                    Some(*pos)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lookahead_pushes,
+            vec![3],
+            "`captures: 2:` (lookahead-internal group) must Push the \
+             clipped scope at match_start=3; raw_ops={:?}",
+            raw_ops
+        );
+        let match_end = 6;
+        let past_match: Vec<_> = raw_ops.iter().filter(|(pos, _)| *pos > match_end).collect();
+        assert!(
+            past_match.is_empty(),
+            "No capture op should sit past match_end={}; found {:?}",
+            match_end,
+            past_match
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -120,6 +120,29 @@ pub struct ParseState {
     /// `flushed_ops`, so it can't be taken back by `ops.truncate`) —
     /// and emits a balancing Pop before the normal escape pops.
     shadow: ScopeStack,
+    /// Active while `handle_fail` recurses into `parse_line_inner*` to
+    /// replay a buffered past line under a new alternative. Overrides
+    /// the "current line" / "pending_lines slot" bookkeeping that
+    /// branches created during the re-parse record, so they anchor to
+    /// the replay line `L+i` rather than the outer `parse_line`'s
+    /// current line. Without it, a later fail on the outer line
+    /// misclassifies the replay-born branch as same-line and applies
+    /// its replay-line-relative `match_start` to a shorter outer line
+    /// (the byte-20-out-of-13 panic on `syntax_test_java.java:10263`
+    /// inside `@MultiLineAnnotation(...)`).
+    replay_ctx: Option<ReplayCtx>,
+}
+
+/// Bookkeeping override used while `handle_fail` is re-parsing a
+/// buffered past line. See the `replay_ctx` field on `ParseState`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ReplayCtx {
+    /// Virtual "current line" of the inner re-parse (`bp.line_number + i`).
+    line_number: usize,
+    /// Slot in `self.pending_lines` that a branch created during this
+    /// replay iteration should record as its snapshot length, so a
+    /// future cross-line fail replays from `L+i` onward.
+    pending_lines_snapshot_offset: usize,
 }
 
 /// A resolved escape pattern from an `embed` operation, stored on the escape stack.
@@ -363,6 +386,7 @@ impl ParseState {
             warnings: Vec::new(),
             escape_stack: Vec::new(),
             shadow: ScopeStack::new(),
+            replay_ctx: None,
         }
     }
 
@@ -959,6 +983,14 @@ impl ParseState {
                 // keyword's own scopes so a same-line fail rewind can
                 // re-emit them (they were truncated off `ops` along
                 // with the alt[0]'s subsequent work).
+                // When `handle_fail` is mid-replay, `self.line_number` /
+                // `self.pending_lines` still reflect the *outer* current
+                // line — read through `replay_ctx` so a branch born
+                // during replay anchors to the virtual replay line `L+i`.
+                let (bp_line_number, bp_pending_lines_snapshot_len) = match &self.replay_ctx {
+                    Some(ctx) => (ctx.line_number, ctx.pending_lines_snapshot_offset),
+                    None => (self.line_number.saturating_sub(1), self.pending_lines.len()),
+                };
                 let bp = BranchPoint {
                     name: name.clone(),
                     next_alternative: 1, // 0 is about to be pushed
@@ -968,13 +1000,13 @@ impl ParseState {
                     match_start: *start, // position before this match's advance
                     trigger_match_start: match_start,
                     pat_scope: pat.scope.clone(),
-                    line_number: self.line_number.saturating_sub(1), // current line (already incremented)
+                    line_number: bp_line_number,
                     ops_snapshot_len: ops.len(),
                     stack_depth: self.stack.len(),
                     non_consuming_push_at_snapshot: *non_consuming_push_at,
                     first_line_snapshot: self.first_line,
                     with_prototype: pat.with_prototype.clone(),
-                    pending_lines_snapshot_len: self.pending_lines.len(),
+                    pending_lines_snapshot_len: bp_pending_lines_snapshot_len,
                     escape_stack_snapshot: self.escape_stack.clone(),
                     pop_count,
                     prefix_ops: ops.clone(),
@@ -1102,7 +1134,15 @@ impl ParseState {
             None => return Ok(false), // No such branch point, fail is no-op
         };
 
-        let cur_line = self.line_number.saturating_sub(1);
+        // During a replay recursion, `cur_line` is the virtual replay
+        // line — without this override a same-line fail fired inside
+        // the re-parse would be misclassified as cross-line, and a
+        // fail on the outer line for a branch created during replay
+        // would be misclassified as same-line.
+        let cur_line = match &self.replay_ctx {
+            Some(ctx) => ctx.line_number,
+            None => self.line_number.saturating_sub(1),
+        };
         let bp = &self.branch_points[bp_index];
 
         // Check validity: not >128 lines old
@@ -1148,6 +1188,7 @@ impl ParseState {
             // stack with `meta.type.js, meta.group.js` — 274 cascading
             // assertion failures in `syntax_test_typescript.ts`.
             let is_cross_line = bp.line_number < cur_line;
+            let bp_line_number = bp.line_number;
             let stack_snapshot = bp.stack_snapshot.clone();
             let proto_starts_snapshot = bp.proto_starts_snapshot.clone();
             let escape_stack_snapshot = bp.escape_stack_snapshot.clone();
@@ -1185,8 +1226,13 @@ impl ParseState {
                 let mut replayed_ops: Vec<Vec<(usize, ScopeStackOp)>> =
                     Vec::with_capacity(truncated_lines.len());
                 for (i, replay_line) in truncated_lines.iter().enumerate() {
-                    let line_ops = if i == 0 {
-                        let mut first_line_ops = prefix_ops.clone();
+                    // Tag branches created during this iteration with
+                    // the replay line's identity, not the outer line's.
+                    let prev_replay_ctx = self.replay_ctx.replace(ReplayCtx {
+                        line_number: bp_line_number + i,
+                        pending_lines_snapshot_offset: pending_lines_snapshot_len + i,
+                    });
+                    let inner_result = if i == 0 {
                         let resume_at = if let Some((j, _)) =
                             replay_line[match_start_pos..].char_indices().nth(1)
                         {
@@ -1194,12 +1240,18 @@ impl ParseState {
                         } else {
                             replay_line.len()
                         };
-                        let tail_ops =
-                            self.parse_line_inner_from(replay_line, syntax_set, resume_at)?;
+                        self.parse_line_inner_from(replay_line, syntax_set, resume_at)
+                    } else {
+                        self.parse_line_inner(replay_line, syntax_set)
+                    };
+                    self.replay_ctx = prev_replay_ctx;
+                    let tail_ops = inner_result?;
+                    let line_ops = if i == 0 {
+                        let mut first_line_ops = prefix_ops.clone();
                         first_line_ops.extend(tail_ops);
                         first_line_ops
                     } else {
-                        self.parse_line_inner(replay_line, syntax_set)?
+                        tail_ops
                     };
                     replayed_ops.push(line_ops);
                 }
@@ -1230,6 +1282,7 @@ impl ParseState {
         let is_cross_line = bp.line_number < cur_line;
 
         // Extract everything we need from bp before mutating self.
+        let bp_line_number = bp.line_number;
         let next_alt_index = bp.next_alternative;
         let next_alt = bp.alternatives[next_alt_index].clone();
         let match_start_pos = bp.match_start;
@@ -1311,6 +1364,19 @@ impl ParseState {
             let mut replayed_ops: Vec<Vec<(usize, ScopeStackOp)>> =
                 Vec::with_capacity(truncated_lines.len());
             for (i, replay_line) in truncated_lines.iter().enumerate() {
+                // Tag branches created during this iteration with the
+                // replay line's identity, not the outer line's.
+                let prev_replay_ctx = self.replay_ctx.replace(ReplayCtx {
+                    line_number: bp_line_number + i,
+                    pending_lines_snapshot_offset: pending_lines_snapshot_len + i,
+                });
+                let inner_result = if i == 0 {
+                    self.parse_line_inner_from(replay_line, syntax_set, match_start_pos)
+                } else {
+                    self.parse_line_inner(replay_line, syntax_set)
+                };
+                self.replay_ctx = prev_replay_ctx;
+                let tail_ops = inner_result?;
                 let line_ops = if i == 0 {
                     // First buffered line: compose prefix + branch ops + resume.
                     let mut first_line_ops = prefix_ops.clone();
@@ -1343,13 +1409,10 @@ impl ParseState {
                     for scope in context.meta_content_scope.iter() {
                         first_line_ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
                     }
-                    // Resume parsing from the branch match's end position.
-                    let tail_ops =
-                        self.parse_line_inner_from(replay_line, syntax_set, match_start_pos)?;
                     first_line_ops.extend(tail_ops);
                     first_line_ops
                 } else {
-                    self.parse_line_inner(replay_line, syntax_set)?
+                    tail_ops
                 };
                 replayed_ops.push(line_ops);
             }
@@ -6582,6 +6645,106 @@ contexts:
                     i,
                     pos,
                     line_lens[i],
+                    op,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn replay_born_branch_routes_as_cross_line_on_later_fail() {
+        // A branch created while `handle_fail` is re-parsing a past buffered
+        // line must record the *replay line's* number, not the outer
+        // `parse_line`'s current line. Otherwise `handle_fail`'s later
+        // `is_cross_line = bp.line_number < cur_line` sees equal values on
+        // the second fail, routes into the same-line path, and applies
+        // `bp.match_start` (a byte offset into the long replay line) to a
+        // shorter outer line. That shipped as the `byte index N out of
+        // bounds` panic on `syntax_test_java.java:10263` (`  foo = BAR,\n`)
+        // and on `syntax_test_markdown.md` under multi-line math blocks.
+        let syntax_str = r#"
+name: ReplayBornBranch
+scope: source.rbb
+contexts:
+  main:
+    - match: 'A'
+      branch_point: bp1
+      branch: [a1, a2]
+  a1:
+    - match: '(?=FAIL1)'
+      fail: bp1
+    - match: '.'
+  a2:
+    - match: 'B'
+      branch_point: bp2
+      branch: [b1, b2]
+    - match: '.'
+  b1:
+    - match: '(?=FAIL2)'
+      fail: bp2
+    - match: '.'
+  b2:
+    - match: '.*'
+      scope: b2.fallback
+      pop: true
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+
+        // Long line 1 so `B` sits past the short outer line's length; bp2's
+        // replay-relative `match_start` would OOB a same-line rewind there.
+        let line1 = "A pad pad pad pad pad pad pad pad pad pad B tail\n";
+        assert!(line1.find('B').unwrap() > "FAIL2\n".len());
+
+        let out1 = state.parse_line(line1, &ss).expect("line 1 parses");
+        assert!(out1.replayed.is_empty());
+
+        // First cross-line fail: swap bp1 → a2. During a2's replay of line 1,
+        // `B` fires bp2 and records (with the fix) `line_number = 0` and
+        // `pending_lines_snapshot_len = 0` — anchored to line 1, not line 2.
+        let out2 = state.parse_line("FAIL1\n", &ss).expect("line 2 parses");
+        assert_eq!(out2.replayed.len(), 1, "bp1 replay covers line 1");
+
+        // Second cross-line fail: bp2 must be classified cross-line on this
+        // outer line. With the fix it is (line 0 < line 2), so the handler
+        // takes the replay path and re-parses past buffered lines under b2.
+        // Without the fix bp2 appears same-line (line 2 == line 2) and the
+        // handler applies `match_start` = offset-of-B-in-line1 to the
+        // 6-byte outer line, corrupting ops / panicking downstream.
+        let outer = "FAIL2\n";
+        let out3 = state.parse_line(outer, &ss).expect("line 3 parses");
+
+        // Cross-line classification fired a second replay covering the
+        // two buffered lines (line 1 + line 2).
+        assert_eq!(
+            out3.replayed.len(),
+            2,
+            "expected replay from bp2's cross-line fail to cover both buffered lines, got {}: {:?}",
+            out3.replayed.len(),
+            out3.replayed,
+        );
+
+        // Panic guard: every op offset in both `ops` and `replayed` must
+        // fit within its paired line's byte length.
+        for (pos, op) in &out3.ops {
+            assert!(
+                *pos <= outer.len(),
+                "outer op past EOL: pos={} len={} op={:?}",
+                pos,
+                outer.len(),
+                op,
+            );
+        }
+        let replay_lines = [line1, "FAIL1\n"];
+        for (i, line_ops) in out3.replayed.iter().enumerate() {
+            for (pos, op) in line_ops {
+                assert!(
+                    *pos <= replay_lines[i].len(),
+                    "replayed[{}] op past EOL: pos={} len={} op={:?}",
+                    i,
+                    pos,
+                    replay_lines[i].len(),
                     op,
                 );
             }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -131,6 +131,18 @@ pub struct ParseState {
     /// (the byte-20-out-of-13 panic on `syntax_test_java.java:10263`
     /// inside `@MultiLineAnnotation(...)`).
     replay_ctx: Option<ReplayCtx>,
+    /// Ops the outer cross-line replay has already composed for the
+    /// first replayed line — outer prefix_ops + new-alt meta/pat/capture
+    /// emission. A branch_point created during the inner re-parse
+    /// records `replay_prefix_ops + ops` as its own `prefix_ops`, so
+    /// when it later fails and reconstructs its line, the outer
+    /// captures (e.g. `[foo]:` LRD opener) survive instead of being
+    /// rebuilt from an empty Vec — the cause of `meta.link.reference`
+    /// scope loss in `syntax_test_markdown.md`'s `[foo]: /url` cases
+    /// where `link-def-title-continuation`'s fail spawns a nested
+    /// `link-def-attr-continuation` whose own fail then replayed line 3
+    /// without the original captures.
+    replay_prefix_ops: Option<Vec<(usize, ScopeStackOp)>>,
 }
 
 /// Bookkeeping override used while `handle_fail` is re-parsing a
@@ -387,6 +399,7 @@ impl ParseState {
             escape_stack: Vec::new(),
             shadow: ScopeStack::new(),
             replay_ctx: None,
+            replay_prefix_ops: None,
         }
     }
 
@@ -991,6 +1004,25 @@ impl ParseState {
                     Some(ctx) => (ctx.line_number, ctx.pending_lines_snapshot_offset),
                     None => (self.line_number.saturating_sub(1), self.pending_lines.len()),
                 };
+                // When this branch is born inside an outer cross-line
+                // replay's `parse_line_inner_from`, the local `ops` Vec
+                // is the inner re-parse's `res` — it does *not* include
+                // the outer prefix the outer replay is about to splice
+                // in front. Without prepending that outer prefix, a
+                // later fail of *this* branch reconstructs its line
+                // from an empty prefix, dropping the outer captures
+                // entirely (the `[foo]:` LRD opener vanished from
+                // `syntax_test_markdown.md`'s `[foo]: /url` cases when
+                // a `link-def-attr-continuation` born inside the
+                // `link-def-title-continuation` replay later failed).
+                let prefix_ops = match &self.replay_prefix_ops {
+                    Some(outer) => {
+                        let mut combined = outer.clone();
+                        combined.extend(ops.iter().cloned());
+                        combined
+                    }
+                    None => ops.clone(),
+                };
                 let bp = BranchPoint {
                     name: name.clone(),
                     next_alternative: 1, // 0 is about to be pushed
@@ -1009,7 +1041,7 @@ impl ParseState {
                     pending_lines_snapshot_len: bp_pending_lines_snapshot_len,
                     escape_stack_snapshot: self.escape_stack.clone(),
                     pop_count,
-                    prefix_ops: ops.clone(),
+                    prefix_ops,
                     capture_ops: pat
                         .captures
                         .as_ref()
@@ -1232,6 +1264,15 @@ impl ParseState {
                         line_number: bp_line_number + i,
                         pending_lines_snapshot_offset: pending_lines_snapshot_len + i,
                     });
+                    // No new-alt construction here (all alternatives
+                    // exhausted), so the first-line prefix is just
+                    // `prefix_ops`. Surface it to inner branch creations
+                    // so their `prefix_ops` keeps the outer captures.
+                    let prev_replay_prefix = if i == 0 {
+                        self.replay_prefix_ops.replace(prefix_ops.clone())
+                    } else {
+                        self.replay_prefix_ops.take()
+                    };
                     let inner_result = if i == 0 {
                         let resume_at = if let Some((j, _)) =
                             replay_line[match_start_pos..].char_indices().nth(1)
@@ -1245,6 +1286,7 @@ impl ParseState {
                         self.parse_line_inner(replay_line, syntax_set)
                     };
                     self.replay_ctx = prev_replay_ctx;
+                    self.replay_prefix_ops = prev_replay_prefix;
                     let tail_ops = inner_result?;
                     let line_ops = if i == 0 {
                         let mut first_line_ops = prefix_ops.clone();
@@ -1361,6 +1403,40 @@ impl ParseState {
             let truncated_lines: Vec<String> =
                 self.pending_lines[pending_lines_snapshot_len..].to_vec();
 
+            // Compose the first replayed line's prefix (outer prefix_ops +
+            // new-alt meta/pat/capture/meta_content emission) up front so a
+            // branch_point born inside the inner re-parse can inherit it
+            // via `self.replay_prefix_ops`. Built once per fail; cloned
+            // and extended with `tail_ops` to form the final line_ops.
+            let mut first_line_prefix = prefix_ops.clone();
+            // Re-emit the trigger's pat.scope and the new alternative's
+            // meta scope ops in the same order the non-fail push path
+            // uses: clear_scopes and meta_scope at `trigger_match_start`
+            // (so the matched text sees them), then pat.scope at the
+            // same position, popped at `match_start_pos`.
+            // meta_content_scope only applies after the matched text, so
+            // it lands at `match_start_pos`.
+            if let Some(clear_amount) = context.clear_scopes {
+                first_line_prefix.push((trigger_match_start, ScopeStackOp::Clear(clear_amount)));
+            }
+            for scope in context.meta_scope.iter() {
+                first_line_prefix.push((trigger_match_start, ScopeStackOp::Push(*scope)));
+            }
+            for scope in &trigger_pat_scope {
+                first_line_prefix.push((trigger_match_start, ScopeStackOp::Push(*scope)));
+            }
+            // See matching comment in the same-line branch below — re-emit
+            // the trigger match's captures inside the pat_scope brackets
+            // so they survive the branch swap.
+            first_line_prefix.extend(trigger_capture_ops.iter().cloned());
+            if !trigger_pat_scope.is_empty() {
+                first_line_prefix
+                    .push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
+            }
+            for scope in context.meta_content_scope.iter() {
+                first_line_prefix.push((match_start_pos, ScopeStackOp::Push(*scope)));
+            }
+
             let mut replayed_ops: Vec<Vec<(usize, ScopeStackOp)>> =
                 Vec::with_capacity(truncated_lines.len());
             for (i, replay_line) in truncated_lines.iter().enumerate() {
@@ -1370,45 +1446,25 @@ impl ParseState {
                     line_number: bp_line_number + i,
                     pending_lines_snapshot_offset: pending_lines_snapshot_len + i,
                 });
+                // Expose the first-line prefix so a branch_point born
+                // during this line's re-parse anchors its `prefix_ops`
+                // to the full line state — outer captures included.
+                // Subsequent replayed lines start fresh.
+                let prev_replay_prefix = if i == 0 {
+                    self.replay_prefix_ops.replace(first_line_prefix.clone())
+                } else {
+                    self.replay_prefix_ops.take()
+                };
                 let inner_result = if i == 0 {
                     self.parse_line_inner_from(replay_line, syntax_set, match_start_pos)
                 } else {
                     self.parse_line_inner(replay_line, syntax_set)
                 };
                 self.replay_ctx = prev_replay_ctx;
+                self.replay_prefix_ops = prev_replay_prefix;
                 let tail_ops = inner_result?;
                 let line_ops = if i == 0 {
-                    // First buffered line: compose prefix + branch ops + resume.
-                    let mut first_line_ops = prefix_ops.clone();
-                    // Re-emit the trigger's pat.scope and the new
-                    // alternative's meta scope ops in the same order
-                    // the non-fail push path uses: clear_scopes and
-                    // meta_scope at `trigger_match_start` (so the
-                    // matched text sees them), then pat.scope at the
-                    // same position, popped at `match_start_pos`.
-                    // meta_content_scope only applies after the
-                    // matched text, so it lands at `match_start_pos`.
-                    if let Some(clear_amount) = context.clear_scopes {
-                        first_line_ops
-                            .push((trigger_match_start, ScopeStackOp::Clear(clear_amount)));
-                    }
-                    for scope in context.meta_scope.iter() {
-                        first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
-                    }
-                    for scope in &trigger_pat_scope {
-                        first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
-                    }
-                    // See matching comment in the same-line branch below —
-                    // re-emit the trigger match's captures inside the
-                    // pat_scope brackets so they survive the branch swap.
-                    first_line_ops.extend(trigger_capture_ops.iter().cloned());
-                    if !trigger_pat_scope.is_empty() {
-                        first_line_ops
-                            .push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
-                    }
-                    for scope in context.meta_content_scope.iter() {
-                        first_line_ops.push((match_start_pos, ScopeStackOp::Push(*scope)));
-                    }
+                    let mut first_line_ops = first_line_prefix.clone();
                     first_line_ops.extend(tail_ops);
                     first_line_ops
                 } else {
@@ -6749,5 +6805,105 @@ contexts:
                 );
             }
         }
+    }
+
+    #[test]
+    fn replay_born_branch_inherits_outer_prefix_ops() {
+        // Branch born inside another branch's cross-line replay must
+        // record the outer replay's first-line prefix as part of its
+        // own `prefix_ops`. Otherwise its later cross-line fail
+        // reconstructs the replayed line from an empty prefix and the
+        // captures emitted before the *outer* branch trigger vanish.
+        // Shipped as `[foo]: /url` losing its
+        // `meta.link.reference.def.markdown` / `entity.name.reference`
+        // scopes in `syntax_test_markdown.md`: the line creates an
+        // outer `link-def-title-continuation` branch whose alt-1
+        // (`immediately-pop2`) replay spawns a nested
+        // `link-def-attr-continuation` branch — when *that* branch
+        // fails on the next line its replay drops the original LRD
+        // opener captures.
+        let syntax_str = r#"
+name: ReplayPrefix
+scope: source.rp
+contexts:
+  main:
+    - match: '(K)(EY)'
+      captures:
+        1: keyword.k.rp
+        2: variable.k.rp
+      push: outer
+  outer:
+    - match: '$'
+      branch_point: bp1
+      branch: [a1, a2]
+  a1:
+    - meta_include_prototype: false
+    - match: '(?=FAIL1)'
+      fail: bp1
+    - match: '.'
+  a2:
+    - meta_include_prototype: false
+    - match: '$'
+      branch_point: bp2
+      branch: [b1, b2]
+    - match: '.'
+  b1:
+    - meta_include_prototype: false
+    - match: '(?=FAIL2)'
+      fail: bp2
+    - match: '.'
+  b2:
+    - meta_include_prototype: false
+    - match: '\n'
+      scope: support.fallback.rp
+      pop: 2
+"#;
+        let syntax = SyntaxDefinition::load_from_str(syntax_str, true, None).unwrap();
+        let ss = link(syntax);
+        let mut state = ParseState::new(&ss.syntaxes()[0]);
+
+        // line 1 — captures `K` and `EY`, pushes `outer`, then `$` fires bp1.
+        let line1 = "KEY\n";
+        let _ = state.parse_line(line1, &ss).expect("line 1 parses");
+
+        // line 2 — `(?=FAIL1)` in a1 trips bp1's cross-line fail. The
+        // alt-1 replay of line 1 spawns bp2 in a2 at end-of-line.
+        let line2 = "FAIL1\n";
+        let _ = state.parse_line(line2, &ss).expect("line 2 parses");
+
+        // line 3 — `(?=FAIL2)` in b1 trips bp2's cross-line fail. With
+        // the fix bp2's `prefix_ops` carries the K / EY captures from
+        // bp1's replay, so the second cross-line replay re-emits them.
+        // Without the fix bp2's `prefix_ops` is empty and the replayed
+        // line 1 ops collapse to just `support.fallback.rp` push/pop.
+        let line3 = "FAIL2\n";
+        let out3 = state.parse_line(line3, &ss).expect("line 3 parses");
+
+        // bp2's cross-line replay covered both buffered lines (line 1
+        // + line 2). Line 1 is the one that must keep its captures.
+        assert_eq!(
+            out3.replayed.len(),
+            2,
+            "bp2 cross-line replay should cover line1 + line2, got {:?}",
+            out3.replayed,
+        );
+        let line1_ops = &out3.replayed[0];
+
+        let pushes_keyword = line1_ops.iter().any(|(_, op)| {
+            matches!(op, ScopeStackOp::Push(s) if *s == Scope::new("keyword.k.rp").unwrap())
+        });
+        let pushes_variable = line1_ops.iter().any(|(_, op)| {
+            matches!(op, ScopeStackOp::Push(s) if *s == Scope::new("variable.k.rp").unwrap())
+        });
+        assert!(
+            pushes_keyword,
+            "line 1 replayed ops should still push keyword.k.rp; got {:?}",
+            line1_ops,
+        );
+        assert!(
+            pushes_variable,
+            "line 1 replayed ops should still push variable.k.rp; got {:?}",
+            line1_ops,
+        );
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -157,6 +157,14 @@ struct BranchPoint {
     /// ESCAPE …`, every non-whitespace before the `LIKE` fires
     /// `else-pop` in the escape-alternative, derailing the stack).
     prefix_ops: Vec<(usize, ScopeStackOp)>,
+    /// Capture Push/Pop ops emitted alongside the branch_point match's
+    /// `pat_scope`. Re-emitted on fail-retry between the pat_scope
+    /// Push and Pop so captures like `keyword.declaration.data.haskell`
+    /// on the first capture group of `(data)(?:\s+(family|instance))?`
+    /// survive a branch swap — without this, a `data CtxCls ctx => …`
+    /// (where alt[0] `data-signature` fails into alt[1] `data-context`)
+    /// drops the keyword scope from the `data` token.
+    capture_ops: Vec<(usize, ScopeStackOp)>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -179,6 +187,35 @@ struct RegexMatch<'a> {
 
 /// Maps the pattern to the start index, which is -1 if not found.
 type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefault<FnvHasher>>;
+
+/// Build the ordered Push/Pop ops for a match's `captures:` mapping over
+/// its regex `regions`. Captures can appear in arbitrary source order
+/// (e.g. `((bob)|(hi))*` matching `hibob` — the outer group must Push
+/// before any inner group). Empty captures are skipped because they'd
+/// otherwise sort a Pop before its Push. The returned ops are already
+/// position-ordered and safe to append to a parser ops vec.
+fn build_capture_ops(
+    capture_map: &CaptureMapping,
+    regions: &Region,
+) -> Vec<(usize, ScopeStackOp)> {
+    let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
+    for &(cap_index, ref scopes) in capture_map.iter() {
+        if let Some((cap_start, cap_end)) = regions.pos(cap_index) {
+            if cap_start == cap_end {
+                continue;
+            }
+            for scope in scopes.iter() {
+                map.push((
+                    (cap_start, -((cap_end - cap_start) as i32)),
+                    ScopeStackOp::Push(*scope),
+                ));
+            }
+            map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
+        }
+    }
+    map.sort_by(|a, b| a.0.cmp(&b.0));
+    map.into_iter().map(|((i, _), op)| (i, op)).collect()
+}
 
 // To understand the implementation of this, here's an introduction to how
 // Sublime Text syntax definitions work.
@@ -873,6 +910,11 @@ impl ParseState {
                     escape_stack_snapshot: self.escape_stack.clone(),
                     pop_count,
                     prefix_ops: ops.clone(),
+                    capture_ops: pat
+                        .captures
+                        .as_ref()
+                        .map(|m| build_capture_ops(m, &reg_match.regions))
+                        .unwrap_or_default(),
                 };
                 self.branch_points.push(bp);
                 // When pop_count > 0 (pop + branch), use Set semantics to
@@ -902,31 +944,12 @@ impl ParseState {
         for s in &pat.scope {
             ops.push((match_start, ScopeStackOp::Push(*s)));
         }
-        if let Some(ref capture_map) = pat.captures {
-            // captures could appear in an arbitrary order, have to produce ops in right order
-            // ex: ((bob)|(hi))* could match hibob in wrong order, and outer has to push first
-            // we don't have to handle a capture matching multiple times, Sublime doesn't
-            let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
-            for &(cap_index, ref scopes) in capture_map.iter() {
-                if let Some((cap_start, cap_end)) = reg_match.regions.pos(cap_index) {
-                    // marking up empty captures causes pops to be sorted wrong
-                    if cap_start == cap_end {
-                        continue;
-                    }
-                    for scope in scopes.iter() {
-                        map.push((
-                            (cap_start, -((cap_end - cap_start) as i32)),
-                            ScopeStackOp::Push(*scope),
-                        ));
-                    }
-                    map.push(((cap_end, i32::MIN), ScopeStackOp::Pop(scopes.len())));
-                }
-            }
-            map.sort_by(|a, b| a.0.cmp(&b.0));
-            for ((index, _), op) in map.into_iter() {
-                ops.push((index, op));
-            }
-        }
+        let capture_ops = pat
+            .captures
+            .as_ref()
+            .map(|m| build_capture_ops(m, &reg_match.regions))
+            .unwrap_or_default();
+        ops.extend(capture_ops.iter().cloned());
         if !pat.scope.is_empty() {
             ops.push((match_end, ScopeStackOp::Pop(pat.scope.len())));
         }
@@ -1113,6 +1136,7 @@ impl ParseState {
         let match_start_pos = bp.match_start;
         let trigger_match_start = bp.trigger_match_start;
         let trigger_pat_scope = bp.pat_scope.clone();
+        let trigger_capture_ops = bp.capture_ops.clone();
         let stack_snapshot = bp.stack_snapshot.clone();
         let proto_starts_snapshot = bp.proto_starts_snapshot.clone();
         let first_line_snapshot = bp.first_line_snapshot;
@@ -1209,6 +1233,10 @@ impl ParseState {
                     for scope in &trigger_pat_scope {
                         first_line_ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
                     }
+                    // See matching comment in the same-line branch below —
+                    // re-emit the trigger match's captures inside the
+                    // pat_scope brackets so they survive the branch swap.
+                    first_line_ops.extend(trigger_capture_ops.iter().cloned());
                     if !trigger_pat_scope.is_empty() {
                         first_line_ops
                             .push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
@@ -1292,6 +1320,12 @@ impl ParseState {
             for scope in &trigger_pat_scope {
                 ops.push((trigger_match_start, ScopeStackOp::Push(*scope)));
             }
+            // Captures emitted alongside the original pat.scope (e.g.
+            // `keyword.declaration.data.haskell` on the first capture of
+            // `(data)(?:\s+(family|instance))?`) were truncated off with
+            // alt[0]'s ops. Re-emit them inside the pat_scope brackets so
+            // the keyword scope survives the branch swap.
+            ops.extend(trigger_capture_ops.iter().cloned());
             if !trigger_pat_scope.is_empty() {
                 ops.push((match_start_pos, ScopeStackOp::Pop(trigger_pat_scope.len())));
             }
@@ -3487,6 +3521,51 @@ contexts:
                   alt-fails:
                     - match: (?=\S)
                       fail: t
+                  alt-succeeds:
+                    - match: \S+
+                      scope: ok.test
+                      pop: 1
+                "#,
+        );
+    }
+
+    /// Regression guard for "branch_point fail-retry drops the
+    /// trigger match's `captures:` scopes". The non-fail path emits
+    /// capture Push/Pop ops inside the pat_scope brackets; the
+    /// same-line fail re-emit must do the same — otherwise the
+    /// inner capture scopes are truncated off `ops` together with
+    /// alt[0]'s subsequent work and never replayed. Observed on
+    /// Haskell's `data CtxCls ctx => ModId.QTyCls`, where the
+    /// `(data)(?:\s+(family|instance))?` branch_point match's first
+    /// capture `keyword.declaration.data.haskell` was dropped from
+    /// the `data` token whenever `data-signature` failed into
+    /// `data-context` — 22 assertion failures in
+    /// `syntax_test_haskell.hs`.
+    #[test]
+    fn branch_point_capture_scopes_survive_fail_retry() {
+        // The `(word)\s` branch_point match carries both `scope:`
+        // and `captures:`. Alt[0] fails on the `!` lookahead,
+        // forcing replay into alt[1]. `inner.capture` on the first
+        // capture group must remain on the stack over `word`.
+        expect_scope_stacks(
+            "word !",
+            &["<outer.match>, <inner.capture>"],
+            r#"
+                name: Branch Capture Re-emit Test
+                scope: source.test
+                contexts:
+                  main:
+                    - match: (word)\s
+                      scope: outer.match
+                      captures:
+                        1: inner.capture
+                      branch_point: bp
+                      branch:
+                        - alt-fails
+                        - alt-succeeds
+                  alt-fails:
+                    - match: (?=!)
+                      fail: bp
                   alt-succeeds:
                     - match: \S+
                       scope: ok.test

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -162,7 +162,7 @@ struct BranchPoint {
     /// Push and Pop so captures like `keyword.declaration.data.haskell`
     /// on the first capture group of `(data)(?:\s+(family|instance))?`
     /// survive a branch swap — without this, a `data CtxCls ctx => …`
-    /// (where alt[0] `data-signature` fails into alt[1] `data-context`)
+    /// (where `alt[0]` `data-signature` fails into `alt[1]` `data-context`)
     /// drops the keyword scope from the `data` token.
     capture_ops: Vec<(usize, ScopeStackOp)>,
 }
@@ -194,10 +194,7 @@ type SearchCache = HashMap<*const MatchPattern, Option<Region>, BuildHasherDefau
 /// before any inner group). Empty captures are skipped because they'd
 /// otherwise sort a Pop before its Push. The returned ops are already
 /// position-ordered and safe to append to a parser ops vec.
-fn build_capture_ops(
-    capture_map: &CaptureMapping,
-    regions: &Region,
-) -> Vec<(usize, ScopeStackOp)> {
+fn build_capture_ops(capture_map: &CaptureMapping, regions: &Region) -> Vec<(usize, ScopeStackOp)> {
     let mut map: Vec<((usize, i32), ScopeStackOp)> = Vec::new();
     for &(cap_index, ref scopes) in capture_map.iter() {
         if let Some((cap_start, cap_end)) = regions.pos(cap_index) {

--- a/src/parsing/syntax_definition.rs
+++ b/src/parsing/syntax_definition.rs
@@ -274,17 +274,20 @@ impl<'a> Iterator for MatchIter<'a> {
                             _ => return self.next(),
                         };
                         let ctx_ptr = self.syntax_set.get_context(context_id).unwrap();
-                        // Also include the external syntax's prototype if the context allows it
+                        // Push target first, then external prototype on top so
+                        // its patterns are iterated first: `MatchIter::next`
+                        // reads the stack top, and ST's `apply_prototype` runs
+                        // the prototype ahead of the included context — mirror
+                        // of `ParseState::find_best_match`'s prototype chaining.
+                        self.ctx_stack.push(ctx_ptr);
+                        self.index_stack.push(0);
                         if ctx_ptr.meta_include_prototype.unwrap_or(true) {
                             if let Some(ref proto_id) = ctx_ptr.prototype {
                                 let proto_ctx = self.syntax_set.get_context(proto_id).unwrap();
-                                // Push prototype first (it will be iterated first)
                                 self.ctx_stack.push(proto_ctx);
                                 self.index_stack.push(0);
                             }
                         }
-                        self.ctx_stack.push(ctx_ptr);
-                        self.index_stack.push(0);
                     }
                 }
             } else {

--- a/src/parsing/syntax_set.rs
+++ b/src/parsing/syntax_set.rs
@@ -2576,8 +2576,159 @@ mod tests {
         builder.add(syntax_using_proto);
         let ss = builder.build();
 
-        // Just verify it builds without errors and the syntax exists
-        assert!(ss.find_syntax_by_name("UsingProto").is_some());
+        let syntax = ss.find_syntax_by_name("UsingProto").unwrap();
+        let mut parse_state = ParseState::new(syntax);
+        let ops = parse_state.parse_line("#", &ss).expect("#[cfg(test)]").ops;
+        // The external `prototype`'s `#` rule must be reachable from the
+        // including context via `apply_prototype: true`.
+        let expected = (0, ScopeStackOp::Push(Scope::new("comment.proto").unwrap()));
+        assert_ops_contain(&ops, &expected);
+    }
+
+    #[test]
+    fn apply_prototype_prototype_wins_tie_over_target_main() {
+        // Both the target's `main` and its `prototype` match `|` at the same
+        // position. ST's `apply_prototype` semantics put the prototype ahead
+        // of the target, so the prototype's scope wins the tie.
+        let target = SyntaxDefinition::load_from_str(
+            r#"
+            name: Target
+            scope: source.target
+            file_extensions: [t]
+            contexts:
+              prototype:
+                - match: '\|'
+                  scope: proto.pipe
+              main:
+                - match: '\|'
+                  scope: target.bitor
+            "#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let outer = SyntaxDefinition::load_from_str(
+            r#"
+            name: Outer
+            scope: source.outer
+            file_extensions: [o]
+            contexts:
+              main:
+                - include: scope:source.target
+                  apply_prototype: true
+            "#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(target);
+        builder.add(outer);
+        let ss = builder.build();
+
+        let syntax = ss.find_syntax_by_name("Outer").unwrap();
+        let mut parse_state = ParseState::new(syntax);
+        let ops = parse_state.parse_line("|", &ss).expect("#[cfg(test)]").ops;
+        assert_ops_contain(
+            &ops,
+            &(0, ScopeStackOp::Push(Scope::new("proto.pipe").unwrap())),
+        );
+        assert!(
+            !ops.iter()
+                .any(|(_, op)| matches!(op, ScopeStackOp::Push(s) if s == &Scope::new("target.bitor").unwrap())),
+            "target main's `|` rule must not pre-empt the external prototype's `|` rule: {:?}",
+            ops,
+        );
+    }
+
+    #[test]
+    fn apply_prototype_respects_meta_include_prototype_false() {
+        // When the include target opts out of prototype inclusion, the
+        // external prototype must NOT be injected even with
+        // `apply_prototype: true` on the include.
+        let target = SyntaxDefinition::load_from_str(
+            r#"
+            name: Target
+            scope: source.target
+            file_extensions: [t]
+            contexts:
+              prototype:
+                - match: '\|'
+                  scope: proto.pipe
+              main:
+                - meta_include_prototype: false
+                - match: '\|'
+                  scope: target.bitor
+            "#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let outer = SyntaxDefinition::load_from_str(
+            r#"
+            name: Outer
+            scope: source.outer
+            file_extensions: [o]
+            contexts:
+              main:
+                - include: scope:source.target
+                  apply_prototype: true
+            "#,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let mut builder = SyntaxSetBuilder::new();
+        builder.add(target);
+        builder.add(outer);
+        let ss = builder.build();
+
+        let syntax = ss.find_syntax_by_name("Outer").unwrap();
+        let mut parse_state = ParseState::new(syntax);
+        let ops = parse_state.parse_line("|", &ss).expect("#[cfg(test)]").ops;
+        assert_ops_contain(
+            &ops,
+            &(0, ScopeStackOp::Push(Scope::new("target.bitor").unwrap())),
+        );
+        assert!(
+            !ops.iter()
+                .any(|(_, op)| matches!(op, ScopeStackOp::Push(s) if s == &Scope::new("proto.pipe").unwrap())),
+            "prototype must stay out when target's `meta_include_prototype: false`: {:?}",
+            ops,
+        );
+    }
+
+    #[test]
+    fn haml_pipe_continuation_wins_over_ruby_bitor() {
+        // Real-package regression guard for the fix: inside HAML attribute
+        // braces, a trailing `|` must scope as HAML's pipe-continuation
+        // (injected via Ruby-for-HAML's prototype under `apply_prototype`),
+        // not as Ruby's bitwise-or operator.
+        let ss = &*testdata::PACKAGES_SYN_SET;
+        let syntax = ss.find_syntax_by_name("HAML").unwrap();
+        let mut parse_state = ParseState::new(syntax);
+        let ops = parse_state
+            .parse_line("%p{:a => 1, |", ss)
+            .expect("#[cfg(test)]")
+            .ops;
+        let pipe_cont = Scope::new("punctuation.separator.continuation.haml").unwrap();
+        let ruby_bitor = Scope::new("keyword.operator.bitwise.ruby").unwrap();
+        assert!(
+            ops.iter()
+                .any(|(_, op)| matches!(op, ScopeStackOp::Push(s) if s == &pipe_cont)),
+            "expected punctuation.separator.continuation.haml push: {:?}",
+            ops,
+        );
+        assert!(
+            !ops.iter()
+                .any(|(_, op)| matches!(op, ScopeStackOp::Push(s) if s == &ruby_bitor)),
+            "Ruby bitwise-or must not win over HAML pipe-continuation: {:?}",
+            ops,
+        );
     }
 
     // =====================================================

--- a/src/parsing/yaml_load.rs
+++ b/src/parsing/yaml_load.rs
@@ -611,16 +611,22 @@ impl SyntaxDefinition {
 
     fn parse_captures(
         map: &Hash,
-        regex_str: &str,
+        _regex_str: &str,
         state: &mut ParserState<'_>,
     ) -> Result<CaptureMapping, ParseSyntaxError> {
-        let valid_indexes = get_consuming_capture_indexes(regex_str);
+        // Accept every numeric capture entry. Groups inside lookarounds are
+        // kept — `build_capture_ops` clips each capture's span to the rule's
+        // consumed match range at parse time, mirroring Sublime Text. An
+        // earlier version filtered lookaround-internal indices here on the
+        // assumption "those scopes are not applied," which produced silent
+        // drops for valid rules like C#'s generic function-call pattern.
         let mut captures = Vec::new();
         for (key, value) in map.iter() {
             if let (Some(key_int), Some(val_str)) = (key.as_i64(), value.as_str()) {
-                if valid_indexes.contains(&(key_int as usize)) {
-                    captures.push((key_int as usize, str_to_scopes(val_str, state.scope_repo)?));
+                if key_int < 0 {
+                    continue;
                 }
+                captures.push((key_int as usize, str_to_scopes(val_str, state.scope_repo)?));
             }
         }
         Ok(captures)
@@ -942,101 +948,6 @@ impl RegexRewriterForNoNewlines<'_> {
             }
         }
         String::from_utf8(result).unwrap()
-    }
-}
-
-fn get_consuming_capture_indexes(regex: &str) -> Vec<usize> {
-    let parser = ConsumingCaptureIndexParser {
-        parser: Parser::new(regex.as_bytes()),
-    };
-    parser.get_consuming_capture_indexes()
-}
-
-struct ConsumingCaptureIndexParser<'a> {
-    parser: Parser<'a>,
-}
-
-impl ConsumingCaptureIndexParser<'_> {
-    /// Find capture groups which are not inside lookarounds.
-    ///
-    /// If, in a YAML syntax definition, a scope stack is applied to a capture group inside a
-    /// lookaround, (i.e. "captures:\n x: scope.stack goes.here", where "x" is the number of a
-    /// capture group in a lookahead/behind), those those scopes are not applied, so no need to
-    /// even parse them.
-    fn get_consuming_capture_indexes(mut self) -> Vec<usize> {
-        let mut result = Vec::new();
-        let mut stack = Vec::new();
-        let mut cap_num = 0;
-        let mut in_lookaround = false;
-        stack.push(in_lookaround);
-        result.push(cap_num);
-
-        while let Some(c) = self.parser.peek() {
-            match c {
-                b'\\' => {
-                    self.parser.next();
-                    self.parser.next();
-                }
-                b'[' => {
-                    self.parser.parse_character_class();
-                }
-                b'(' => {
-                    self.parser.next();
-                    // add the current lookaround state to the stack so we can just pop at a closing paren
-                    stack.push(in_lookaround);
-                    if let Some(c2) = self.parser.peek() {
-                        if c2 != b'?' {
-                            // simple numbered capture group
-                            cap_num += 1;
-                            // if we are not currently in a lookaround,
-                            // add this capture group number to the valid ones
-                            if !in_lookaround {
-                                result.push(cap_num);
-                            }
-                        } else {
-                            self.parser.next();
-                            if let Some(c3) = self.parser.peek() {
-                                self.parser.next();
-                                if c3 == b'=' || c3 == b'!' {
-                                    // lookahead
-                                    in_lookaround = true;
-                                } else if c3 == b'<' {
-                                    if let Some(c4) = self.parser.peek() {
-                                        if c4 == b'=' || c4 == b'!' {
-                                            self.parser.next();
-                                            // lookbehind
-                                            in_lookaround = true;
-                                        }
-                                    }
-                                } else if c3 == b'P' {
-                                    if let Some(c4) = self.parser.peek() {
-                                        if c4 == b'<' {
-                                            // named capture group
-                                            cap_num += 1;
-                                            // if we are not currently in a lookaround,
-                                            // add this capture group number to the valid ones
-                                            if !in_lookaround {
-                                                result.push(cap_num);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                b')' => {
-                    if let Some(value) = stack.pop() {
-                        in_lookaround = value;
-                    }
-                    self.parser.next();
-                }
-                _ => {
-                    self.parser.next();
-                }
-            }
-        }
-        result
     }
 }
 
@@ -1578,33 +1489,6 @@ mod tests {
         assert_eq!(&rewrite(r"ab(?:\n)?"), r"ab(?:$|)");
         assert_eq!(&rewrite(r"(?<!\n)ab"), r"(?<!$)ab");
         assert_eq!(&rewrite(r"(?<=\n)ab"), r"(?<=$)ab");
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_regex() {
-        let regex = "hello(test)(?=(world))(foo(?P<named>bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 3, 4]);
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_regex2() {
-        let regex = "hello(test)[(?=tricked](foo(bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 2, 3]);
-    }
-
-    #[test]
-    fn can_get_valid_captures_from_nested_regex() {
-        let regex = "hello(test)(?=(world(?!(te(?<=(st))))))(foo(bar))";
-        println!("{:?}", regex);
-        let valid_indexes = get_consuming_capture_indexes(regex);
-        println!("{:?}", valid_indexes);
-        assert_eq!(valid_indexes, [0, 1, 5, 6]);
     }
 
     #[test]

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -13,7 +13,6 @@ FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,8 +1,6 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
@@ -17,7 +15,6 @@ FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -7,7 +7,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -6,8 +6,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 12
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 897
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 565
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,10 +1,8 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
-FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,6 +1,5 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 74
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -1,16 +1,16 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
-FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
+FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 2
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 230
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 249
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 604
 exiting with code 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -6,8 +6,8 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 230
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 12
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 897
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -9,7 +9,6 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -8,7 +8,7 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1

--- a/testdata/known_syntest_failures.txt
+++ b/testdata/known_syntest_failures.txt
@@ -4,9 +4,9 @@ FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 2
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
-FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
+FAILED testdata/Packages/Java/tests/syntax_test_java.java: 18953
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 565
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 158
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -13,7 +13,6 @@ FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,8 +1,6 @@
 loading syntax definitions from testdata/Packages
-FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3
 FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
@@ -17,7 +15,6 @@ FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -7,7 +7,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
-FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
+FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
 FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -6,8 +6,7 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 12
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 897
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 565
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,10 +1,8 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
-FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
-FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,6 +1,5 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/ASP/syntax_test_asp.asp: 53
-FAILED testdata/Packages/Batch File/tests/syntax_test_batch_file.bat: 74
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
 FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
 FAILED testdata/Packages/C#/tests/syntax_test_Generics.cs: 3

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -1,16 +1,16 @@
 loading syntax definitions from testdata/Packages
 FAILED testdata/Packages/C#/tests/syntax_test_C#11.cs: 35
-FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 3
+FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 2
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 230
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
-FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
+FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
-FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
+FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 249
+FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 604
 exiting with code 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -6,8 +6,8 @@ FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 230
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
+FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 12
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 897
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -9,7 +9,6 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -8,7 +8,7 @@ FAILED testdata/Packages/Clojure/tests/syntax_test_clojure.clj: 1
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Git Formats/tests/syntax_test_git_config: 17
-FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
+FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -4,9 +4,9 @@ FAILED testdata/Packages/C#/tests/syntax_test_GeneralStructure.cs: 2
 FAILED testdata/Packages/Clojure/tests/syntax_test_shebang.clj: 1
 FAILED testdata/Packages/D/tests/syntax_test_shebang.d: 1
 FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 50
-FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
+FAILED testdata/Packages/Java/tests/syntax_test_java.java: 18953
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 39
-FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 565
+FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 158
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 66
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1

--- a/testdata/known_syntest_failures_fancy.txt
+++ b/testdata/known_syntest_failures_fancy.txt
@@ -12,14 +12,13 @@ FAILED testdata/Packages/Haskell/tests/syntax_test_haskell.hs: 72
 FAILED testdata/Packages/Java/tests/syntax_test_java.java: 1
 FAILED testdata/Packages/Java/tests/syntax_test_jsp.jsp: 44
 FAILED testdata/Packages/JavaScript/tests/syntax_test_typescript.ts: 1
-FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 1
+FAILED testdata/Packages/LaTeX/tests/syntax_test_latex.tex: 76
 FAILED testdata/Packages/Markdown/tests/syntax_test_markdown.md: 1
 FAILED testdata/Packages/PHP/tests/syntax_test_php.php: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python.py: 1
 FAILED testdata/Packages/Python/tests/syntax_test_python_strings.py: 1
-FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 1
+FAILED testdata/Packages/Rails/tests/syntax_test_rails.haml: 65
 FAILED testdata/Packages/Rails/tests/syntax_test_rails.html.erb: 23
-FAILED testdata/Packages/Rust/tests/syntax_test_frontmatter.md: 1
 FAILED testdata/Packages/ShellScript/Bash/tests/syntax_test_scope.bash: 1
 FAILED testdata/Packages/ShellScript/Zsh/tests/syntax_test_scope.zsh: 1
 exiting with code 1


### PR DESCRIPTION
Stacked on #658.

`parse_line` and `syntest`'s consumer captured the buffered shadow / `stack_before` BEFORE the line ran, but a replay applied during that line's parse may correct ops for prior buffered lines — leaving the captured snapshot reflecting the uncorrected baseline. A later replay covering the same line resets to that stale snapshot, re-applies the corrected ops, and resurrects any meta_scope the prior replay had unwound.

Manifested in `syntax_test_markdown.md` as `meta.link.reference.def.markdown` leaking past back-to-back link reference definitions and polluting all subsequent paragraphs / code / blockquotes / autolinks for the rest of the file.

Fix: after applying replays, overwrite each buffered baseline with the post-correction shadow / `stack_before` (`src/parsing/parser.rs`, `examples/syntest.rs`). Pinned by a unit test using the real Markdown syntax.

Compare with #658:
https://github.com/stefanobaghino/syntect/compare/631-markdown-lrd-scope-loss...631-markdown-lrd-meta-scope-cascade-on-replay

Baselines:
- Markdown 565 → 158 (the LRD-leak family)
- Java 1 (panic) → 18953 (the `NoClearedScopesToRestore` panic that the same drift was triggering is gone; the assertions underneath are now visible — same shape as #657's effect on Markdown)