### PR TITLE
chore: bump deps (onig)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,9 +499,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "e9f0430136375a315630bfaf61d6bca71a048258b312be75f26f910fb4333e44"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "725f3ee364ae6d02cfca12ef2be392cfee2733c2a01f0ed386fb74fa94a0fd26"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ features = ["metadata"]
 
 [dependencies]
 yaml-rust2 = { version = "0.10.4", optional = true, default-features = false }
-onig = { version = "6.5.1", optional = true, default-features = false }
+onig = { version = "6.5.2", optional = true, default-features = false }
 fancy-regex = { version = "0.18.0", optional = true }
 walkdir = "2.5"
 regex-syntax = { version = "0.8", optional = true }


### PR DESCRIPTION
Hello, this PR trivially bumps onig's version to account for a recent build fix on musl systems.

Relevant onig issue: https://github.com/rust-onig/rust-onig/issues/219
Relevant onig PR(s): https://github.com/rust-onig/rust-onig/pull/220 & https://github.com/rust-onig/rust-onig/pull/223